### PR TITLE
Alert on the failures that currently wait to be noticed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,32 @@ Config vars:
 * `RETRY_BUDGET_MIN` (default 45) - how long a job keeps retrying a stalled ICOS
 * `CONCURRENT_WAIT_MIN` (default 16) - how long to wait out a locked ESA account
 * `NAPIER_DISABLE_BACKGROUND` - set to `1` to skip the keepalive and reapers (tests)
+* `NAPIER_ALERT_URL` - where to push failure alerts; unset means no alerts
 
-Useful log filters: `heroku logs -a crs-napier | grep -E 'ICOS|KEEPALIVE|JOB'`.
+Useful log filters: `heroku logs -a crs-napier | grep -E 'ICOS|KEEPALIVE|JOB|ALERT'`.
+
+### Alerts
+
+Napier runs unattended, so the two failures that leave staff stuck now push a
+notification instead of waiting to be found in a log: ICOS becoming unreachable,
+and a job crashing on something the app did not anticipate. Point
+`NAPIER_ALERT_URL` at an ntfy topic, or at anything else that takes an HTTPS
+POST with a text body.
+
+Alerts are per episode rather than per occurrence. A condition sends once when
+it starts, at most hourly while it lasts, and once more when it clears, so an
+afternoon of ICOS being down is a handful of messages rather than one every
+twenty seconds. A failure to deliver an alert is logged and otherwise ignored,
+because a notification endpoint being down must not take Napier down with it.
+
+Alerts carry the shape of a failure and never its content: which subsystem,
+which exception type, how long it has been going. The endpoint is a third-party
+service and the payloads here are client court records, so no name, case number
+or exception message is ever sent. That detail stays in the dyno log.
+
+The keepalive used to log every ping, which was 4,300 lines a day and buried
+everything worth reading. It now logs state changes and a heartbeat every
+fifteen minutes.
 
 ## Development
 
@@ -70,7 +94,9 @@ Open http://127.0.0.1:5000/ and use the website to create a spreadsheet.
 
 `tests/` covers the retry engine (with virtual time, so no real waiting), the
 job engine and session reaper, the staff-facing flow against a fake court site,
-and the financial reconciliation against a fixture built from a real case.
+the financial reconciliation against a fixture built from a real case, and
+alerting against a real local HTTP server, so an alert is proven to leave the
+process rather than proven to have been asked to.
 
 Raw html from ICOS is written to `tmp/` as searches run, which is useful when
 working on the parsers.

--- a/alerts.py
+++ b/alerts.py
@@ -1,0 +1,108 @@
+"""Out-of-band alerts for failures nobody is watching the logs for.
+
+Napier runs unattended. When ICOS stops answering or a job crashes, the only
+record is a line in `heroku logs`, which is read after someone complains rather
+than before. This module pushes the handful of failures worth waking up for to
+a notification endpoint, and pushes the all-clear when they end.
+
+Set NAPIER_ALERT_URL to an ntfy topic (or anything that accepts an HTTPS POST
+with a text body). Unset, every call here is a no-op, which is what tests and
+local development want.
+
+Two rules shape the rest of this module.
+
+Nothing from ICOS goes into an alert. The endpoint is a third-party service and
+the payloads are client court records, so alerts carry the shape of a failure
+(which subsystem, which exception type, how long) and never its content. No
+names, no case numbers, no exception messages, since a parser blowing up on a
+case tends to put that case in its message. The full detail stays in the Heroku
+log, which is inside the trust boundary.
+
+An alert that repeats is an alert that gets muted. A sustained ICOS outage would
+otherwise fire every twenty seconds, so alerts are per episode: one when a
+condition starts, an hourly reminder while it continues, one when it clears.
+"""
+
+import os
+import threading
+import time
+import urllib.request
+
+ALERT_URL_ENV = 'NAPIER_ALERT_URL'
+
+# ntfy accepts exactly these and silently 400s on anything else, so an invalid
+# priority means the alert is never delivered and nothing says so. Validate here
+# rather than discover it during an outage.
+PRIORITIES = ('min', 'low', 'default', 'high', 'urgent', 'max')
+
+# How long a still-firing condition waits before it reminds anyone.
+REMINDER_SECONDS = 60 * 60
+
+_firing = {}
+_lock = threading.Lock()
+
+
+def _post(title, body, priority, tags):
+    url = os.environ.get(ALERT_URL_ENV)
+    if not url:
+        return False
+    if priority not in PRIORITIES:
+        print("ALERT bad priority %r, sending as default" % (priority,), flush=True)
+        priority = 'default'
+    request = urllib.request.Request(
+        url, data=body.encode('utf-8'), method='POST',
+        headers={'Title': title, 'Priority': priority, 'Tags': tags})
+    urllib.request.urlopen(request, timeout=10).read()
+    return True
+
+
+def _send(title, body, priority, tags):
+    """Deliver one alert. Never raises: alerting must not take the app down."""
+    try:
+        sent = _post(title, body, priority, tags)
+    except Exception as e:
+        print("ALERT delivery failed (%s): %s" % (type(e).__name__, title), flush=True)
+        return False
+    print("ALERT %s %s" % ("sent" if sent else "suppressed (no %s)" % ALERT_URL_ENV,
+                           title), flush=True)
+    return sent
+
+
+def raise_alert(event, title, body, priority='high', tags='rotating_light'):
+    """Report that `event` is broken.
+
+    Sends on the first call, then at most once an hour while the condition
+    lasts, so an outage is one page plus a reminder rather than a stream.
+    """
+    now = time.time()
+    with _lock:
+        last = _firing.get(event)
+        if last is not None and now - last < REMINDER_SECONDS:
+            return False
+        _firing[event] = now
+    if last is not None:
+        title = "%s (still)" % title
+    return _send(title, body, priority, tags)
+
+
+def clear_alert(event, title, body, tags='white_check_mark'):
+    """Report that `event` recovered, if it had been reported broken.
+
+    Silent when the event was never firing, so a healthy app is silent.
+    """
+    with _lock:
+        if event not in _firing:
+            return False
+        del _firing[event]
+    return _send(title, body, 'default', tags)
+
+
+def is_firing(event):
+    with _lock:
+        return event in _firing
+
+
+def reset():
+    """Forget all firing state. For tests."""
+    with _lock:
+        _firing.clear()

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 import platform
 import time
 
+import alerts
 import icos_sessions
 import jobs
 import tasks
@@ -36,7 +37,13 @@ import urllib.request as _urlreq
 KEEPALIVE_URL = "https://www.iowacourts.state.ia.us/ESAWebApp/ESALogin.jsp"
 KEEPALIVE_SECS = 20
 KEEPALIVE_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+KEEPALIVE_BURST = 8
+# A ping every 20 seconds logging a line each time is 4,300 lines a day, which
+# buries the job and ICOS lines that someone reads a log to find. Every change
+# of state is logged; a steady healthy ping only says so this often.
+KEEPALIVE_LOG_SECS = 15 * 60
 _keepalive_lock = None
+_keepalive_state = {"ok": None, "logged_at": 0.0, "cold_since": None}
 
 def _keepalive_ping(timeout=6):
     t0 = time.time()
@@ -47,24 +54,67 @@ def _keepalive_ping(timeout=6):
     except Exception:
         return time.time() - t0, False
 
-def _keepalive_loop():
+def _describe_duration(seconds):
+    minutes = int(seconds // 60)
+    if minutes < 1:
+        return "under a minute"
+    if minutes < 60:
+        return "%d minute%s" % (minutes, "" if minutes == 1 else "s")
+    hours = minutes / 60.0
+    return "%.1f hours" % hours
+
+def _keepalive_cycle(state, now=None):
     # ICOS tarpits the first connection(s) from an idle source IP, and a single
     # ping does NOT warm a cold path (it takes several attempts). So ping often,
     # and the moment a ping comes back cold, BURST until it warms again, instead
     # of waiting a full cycle. Keeps the web dyno's path to ICOS continuously
     # warm so real searches don't land on a cold start.
-    while True:
-        dt, ok = _keepalive_ping()
-        if ok:
-            print("KEEPALIVE ok %.2fs" % dt, flush=True)
+    #
+    # One iteration, split out of the loop below so the alerting can be tested
+    # without waiting on a timer.
+    now = time.time() if now is None else now
+    dt, ok = _keepalive_ping()
+    if not ok:
+        for i in range(KEEPALIVE_BURST):
+            dt, ok = _keepalive_ping()
+            if ok:
+                print("KEEPALIVE re-warmed after %d burst tries (%.2fs)" % (i + 1, dt), flush=True)
+                break
         else:
-            for i in range(8):
-                dt2, ok2 = _keepalive_ping()
-                if ok2:
-                    print("KEEPALIVE re-warmed after %d burst tries (%.2fs)" % (i + 1, dt2), flush=True)
-                    break
-            else:
-                print("KEEPALIVE still cold after burst", flush=True)
+            print("KEEPALIVE still cold after burst", flush=True)
+
+    if ok:
+        if state["cold_since"] is not None:
+            alerts.clear_alert(
+                "icos-keepalive",
+                "Napier can reach ICOS again",
+                "The keepalive warmed the path back up after %s. Searches "
+                "should work normally." % _describe_duration(now - state["cold_since"]))
+            state["cold_since"] = None
+        if state["ok"] is not True or now - state["logged_at"] >= KEEPALIVE_LOG_SECS:
+            print("KEEPALIVE ok %.2fs" % dt, flush=True)
+            state["logged_at"] = now
+    else:
+        if state["cold_since"] is None:
+            state["cold_since"] = now
+        alerts.raise_alert(
+            "icos-keepalive",
+            "Napier cannot reach ICOS",
+            "%d keepalive attempts on the ICOS login page failed in a row, so "
+            "searches will stall or fail until this clears. Cold for %s."
+            % (KEEPALIVE_BURST + 1, _describe_duration(now - state["cold_since"])),
+            priority="urgent")
+    state["ok"] = ok
+    return state
+
+def _keepalive_loop():
+    while True:
+        try:
+            _keepalive_cycle(_keepalive_state)
+        except Exception as e:
+            # A keepalive thread that dies is invisible until searches start
+            # failing, so swallow and keep pinging.
+            print("KEEPALIVE cycle error (%s)" % type(e).__name__, flush=True)
         time.sleep(KEEPALIVE_SECS)
 
 def _start_background_threads():

--- a/jobs.py
+++ b/jobs.py
@@ -15,6 +15,8 @@ import threading
 import time
 import uuid
 
+import alerts
+
 QUEUED = "queued"
 RUNNING = "running"
 DONE = "done"
@@ -89,6 +91,17 @@ def start(kind, target, *args, **kwargs):
             message = getattr(e, "message", None)
             if message is None:
                 print("JOB %s %s crashed: %r" % (kind, job.id[:8], e), flush=True)
+                # Staff get an apology they cannot act on, so someone who can
+                # act has to hear about it. The exception type and job id are
+                # enough to find the traceback in the dyno log; the exception
+                # message is deliberately left out, because a parser failing on
+                # a case tends to quote that case.
+                alerts.raise_alert(
+                    "job-crash-%s" % kind,
+                    "Napier %s job crashed" % kind,
+                    "A %s job ended in an unhandled %s and the user was shown a "
+                    "generic apology. Job %s in the dyno log has the traceback."
+                    % (kind, type(e).__name__, job.id[:8]))
                 message = ("Something went wrong inside Napier. Please try again, "
                            "and let Clark Management Consulting know if it keeps "
                            "happening.")

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,246 @@
+"""Alerting: does a failure nobody is watching actually reach someone.
+
+These tests run a real HTTP server and assert on the request that arrives on it,
+rather than on a mock having been called. A mock proves the code called what we
+told it to call. It does not prove an alert leaves the process, which is the
+only thing this feature is for.
+"""
+
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
+
+import alerts
+import app as app_module
+import jobs
+
+
+class Collector(BaseHTTPRequestHandler):
+    received = []
+    status = 200
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length') or 0)
+        Collector.received.append({
+            'body': self.rfile.read(length).decode('utf-8'),
+            'title': self.headers.get('Title'),
+            'priority': self.headers.get('Priority'),
+            'tags': self.headers.get('Tags'),
+        })
+        self.send_response(Collector.status)
+        self.end_headers()
+        self.wfile.write(b'ok')
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    """A real listening socket standing in for the ntfy topic."""
+    Collector.received = []
+    Collector.status = 200
+    server = HTTPServer(('127.0.0.1', 0), Collector)
+    # serve_forever polls at half a second by default, which is half a second
+    # of teardown on every test in this file.
+    threading.Thread(target=server.serve_forever, kwargs={'poll_interval': 0.01},
+                     daemon=True).start()
+    monkeypatch.setenv(alerts.ALERT_URL_ENV,
+                       'http://127.0.0.1:%d/napier' % server.server_port)
+    alerts.reset()
+    yield Collector.received
+    server.shutdown()
+    alerts.reset()
+
+
+def test_an_alert_actually_leaves_the_process(endpoint):
+    assert alerts.raise_alert('t', 'ICOS is down', 'Nothing is answering.') is True
+    assert len(endpoint) == 1
+    assert endpoint[0]['title'] == 'ICOS is down'
+    assert endpoint[0]['body'] == 'Nothing is answering.'
+    assert endpoint[0]['priority'] == 'high'
+
+
+def test_a_repeat_within_the_hour_is_not_sent_again(endpoint):
+    alerts.raise_alert('t', 'ICOS is down', 'first')
+    for _ in range(20):
+        alerts.raise_alert('t', 'ICOS is down', 'again')
+    # A 20-second keepalive loop would otherwise send 180 pages an hour.
+    assert len(endpoint) == 1
+
+
+def test_a_lasting_failure_reminds_once_the_cooldown_passes(endpoint, monkeypatch):
+    alerts.raise_alert('t', 'ICOS is down', 'first')
+    monkeypatch.setattr(alerts, 'REMINDER_SECONDS', 0)
+    alerts.raise_alert('t', 'ICOS is down', 'still going')
+    assert len(endpoint) == 2
+    assert endpoint[1]['title'] == 'ICOS is down (still)'
+
+
+def test_recovery_is_announced_only_if_something_broke(endpoint):
+    assert alerts.clear_alert('t', 'all clear', 'nothing was wrong') is False
+    assert endpoint == []
+    alerts.raise_alert('t', 'ICOS is down', 'broken')
+    assert alerts.clear_alert('t', 'ICOS is back', 'recovered') is True
+    assert len(endpoint) == 2
+    assert endpoint[1]['title'] == 'ICOS is back'
+    assert endpoint[1]['priority'] == 'default'
+
+
+def test_recovery_rearms_the_alert(endpoint):
+    alerts.raise_alert('t', 'down', 'a')
+    alerts.clear_alert('t', 'up', 'b')
+    # Second outage inside the cooldown window must still page.
+    assert alerts.raise_alert('t', 'down', 'c') is True
+    assert len(endpoint) == 3
+
+
+def test_an_invalid_priority_is_downgraded_rather_than_dropped(endpoint):
+    # ntfy accepts six priority words and silently 400s on anything else, so a
+    # typo here would mean an outage page that never arrives.
+    alerts.raise_alert('t', 'ICOS is down', 'body', priority='critical')
+    assert endpoint[0]['priority'] == 'default'
+
+
+@pytest.mark.parametrize('priority', alerts.PRIORITIES)
+def test_every_documented_priority_is_passed_through(endpoint, priority):
+    alerts.reset()
+    alerts.raise_alert('p-%s' % priority, 't', 'b', priority=priority)
+    assert endpoint[-1]['priority'] == priority
+
+
+def test_no_endpoint_configured_is_a_silent_no_op(monkeypatch):
+    monkeypatch.delenv(alerts.ALERT_URL_ENV, raising=False)
+    alerts.reset()
+    assert alerts.raise_alert('t', 'title', 'body') is False
+
+
+def test_a_dead_endpoint_does_not_take_the_caller_down(monkeypatch):
+    monkeypatch.setenv(alerts.ALERT_URL_ENV, 'http://127.0.0.1:1/nope')
+    alerts.reset()
+    assert alerts.raise_alert('t', 'title', 'body') is False
+    # The condition still counts as firing, so recovery is still announced.
+    assert alerts.is_firing('t')
+
+
+def test_a_rejecting_endpoint_does_not_take_the_caller_down(endpoint):
+    Collector.status = 500
+    assert alerts.raise_alert('t', 'title', 'body') is False
+
+
+# --- the two conditions actually wired up -------------------------------
+
+
+@pytest.fixture
+def keepalive(monkeypatch):
+    """Drive the keepalive cycle with a scripted sequence of ping outcomes."""
+    outcomes = []
+
+    def fake_ping(timeout=6):
+        return 0.1, outcomes.pop(0) if outcomes else True
+
+    monkeypatch.setattr(app_module, '_keepalive_ping', fake_ping)
+    return outcomes
+
+
+def test_icos_going_cold_pages_someone(endpoint, keepalive):
+    keepalive.extend([False] * (app_module.KEEPALIVE_BURST + 1))
+    app_module._keepalive_cycle({'ok': True, 'logged_at': 0.0, 'cold_since': None})
+    assert len(endpoint) == 1
+    assert 'cannot reach ICOS' in endpoint[0]['title']
+    assert endpoint[0]['priority'] == 'urgent'
+
+
+def test_a_ping_that_recovers_inside_the_burst_pages_nobody(endpoint, keepalive):
+    keepalive.extend([False, False, True])
+    app_module._keepalive_cycle({'ok': True, 'logged_at': 0.0, 'cold_since': None})
+    assert endpoint == []
+
+
+def test_icos_coming_back_says_so_and_says_how_long(endpoint, keepalive):
+    state = {'ok': True, 'logged_at': 0.0, 'cold_since': None}
+    keepalive.extend([False] * (app_module.KEEPALIVE_BURST + 1))
+    app_module._keepalive_cycle(state, now=1000.0)
+    app_module._keepalive_cycle(state, now=1000.0 + 25 * 60)
+    assert len(endpoint) == 2
+    assert 'reach ICOS again' in endpoint[1]['title']
+    assert '25 minutes' in endpoint[1]['body']
+    assert state['cold_since'] is None
+
+
+def test_a_healthy_keepalive_stops_logging_every_ping(endpoint, keepalive, capsys):
+    state = {'ok': None, 'logged_at': 0.0, 'cold_since': None}
+    now = 10000.0
+    for _ in range(30):
+        app_module._keepalive_cycle(state, now=now)
+        now += app_module.KEEPALIVE_SECS
+    lines = [l for l in capsys.readouterr().out.splitlines() if 'KEEPALIVE ok' in l]
+    # Ten minutes of pings. One line for the first success, none after, because
+    # a line every 20 seconds buries the JOB and ICOS lines in the same log.
+    assert len(lines) == 1
+
+
+def test_a_healthy_keepalive_still_says_so_periodically(endpoint, keepalive):
+    state = {'ok': True, 'logged_at': 1000.0, 'cold_since': None}
+    app_module._keepalive_cycle(state, now=1000.0 + app_module.KEEPALIVE_LOG_SECS)
+    assert state['logged_at'] == 1000.0 + app_module.KEEPALIVE_LOG_SECS
+
+
+def test_a_crashing_job_pages_someone(endpoint):
+    def explode(job):
+        raise ValueError('TESTER, PAT Q had an unparseable charge row')
+
+    job = jobs.start('search', explode)
+    for _ in range(200):
+        if job.status == jobs.FAILED:
+            break
+        time.sleep(0.01)
+    assert job.status == jobs.FAILED
+    assert len(endpoint) == 1
+    assert endpoint[0]['title'] == 'Napier search job crashed'
+    assert 'ValueError' in endpoint[0]['body']
+
+
+def test_a_crash_alert_carries_no_case_data(endpoint):
+    """The endpoint is a third-party service and the payload is court records.
+
+    An exception raised while parsing a case usually quotes that case, so the
+    alert reports the exception type and nothing else from it.
+    """
+    def explode(job):
+        raise ValueError('TESTER, PAT Q 01311 FECR000000 01/01/1900')
+
+    job = jobs.start('crs', explode)
+    for _ in range(200):
+        if job.status == jobs.FAILED:
+            break
+        time.sleep(0.01)
+    assert job.status == jobs.FAILED
+    sent = endpoint[0]['title'] + endpoint[0]['body']
+    for leak in ('TESTER', 'PAT Q', 'FECR000000', '01/01/1900'):
+        assert leak not in sent
+
+
+def test_a_handled_failure_pages_nobody(endpoint):
+    """Failures already phrased for staff are the app working, not breaking."""
+    class Handled(Exception):
+        message = 'That user ID or password was not accepted by Iowa Courts.'
+
+    def refuse(job):
+        raise Handled()
+
+    job = jobs.start('search', refuse)
+    for _ in range(200):
+        if job.status == jobs.FAILED:
+            break
+        time.sleep(0.01)
+    assert job.status == jobs.FAILED
+    assert endpoint == []


### PR DESCRIPTION
Phase 6. Napier runs unattended, so the failures that leave staff stuck currently wait to be noticed. The only record is a line in the dyno log, which gets read after someone complains rather than before.

## What now pages someone

**ICOS becomes unreachable.** The keepalive already bursts when a ping comes back cold. If all nine attempts fail, that is the condition that produced the "Application error" outage, and it now sends at `urgent`. When the path warms back up it sends an all clear that says how long it was down.

**A job crashes on something the app did not anticipate.** The user gets a generic apology they cannot act on, so someone who can act needs to hear about it. Failures that already carry a staff-facing message, like a rejected password, are the app working correctly and page nobody.

Point `NAPIER_ALERT_URL` at an ntfy topic or anything else taking an HTTPS POST with a text body. Unset, every path here is a no-op, so tests and local development send nothing.

## Design decisions worth reviewing

**Alerts carry the shape of a failure, never its content.** The endpoint is a third-party service and the payloads here are client court records. The crash alert reports the exception type and the short job id and deliberately drops the exception message, because a parser blowing up on a case usually quotes that case. `test_a_crash_alert_carries_no_case_data` asserts it, and I verified it fails when the redaction is removed rather than assuming it would.

**Per episode, not per occurrence.** One alert when a condition starts, an hourly reminder while it lasts, one when it clears. A 20 second keepalive loop would otherwise send 180 pages an hour through an outage, and an alert that repeats is an alert that gets muted. Recovery rearms, so a second outage inside the cooldown still pages.

**Delivery failures are swallowed.** A notification endpoint being down must not take Napier down with it. The condition still counts as firing, so recovery is still announced.

**Priorities are validated against the six ntfy accepts.** It silently 400s on anything else, so a typo would mean an outage page that never arrives and nothing saying so.

## Keepalive logging demoted

It logged every ping, roughly 4,300 lines a day, which buried the JOB and ICOS lines someone actually reads a log to find. Now it logs every state change plus a heartbeat every fifteen minutes. The cycle is split out of the loop so the alerting can be tested without waiting on a timer, and the loop swallows exceptions, since a keepalive thread that dies is invisible until searches start failing.

## Testing

93 passed, up from 70. The alerting tests run a real HTTP server and assert on the request that arrives on it. A mock would prove the code called what we told it to call; it would not prove an alert leaves the process, which is the only thing this feature is for.

Covered: the alert arriving with its title, body and priority intact; the hourly suppression; the reminder once the cooldown passes; recovery only announced if something broke; recovery rearming; invalid priority downgraded rather than dropped; every documented priority passed through; no endpoint configured being a silent no-op; a dead endpoint and a 500-ing endpoint both leaving the caller standing; ICOS going cold paging at urgent; a ping that recovers inside the burst paging nobody; recovery reporting the duration; the healthy keepalive logging once instead of thirty times; the crash alert firing; the crash alert leaking nothing; a handled failure paging nobody.

## Not done here

Deploying to `napier-dev` and firing one alert at a real topic end to end. That needs a `NAPIER_ALERT_URL` value and a deploy, both yours. The local proof is genuine, real socket and real urllib, but it is not the same as watching a phone buzz.
