### PR TITLE
Mend autofix: Napier3 security updates

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -27,7 +27,7 @@
     <div id="status"></div>
 
 
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script>
         var cases = {{ cases|tojson }};
         var casesToDownload = [];


### PR DESCRIPTION
## Summary
- Bump jQuery from 3.3.1 to 3.7.1 in `templates/search.html`
  - Fixes CVE-2019-11358, CVE-2020-11022, CVE-2020-11023

All other open Mend issues in this repo were already addressed by previously-merged dependency bump PRs (#19, #18, #30, #20, #21, #22, #23, #25, #27, #28). Those Mend issues will be closed manually since the underlying vulnerable versions are no longer in `requirements.txt`:

- Closes #2 (selenium already 4.43.0)
- Closes #3 (urllib3 already 2.7.0)
- Closes #4 (Werkzeug already 3.1.8)
- Closes #5 (Flask already 3.1.3)
- Closes #6 (jQuery bumped here)
- Closes #7 (Jinja2 already 3.1.6)
- Closes #8 (gunicorn already 25.3.0)
- Closes #29 (click already 8.3.3)

## Test plan
- [ ] Confirm `search.html` still loads jQuery and the page works
- [ ] Mend rescan no longer flags the listed CVEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)