### PR TITLE
Fix napier-dev boot: bump Flask to 3.1.3 + Jinja2 to 3.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 beautifulsoup4==4.11.1
 click==8.3.3
 et-xmlfile==1.0.1
-Flask==2.0.3
+Flask==3.1.3
 gunicorn==25.3.0
 html5lib==1.0.1
 itsdangerous==2.2.0
 jdcal==1.4
-Jinja2==3.0
+Jinja2==3.1.6
 MarkupSafe==3.0.3
 openpyxl==2.5.5
 selenium==4.43.0


### PR DESCRIPTION
Production napier-dev is currently in a boot loop after Dependabot bumped Werkzeug to 3.1.8 while Flask was still pinned at 2.0.3.

Crash trace:
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```
Werkzeug 3.x removed url_quote; Flask 2.0.3 still imports it.

Bumping Flask to 3.x (which is compatible with Werkzeug 3.x) and Jinja2 to 3.1.x (required by Flask 3) restores compatibility.

Supersedes #12 and #13, which Dependabot can no longer rebase.