### PR TITLE
Reconcile the ICOS summary against the itemization

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -135,6 +135,163 @@ def get_finance_column(detail):
 
     return "O" # MISC
 
+ICOS_BUCKETS = ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')
+
+# Rows the summary counts as COSTS. Everything the summary does not put in one
+# of the four named buckets falls into OTHER, so only COSTS needs listing.
+COSTS_MARKERS = (
+    'SHERIFF', 'INDIGENT DEFENSE', 'COURT COSTS', 'FILING', 'CLERK',
+    'WITNESS', 'JURY', 'SERVICE', 'ROOM/BOARD', 'ATTORNEY FEE',
+    'TRANSCRIPT', 'APPEAL FEES', 'DEPOSITION',
+)
+
+FINE_MARKERS = (
+    'FINE', 'DEFERRED JUDGMENT CIVIL PENALTY',
+    'INFRACTIONS-PENALTIES AND FORFEITURES-CITY',
+    'NONSCHEDULED CHAPTER 321', 'SCHEDULED VIOLATION/NON-SCHEDULED',
+)
+
+
+def get_summary_bucket(detail):
+    """Which of the five ICOS summary buckets a line item rolls up into.
+
+    The summary is a rollup, not a fee breakdown, so reconciling a payment back
+    to a fee means knowing which bucket each line fed. Getting this wrong is
+    caught by the partition check in reconcile_financials rather than producing
+    a wrong number, so an unrecognised fee costs us the reconciliation and
+    nothing else.
+    """
+    text = (detail or '').upper()
+    if 'SURCHARGE' in text:
+        return 'SURCHARGE'
+    if 'RESTITUTION' in text:
+        return 'RESTITUTION'
+    if any(m in text for m in FINE_MARKERS):
+        return 'FINE'
+    if any(m in text for m in COSTS_MARKERS):
+        return 'COSTS'
+    return 'OTHER'
+
+
+def _unique_paid_subset(amounts, target):
+    """Indices of the rows that sum to target, when exactly one set does.
+
+    ICOS records payments per bucket, not per line. Where only one combination
+    of lines can account for the amount paid, that combination is the answer.
+    Where several could, we cannot tell which fee was paid and say so.
+    """
+    if target == 0:
+        return frozenset()
+    if target == sum(amounts):
+        return frozenset(range(len(amounts)))
+    if len(amounts) == 1:
+        return frozenset([0]) if amounts[0] == target else None
+    if len(amounts) > 18:
+        return None  # combinatorially unreasonable; treat as ambiguous
+
+    from itertools import combinations
+    found = None
+    for size in range(1, len(amounts)):
+        for combo in combinations(range(len(amounts)), size):
+            if sum(amounts[i] for i in combo) != target:
+                continue
+            if found is not None:
+                return None  # more than one explanation
+            found = frozenset(combo)
+    return found
+
+
+def reconcile_financials(case):
+    """Per-column amounts owed, keeping the fee breakdown and the ICOS balance.
+
+    The summary reconciles against what ICOS says is due but collapses every fee
+    into five buckets. The itemization keeps the fee detail but shows original
+    assessments with the Paid column blank, so it overstates anything already
+    paid. This partitions the itemization into the buckets the summary reports,
+    checks each bucket against its summary original, and then subtracts the
+    bucket's payment from the specific lines that account for it.
+
+    Returns (columns, note). columns is None when the itemization cannot be
+    reconciled against the summary, which means the caller should fall back.
+    note is None when every payment was resolved, or a string naming the buckets
+    whose payment could not be attributed to particular lines.
+    """
+    categories = case.get('summary_categories')
+    rows = case.get('financials')
+    if not categories or not rows:
+        return None, None
+
+    summary = {}
+    for category in categories:
+        if category.get('original') is None:
+            return None, None
+        summary[category['label'].upper()] = category
+    if set(summary) != set(ICOS_BUCKETS):
+        return None, None
+
+    # Partition the itemization, carrying the last detail across continuation
+    # rows the way itemized_financials does.
+    buckets = {name: [] for name in ICOS_BUCKETS}
+    last_detail = None
+    for row in rows:
+        detail = row.get('detail') or ''
+        if is_excluded_fee(detail):
+            last_detail = None
+            continue
+        if not detail.strip():
+            if last_detail is None:
+                continue
+            detail = last_detail
+        else:
+            last_detail = detail
+        amount = row.get('amount')
+        if amount is None:
+            continue
+        buckets[get_summary_bucket(detail)].append(
+            (detail, Decimal(str(amount))))
+
+    # Every bucket must add up to what the summary says was assessed. If it
+    # does not, the partition is wrong and any payment we attributed off it
+    # would be wrong too.
+    for name in ICOS_BUCKETS:
+        assessed = sum((amt for _, amt in buckets[name]), Decimal(0))
+        if abs(assessed - summary[name]['original']) > Decimal('0.01'):
+            return None, None
+
+    columns = {}
+    unresolved = []
+    for name in ICOS_BUCKETS:
+        entries = buckets[name]
+        if not entries:
+            continue
+        paid = summary[name].get('paid') or Decimal(0)
+        amounts = [amt for _, amt in entries]
+        settled = _unique_paid_subset(amounts, paid)
+        if settled is None:
+            # Cannot say which line was paid. Report the bucket's balance in
+            # MISC rather than guessing a fee it might not belong to.
+            unresolved.append(name)
+            due = summary[name].get('due')
+            if due is None:
+                due = sum(amounts, Decimal(0)) - paid
+            columns['O'] = columns.get('O', Decimal(0)) + due
+            continue
+        for index, (detail, amount) in enumerate(entries):
+            owed = Decimal(0) if index in settled else amount
+            if owed == 0:
+                continue
+            column = get_finance_column(detail)
+            columns[column] = columns.get(column, Decimal(0)) + owed
+
+    note = None
+    if unresolved:
+        note = ("ICOS records payments per category, not per fee. The payment "
+                "in %s could not be tied to a specific line, so that balance "
+                "is reported under MISC."
+                % ", ".join(unresolved))
+    return columns, note
+
+
 def is_excluded_fee(detail):
     """Fees ICOS lists but does not count toward the balance.
 

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -146,6 +146,100 @@ def test_itemized_fallback_flags_the_mismatch(felony_case):
     assert 'trust the ICOS total' in sheet.value_of('V4')
 
 
+def test_reconciled_keeps_the_breakdown_and_matches_icos(felony_case):
+    """The whole point: fee detail and the ICOS balance at the same time.
+
+    The summary path gets the total right and loses the fees. The itemized path
+    keeps the fees and overstates the total by whatever was already paid.
+    Partitioning the itemization into the summary's buckets and subtracting each
+    bucket's payment from the lines that account for it gets both.
+    """
+    columns, note = crs.reconcile_financials(felony_case)
+    assert note is None
+    assert columns == {
+        'M': Decimal('579.00'),   # two sheriff fees, nothing paid
+        'J': Decimal('50.00'),    # indigent defense
+        'P': Decimal('90.00'),    # revolving fund, five lines
+        'S': Decimal('500.00'),   # restitution
+    }
+    assert sum(columns.values()) == Decimal('1219.00')
+    assert 'K' not in columns   # the revenue fee was paid; this was the bug
+
+
+def test_reconciled_total_equals_the_icos_total(felony_case):
+    columns, _ = crs.reconcile_financials(felony_case)
+    total_due = Decimal(felony_case['total_due'].replace('$', ''))
+    assert sum(columns.values()) == total_due
+
+
+def test_reconciliation_needs_both_halves(felony_case):
+    del felony_case['summary_categories']
+    assert crs.reconcile_financials(felony_case) == (None, None)
+
+
+def test_reconciliation_refuses_a_partition_that_does_not_add_up(felony_case):
+    # If a fee lands in the wrong bucket the bucket stops matching its summary
+    # original. That must cost us the reconciliation, not produce a wrong split.
+    felony_case['financials'][0]['amount'] = '31.00'
+    columns, note = crs.reconcile_financials(felony_case)
+    assert columns is None and note is None
+
+
+def test_ambiguous_payment_is_flagged_not_guessed():
+    # Two lines of the same amount in one bucket, one of them paid. Nothing on
+    # the page says which, so the balance goes to MISC and the row gets a note.
+    case = {
+        'total_due': '$25.00',
+        'summary_categories': [
+            {'label': 'COSTS', 'original': Decimal('0'), 'paid': Decimal('0'),
+             'due': Decimal('0')},
+            {'label': 'FINE', 'original': Decimal('0'), 'paid': Decimal('0'),
+             'due': Decimal('0')},
+            {'label': 'SURCHARGE', 'original': Decimal('0'),
+             'paid': Decimal('0'), 'due': Decimal('0')},
+            {'label': 'RESTITUTION', 'original': Decimal('0'),
+             'paid': Decimal('0'), 'due': Decimal('0')},
+            {'label': 'OTHER', 'original': Decimal('50.00'),
+             'paid': Decimal('25.00'), 'due': Decimal('25.00')},
+        ],
+        'financials': [
+            {'detail': 'DELINQUENT REVOLVING FUND OBLIGATION',
+             'amount': '25.00', 'paid': None, 'paidDate': None},
+            {'detail': 'IOWA DEPT OF REVENUE COLLECTIONS FEE',
+             'amount': '25.00', 'paid': None, 'paidDate': None},
+        ],
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert columns == {'O': Decimal('25.00')}
+    assert note is not None and 'OTHER' in note
+
+
+def test_third_party_fee_stays_out_of_the_partition(felony_case):
+    # ICOS itemises the Linebarger fee but leaves it out of the totals, so it
+    # must not be counted when checking a bucket against its summary original.
+    details = [f['detail'] for f in felony_case['financials']]
+    assert any('THIRD PARTY' in (d or '') for d in details)
+    columns, note = crs.reconcile_financials(felony_case)
+    assert columns is not None
+    assert Decimal('304.75') not in columns.values()
+
+
+@pytest.mark.parametrize("detail,bucket", [
+    ("SHERIFFS FEES - LOCAL", "COSTS"),
+    ("INDIGENT DEFENSE-FELONY-REIMBURSE STATE", "COSTS"),
+    ("RESTITUTIONS", "RESTITUTION"),
+    ("CRIMINAL PENALTY SURCHARGE", "SURCHARGE"),
+    ("FINE", "FINE"),
+    ("NONSCHEDULED CHAPTER 321", "FINE"),
+    ("DNU-DELINQUENT REVOLVING FUND OBLIGATION", "OTHER"),
+    ("IOWA DEPT OF REVENUE COLLECTIONS FEE", "OTHER"),
+    ("", "OTHER"),
+    (None, "OTHER"),
+])
+def test_summary_bucket_classification(detail, bucket):
+    assert crs.get_summary_bucket(detail) == bucket
+
+
 @pytest.mark.parametrize("text,expected", [
     ("$1,401.85", Decimal('1401.85')),
     ("0.00", Decimal('0')),


### PR DESCRIPTION
Adds `reconcile_financials` to `crs.py`, which resolves the open question PR #43 documented but deliberately left alone. Nothing calls it yet.

## The problem it solves

ICOS gives us two views of a case and neither is sufficient on its own.

| path | this case | total |
|---|---|---|
| summary (current default) | O=719.00, S=500.00 | 1219.00, matches ICOS |
| itemized | M=579.00, J=50.00, K=182.85, P=90.00, S=500.00 | 1401.85, overstates by the 182.85 already paid |
| reconciled (this PR) | M=579.00, J=50.00, P=90.00, S=500.00 | 1219.00, matches ICOS |

The summary is a five-bucket rollup, so COSTS and OTHER both fall through to MISC and the sheriff, indigent-defense and revolving-fund columns the CRS workbook exists to fill come back empty. The itemization has the fee detail but shows a blank Paid column on every row, including fees that were in fact paid, so its total is wrong. Only the summary knows about payments, and only at bucket level.

## How it works

Partition the itemization into the five buckets, then check each bucket's assessed total against its summary original. If any bucket disagrees, the whole reconciliation is refused and the caller falls back. That check is the safety net: a fee that classifies into the wrong bucket makes its bucket stop adding up, so a misclassification costs us the reconciliation instead of producing a plausible but wrong split.

Payments are then attributed within each bucket by subset sum. If exactly one subset of a bucket's fees adds up to what was paid, those lines are settled and the rest carry their full amount into their normal column. If more than one subset works, nothing is guessed: that bucket's balance goes to MISC and the row gets a note explaining that ICOS records payments per category rather than per fee. Buckets over 18 lines are treated as ambiguous rather than searched.

The MISC fallback is the honest answer to a real limit in the source data, not a defect. It should be rare, and when it happens the note tells staff exactly why the detail is missing.

## Testing

70 passed, up from 54. Sixteen new tests, all against the real ICOS page committed in #43:

- the reconciled split, asserted column by column, with the collection fee at zero because it was paid;
- the reconciled total equalling the ICOS balance;
- the partition guard, verified by corrupting one fee amount and confirming the reconciliation is refused;
- the ambiguous-payment path, verified by two identical fees in one bucket with one of them paid;
- the third-party debt collection fee staying out of the partition, since ICOS itemises it but leaves it out of the totals;
- bucket classification across ten fee descriptions.

I printed the function's actual output against the fixture rather than trusting the green run, and confirmed each guard trips for the reason intended rather than incidentally.

## What is not in this PR

`process_financials` still prefers the summary. The reporting behaviour is unchanged, so switching to reconciliation is a decision about flipping a default rather than a decision about whether the code exists. That call needs Ari.

Bucket classification is validated against exactly one case. Before this becomes the default it wants four to six more captures: traffic with FINE and SURCHARGE populated, jail room and board, probation fees, and one case with a partial payment spread across several lines. Anything that classifies wrong will refuse rather than mislead, but a reconciliation that keeps refusing is not worth switching to.
