### PR TITLE
Rebuild Phase 6 alerting on email, to the contracted spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,52 @@ Config vars:
 * `RETRY_BUDGET_MIN` (default 45) - how long a job keeps retrying a stalled ICOS
 * `CONCURRENT_WAIT_MIN` (default 16) - how long to wait out a locked ESA account
 * `NAPIER_DISABLE_BACKGROUND` - set to `1` to skip the keepalive and reapers (tests)
-* `NAPIER_ALERT_URL` - where to push failure alerts; unset means no alerts
+* `MAILGUN_DOMAIN` - the Mailgun sending domain, for failure alerts
+* `MAILGUN_API_KEY` - the Mailgun private API key
+* `ALERT_EMAIL_TO` - where failure alerts go; leaving any of these three unset
+  turns alerting into a logged no-op
+* `ALERT_EMAIL_FROM` (optional) - defaults to `Napier <napier@MAILGUN_DOMAIN>`
 
 Useful log filters: `heroku logs -a crs-napier | grep -E 'ICOS|KEEPALIVE|JOB|ALERT'`.
 
 ### Alerts
 
-Napier runs unattended, so the two failures that leave staff stuck now push a
-notification instead of waiting to be found in a log: ICOS becoming unreachable,
-and a job crashing on something the app did not anticipate. Point
-`NAPIER_ALERT_URL` at an ntfy topic, or at anything else that takes an HTTPS
-POST with a text body.
+Napier runs unattended. When a search dies after forty-five minutes of retrying,
+or a case will not parse, the only record used to be a line in `heroku logs`
+that got read after staff complained rather than before. Napier now emails the
+detail needed to diagnose a failure without shelling into Heroku.
 
-Alerts are per episode rather than per occurrence. A condition sends once when
-it starts, at most hourly while it lasts, and once more when it clears, so an
-afternoon of ICOS being down is a handful of messages rather than one every
-twenty seconds. A failure to deliver an alert is logged and otherwise ignored,
-because a notification endpoint being down must not take Napier down with it.
+Seven things send mail: ICOS exhausting the retry budget, an ESA account still
+locked when the wait gives up, a run that succeeded but needed three or more
+attempts, an unusable response once signed in, a case that would not parse, a
+job crashing, and an unhandled exception in a request. A bad password does not,
+because it is always a typo. Nor does a cold keepalive, which is the normal
+state of an idle path to ICOS and recovers on its own; paging on it would train
+everyone to ignore Napier's mail.
 
-Alerts carry the shape of a failure and never its content: which subsystem,
-which exception type, how long it has been going. The endpoint is a third-party
-service and the payloads here are client court records, so no name, case number
-or exception message is ever sent. That detail stays in the dyno log.
+Sending is one POST to the Mailgun HTTP API over `urllib`, on a daemon thread
+with its own timeout. No SMTP handshake to stall a worker, no dependency, no
+Heroku add-on. A failed send is logged and dropped, because a mail outage must
+not become a failed search.
+
+An alert that repeats is an alert that gets muted. A forty-five minute retry
+budget at escalating backoff is dozens of attempts, and a clinic morning puts
+several staff behind the same broken ICOS. So it is one email per job per
+failure class, with a floor of one per class per ten minutes across all jobs on
+top, and one digest when the job ends carrying every event including the ones
+that were suppressed.
+
+Alerts carry case numbers but never people. A case number is court public record
+and a parse-failure alert without one gives nobody anything to look at. The
+defendant's name and date of birth are the privileged part and are never
+assembled into an alert. Exception messages are dropped for the same reason: a
+parser that dies on a case tends to quote that case back. What survives is the
+traceback's frames, which are our own source, plus the exception type. Both
+guards have tests that fail when the guard is removed.
 
 The keepalive used to log every ping, which was 4,300 lines a day and buried
-everything worth reading. It now logs state changes and a heartbeat every
-fifteen minutes.
+everything worth reading. It now logs state changes and a heartbeat every ten
+minutes.
 
 ## Development
 

--- a/alerts.py
+++ b/alerts.py
@@ -60,10 +60,22 @@ CLASS_FLOOR_SECONDS = 10 * 60
 
 MAILGUN_ENDPOINT = 'https://api.mailgun.net/v3/%s/messages'
 
-_sent = set()          # (job_id, failure class) already emailed
+# Both maps below are keyed by something unique per job, and the web error path
+# has no end-of-job digest to clean up after itself, so without a cap a dyno
+# that stays up for weeks accumulates one entry per request that ever threw.
+# Anything evicted is old enough that re-alerting on it would be correct.
+MAX_TRACKED_JOBS = 500
+
+_sent = {}             # job_id -> failure classes already emailed for that job
 _class_floor = {}      # failure class -> when it last went out, any job
 _pending = {}          # job_id -> the events behind the end-of-job digest
 _lock = threading.Lock()
+
+
+def _forget(job_id):
+    """Drop a job's bookkeeping. Caller holds the lock."""
+    _pending.pop(job_id, None)
+    _sent.pop(job_id, None)
 
 
 # -- what may and may not go in an email ----------------------------------
@@ -183,12 +195,15 @@ def record(job_id, kind, failure, progress=None, now=None, **fields):
     now = time.time() if now is None else now
     with _lock:
         _pending.setdefault(job_id, []).append((failure, dict(fields)))
-        if (job_id, failure) in _sent:
+        # Dicts keep insertion order, so the first key is the oldest job.
+        while len(_pending) > MAX_TRACKED_JOBS:
+            _forget(next(iter(_pending)))
+        if failure in _sent.get(job_id, ()):
             return None
         last = _class_floor.get(failure)
         if last is not None and now - last < CLASS_FLOOR_SECONDS:
             return None
-        _sent.add((job_id, failure))
+        _sent.setdefault(job_id, set()).add(failure)
         _class_floor[failure] = now
     return _send('Napier: %s' % failure,
                  _format(job_id, kind, failure, fields, progress))
@@ -201,7 +216,9 @@ def digest(job_id, kind, progress=None):
     where the full picture of a bad run lands.
     """
     with _lock:
-        events = _pending.pop(job_id, None)
+        events = _pending.get(job_id)
+        # The job is over either way, so its dedup state goes with it.
+        _forget(job_id)
     if not events:
         return None
     lines = ['%s job %s finished with %d problem%s.'

--- a/alerts.py
+++ b/alerts.py
@@ -1,108 +1,246 @@
-"""Out-of-band alerts for failures nobody is watching the logs for.
+"""Realtime failure alerting by email.
 
-Napier runs unattended. When ICOS stops answering or a job crashes, the only
-record is a line in `heroku logs`, which is read after someone complains rather
-than before. This module pushes the handful of failures worth waking up for to
-a notification endpoint, and pushes the all-clear when they end.
+Napier runs unattended. When a search dies after forty-five minutes of retrying,
+or a case will not parse, or something throws where nobody expected it, the only
+record today is a line in `heroku logs` that gets read after staff complain
+rather than before. This module emails the detail needed to diagnose a failure
+without shelling into Heroku.
 
-Set NAPIER_ALERT_URL to an ntfy topic (or anything that accepts an HTTPS POST
-with a text body). Unset, every call here is a no-op, which is what tests and
-local development want.
+Configured with `MAILGUN_DOMAIN`, `MAILGUN_API_KEY` and `ALERT_EMAIL_TO`, plus
+an optional `ALERT_EMAIL_FROM`. Any of them missing and every path here becomes
+a logged no-op, which is what local development and the test suite want. The
+Mailgun HTTP API is one POST with no SMTP handshake to stall a worker, and it is
+reached with `urllib`, so alerting adds no dependency and no Heroku add-on.
 
-Two rules shape the rest of this module.
+Three things shape the rest of this module.
 
-Nothing from ICOS goes into an alert. The endpoint is a third-party service and
-the payloads are client court records, so alerts carry the shape of a failure
-(which subsystem, which exception type, how long) and never its content. No
-names, no case numbers, no exception messages, since a parser blowing up on a
-case tends to put that case in its message. The full detail stays in the Heroku
-log, which is inside the trust boundary.
+Delivery never blocks the work. Sends run on a short daemon thread with their
+own timeout, and a failed send is logged and dropped. A mail outage must not
+turn into a failed search.
 
-An alert that repeats is an alert that gets muted. A sustained ICOS outage would
-otherwise fire every twenty seconds, so alerts are per episode: one when a
-condition starts, an hourly reminder while it continues, one when it clears.
+An alert that repeats is an alert that gets muted. A forty-five minute retry
+budget at escalating backoff produces dozens of attempts, and a clinic morning
+puts several staff behind the same broken ICOS. So it is one email per job per
+failure class, then one digest when the job ends, with a floor of one email per
+class per ten minutes across all jobs on top.
+
+Alerts carry case numbers but never people. A case number is court public record
+and a parse-failure alert without one is not actionable, so case ids are in.
+The defendant's name and date of birth are the privileged part under Article 5
+and are never assembled into an alert. Exception messages are dropped for the
+same reason: a parser that dies on a case usually quotes that case back. What
+survives is the traceback's frames, which are our own source, plus the exception
+type.
 """
 
+import base64
 import os
 import threading
 import time
+import traceback
+import urllib.parse
 import urllib.request
 
-ALERT_URL_ENV = 'NAPIER_ALERT_URL'
+# Failure classes. The wording is the email subject line, so it reads as English.
+RETRY_EXHAUSTED = 'ICOS retry budget exhausted'
+CONCURRENT_EXHAUSTED = 'ESA account stayed locked'
+SLOW_RECOVERY = 'ICOS needed repeated retries'
+BAD_RESPONSE = 'unusable response from ICOS'
+PARSE_FAILURE = 'case could not be read'
+JOB_FAILED = 'job failed'
+UNHANDLED = 'unhandled exception'
 
-# ntfy accepts exactly these and silently 400s on anything else, so an invalid
-# priority means the alert is never delivered and nothing says so. Validate here
-# rather than discover it during an outage.
-PRIORITIES = ('min', 'low', 'default', 'high', 'urgent', 'max')
+# A run that eventually worked but took this many attempts is the early warning
+# that ICOS is degrading, which is worth one email before staff start noticing.
+SLOW_RECOVERY_ATTEMPTS = 3
 
-# How long a still-firing condition waits before it reminds anyone.
-REMINDER_SECONDS = 60 * 60
+# Floor across all jobs, so a broad ICOS outage during a clinic sends a handful
+# of emails rather than one per staffer per attempt.
+CLASS_FLOOR_SECONDS = 10 * 60
 
-_firing = {}
+MAILGUN_ENDPOINT = 'https://api.mailgun.net/v3/%s/messages'
+
+_sent = set()          # (job_id, failure class) already emailed
+_class_floor = {}      # failure class -> when it last went out, any job
+_pending = {}          # job_id -> the events behind the end-of-job digest
 _lock = threading.Lock()
 
 
-def _post(title, body, priority, tags):
-    url = os.environ.get(ALERT_URL_ENV)
-    if not url:
+# -- what may and may not go in an email ----------------------------------
+
+def username_prefix(username):
+    """The account family, never the account.
+
+    Article 1.2 keeps credentials out of anything we transmit, and the useful
+    signal is which pool of logins collided, not which login.
+    """
+    if not username:
+        return 'unknown'
+    lowered = username.lower()
+    if lowered.startswith('drakelegalclinic'):
+        return 'drakelegalclinic'
+    if lowered.startswith('ila'):
+        return 'ILA##'
+    return 'other'
+
+
+def safe_traceback(exc):
+    """Frames and exception type, without the exception's own message.
+
+    The frames are Napier's source and carry nothing about a client. The
+    message is the risk: a parser failing on a case tends to include the case,
+    and sometimes the defendant, in what it raises. Exceptions we authored
+    ourselves carry a `.message` written for staff, so that one is safe to keep.
+    """
+    if exc is None:
+        return ''
+    frames = ''.join(traceback.format_tb(exc.__traceback__))
+    authored = getattr(exc, 'message', None)
+    tail = type(exc).__name__
+    if authored:
+        tail = '%s: %s' % (tail, authored)
+    return frames + tail
+
+
+def _format(job_id, kind, failure, fields, progress):
+    lines = ['%s job %s' % (kind, job_id), '']
+    for label in ('classification', 'endpoint', 'attempts', 'elapsed',
+                  'backoff', 'status', 'response size', 'account', 'case'):
+        value = fields.get(label)
+        if value is not None:
+            lines.append('%-14s %s' % (label + ':', value))
+    lines.insert(2, '%-14s %s' % ('failure:', failure))
+
+    note = fields.get('note')
+    if note:
+        lines += ['', note]
+
+    tb = fields.get('traceback')
+    if tb:
+        lines += ['', 'Traceback (exception message withheld under Article 5):',
+                  tb]
+
+    if progress:
+        lines += ['', 'Last %d progress lines:' % len(progress)]
+        lines += ['  ' + line for line in progress]
+
+    return '\n'.join(lines)
+
+
+# -- delivery -------------------------------------------------------------
+
+def _mailgun(subject, body):
+    domain = os.environ.get('MAILGUN_DOMAIN')
+    key = os.environ.get('MAILGUN_API_KEY')
+    to = os.environ.get('ALERT_EMAIL_TO')
+    if not (domain and key and to):
         return False
-    if priority not in PRIORITIES:
-        print("ALERT bad priority %r, sending as default" % (priority,), flush=True)
-        priority = 'default'
-    request = urllib.request.Request(
-        url, data=body.encode('utf-8'), method='POST',
-        headers={'Title': title, 'Priority': priority, 'Tags': tags})
+    sender = os.environ.get('ALERT_EMAIL_FROM') or 'Napier <napier@%s>' % domain
+    data = urllib.parse.urlencode({
+        'from': sender,
+        'to': to,
+        'subject': subject,
+        'text': body,
+    }).encode('utf-8')
+    request = urllib.request.Request(MAILGUN_ENDPOINT % domain, data=data)
+    request.add_header('Authorization', 'Basic ' + base64.b64encode(
+        ('api:%s' % key).encode('utf-8')).decode('ascii'))
     urllib.request.urlopen(request, timeout=10).read()
     return True
 
 
-def _send(title, body, priority, tags):
-    """Deliver one alert. Never raises: alerting must not take the app down."""
+def _deliver(subject, body):
     try:
-        sent = _post(title, body, priority, tags)
+        if _mailgun(subject, body):
+            print('ALERT sent: %s' % subject, flush=True)
+        else:
+            print('ALERT not configured, would have sent: %s' % subject, flush=True)
     except Exception as e:
-        print("ALERT delivery failed (%s): %s" % (type(e).__name__, title), flush=True)
-        return False
-    print("ALERT %s %s" % ("sent" if sent else "suppressed (no %s)" % ALERT_URL_ENV,
-                           title), flush=True)
-    return sent
+        # A mail outage must never become a failed search.
+        print('ALERT delivery failed (%s): %s' % (type(e).__name__, subject),
+              flush=True)
 
 
-def raise_alert(event, title, body, priority='high', tags='rotating_light'):
-    """Report that `event` is broken.
+def _send(subject, body):
+    """Hand the send to a daemon thread and get out of the way.
 
-    Sends on the first call, then at most once an hour while the condition
-    lasts, so an outage is one page plus a reminder rather than a stream.
+    Returned so tests can join it. Nothing in the app waits on it.
     """
-    now = time.time()
+    thread = threading.Thread(target=_deliver, args=(subject, body),
+                              name='alert', daemon=True)
+    thread.start()
+    return thread
+
+
+# -- the API the rest of the app uses --------------------------------------
+
+def record(job_id, kind, failure, progress=None, now=None, **fields):
+    """Note a failure, and email about it if this is the first of its kind.
+
+    Every call is remembered for the end-of-job digest whether or not it sends,
+    so suppressing an email never loses the event.
+    """
+    now = time.time() if now is None else now
     with _lock:
-        last = _firing.get(event)
-        if last is not None and now - last < REMINDER_SECONDS:
-            return False
-        _firing[event] = now
-    if last is not None:
-        title = "%s (still)" % title
-    return _send(title, body, priority, tags)
+        _pending.setdefault(job_id, []).append((failure, dict(fields)))
+        if (job_id, failure) in _sent:
+            return None
+        last = _class_floor.get(failure)
+        if last is not None and now - last < CLASS_FLOOR_SECONDS:
+            return None
+        _sent.add((job_id, failure))
+        _class_floor[failure] = now
+    return _send('Napier: %s' % failure,
+                 _format(job_id, kind, failure, fields, progress))
 
 
-def clear_alert(event, title, body, tags='white_check_mark'):
-    """Report that `event` recovered, if it had been reported broken.
+def digest(job_id, kind, progress=None):
+    """One closing email with the whole timeline, if anything went wrong.
 
-    Silent when the event was never firing, so a healthy app is silent.
+    The per-failure emails are deliberately terse and rate limited, so this is
+    where the full picture of a bad run lands.
     """
     with _lock:
-        if event not in _firing:
-            return False
-        del _firing[event]
-    return _send(title, body, 'default', tags)
+        events = _pending.pop(job_id, None)
+    if not events:
+        return None
+    lines = ['%s job %s finished with %d problem%s.'
+             % (kind, job_id, len(events), '' if len(events) == 1 else 's'), '']
+    for index, (failure, fields) in enumerate(events, start=1):
+        detail = ', '.join('%s %s' % (k, v) for k, v in sorted(fields.items())
+                           if k not in ('traceback', 'note'))
+        lines.append('%2d. %s%s' % (index, failure, ' (%s)' % detail if detail else ''))
+    if progress:
+        lines += ['', 'Last %d progress lines:' % len(progress)]
+        lines += ['  ' + line for line in progress]
+    return _send('Napier: %s job ended with %d problem%s'
+                 % (kind, len(events), '' if len(events) == 1 else 's'),
+                 '\n'.join(lines))
 
 
-def is_firing(event):
-    with _lock:
-        return event in _firing
+def emitter(job):
+    """An alert callback bound to one job, for handing to IcosClient."""
+    def emit(failure, **fields):
+        return record(job.id[:8], job.kind, failure,
+                      progress=recent_progress(job), **fields)
+    return emit
+
+
+def recent_progress(job, limit=20):
+    """The tail of a job's staff-facing progress log.
+
+    These are messages Napier wrote for a person to read on the progress page.
+    They report counts, retry state and case ids, never the search subject.
+    """
+    try:
+        return [entry['message'] for entry in job.progress[-limit:]]
+    except Exception:
+        return []
 
 
 def reset():
-    """Forget all firing state. For tests."""
+    """Forget all dedup and digest state. For tests."""
     with _lock:
-        _firing.clear()
+        _sent.clear()
+        _class_floor.clear()
+        _pending.clear()

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ KEEPALIVE_BURST = 8
 # A ping every 20 seconds logging a line each time is 4,300 lines a day, which
 # buries the job and ICOS lines that someone reads a log to find. Every change
 # of state is logged; a steady healthy ping only says so this often.
-KEEPALIVE_LOG_SECS = 15 * 60
+KEEPALIVE_LOG_SECS = 10 * 60
 _keepalive_lock = None
 _keepalive_state = {"ok": None, "logged_at": 0.0, "cold_since": None}
 
@@ -83,27 +83,20 @@ def _keepalive_cycle(state, now=None):
         else:
             print("KEEPALIVE still cold after burst", flush=True)
 
+    # Deliberately does not alert. A cold keepalive is the normal state of an
+    # idle path to ICOS and it recovers on its own, so paging on it would train
+    # everyone to ignore Napier's email. Staff-visible failures are alerted
+    # where they happen, in the retry classifier and the job engine.
     if ok:
         if state["cold_since"] is not None:
-            alerts.clear_alert(
-                "icos-keepalive",
-                "Napier can reach ICOS again",
-                "The keepalive warmed the path back up after %s. Searches "
-                "should work normally." % _describe_duration(now - state["cold_since"]))
+            print("KEEPALIVE warm again after %s"
+                  % _describe_duration(now - state["cold_since"]), flush=True)
             state["cold_since"] = None
         if state["ok"] is not True or now - state["logged_at"] >= KEEPALIVE_LOG_SECS:
             print("KEEPALIVE ok %.2fs" % dt, flush=True)
             state["logged_at"] = now
-    else:
-        if state["cold_since"] is None:
-            state["cold_since"] = now
-        alerts.raise_alert(
-            "icos-keepalive",
-            "Napier cannot reach ICOS",
-            "%d keepalive attempts on the ICOS login page failed in a row, so "
-            "searches will stall or fail until this clears. Cold for %s."
-            % (KEEPALIVE_BURST + 1, _describe_duration(now - state["cold_since"])),
-            priority="urgent")
+    elif state["cold_since"] is None:
+        state["cold_since"] = now
     state["ok"] = ok
     return state
 
@@ -256,6 +249,26 @@ def download(job_id):
     return send_file(path, as_attachment=True,
                      download_name=tasks.download_name(job.result['def_name'],
                                                        job.result['is_lite']))
+
+
+@app.errorhandler(Exception)
+def unhandled(e):
+    """Anything that got past a route without being handled.
+
+    Background jobs report their own failures, so what lands here is a bug in a
+    request path, which is the case nobody would otherwise find out about: the
+    user sees a 500 and closes the tab. Re-raised afterwards so Flask still
+    produces its normal error response and the traceback still reaches the log.
+    """
+    from werkzeug.exceptions import HTTPException
+    if isinstance(e, HTTPException):
+        # 404s and the like are routing, not breakage.
+        return e
+    # The request path is included and the query string is not, since a search
+    # is submitted as a POST body and a path is only ever a route plus a job id.
+    alerts.record(request.path, 'web', alerts.UNHANDLED,
+                  **{'traceback': alerts.safe_traceback(e)})
+    raise e
 
 
 @app.template_filter('pluralize')

--- a/icos.py
+++ b/icos.py
@@ -17,8 +17,12 @@ Timing is injectable so the retry behaviour can be tested without real waits.
 import os
 import time
 
+import alerts
 from opener import Opener
 from reader import Reader
+
+# Attempts before a run that still succeeded is worth an early-warning email.
+SLOW_RECOVERY_ATTEMPTS = alerts.SLOW_RECOVERY_ATTEMPTS
 
 # Backoff between attempts, in seconds; the last value repeats once reached.
 BACKOFF = [2, 5, 10, 30, 60, 120, 120, 300]
@@ -50,6 +54,19 @@ def backoff_for(attempt):
     return BACKOFF[min(attempt, len(BACKOFF) - 1)]
 
 
+def _describe(seconds):
+    if seconds < 90:
+        return "%ds" % round(seconds)
+    return "%dm%02ds" % (int(seconds // 60), int(seconds % 60))
+
+
+def _timeline(waits):
+    """The backoff actually used, so an alert shows the shape of the stall."""
+    if not waits:
+        return "none"
+    return "+".join(str(w) for w in waits) + "s"
+
+
 class IcosError(Exception):
     """Base for failures we surface to staff with a plain-language message."""
 
@@ -73,9 +90,13 @@ class IcosUnavailable(IcosError):
 class IcosClient:
     def __init__(self, log=None, reader=None, budget_seconds=None,
                  concurrent_budget_seconds=None, sleep=time.sleep,
-                 monotonic=time.monotonic):
+                 monotonic=time.monotonic, alert=None):
         self.reader = reader if reader is not None else Reader(Opener())
         self._log = log or (lambda message: None)
+        # Alerting is a callback rather than an import so this module stays
+        # testable without a mail path, and so alerts describe the
+        # classification below rather than a raw exception.
+        self._alert = alert or (lambda failure, **fields: None)
         self._sleep = sleep
         self._monotonic = monotonic
         self.budget = budget_seconds if budget_seconds is not None \
@@ -85,6 +106,15 @@ class IcosClient:
             else _env_seconds("CONCURRENT_WAIT_MIN", 16)
         self.logged_in = False
         self.username = None
+
+    def set_alert(self, alert):
+        """Point alerts at a different job.
+
+        The CRS job inherits the live session the search job created, so
+        without this a case failure during CRS is filed under the search that
+        produced the results list.
+        """
+        self._alert = alert or (lambda failure, **fields: None)
 
     # -- retry core --------------------------------------------------------
 
@@ -108,24 +138,51 @@ class IcosClient:
         started = self._monotonic()
         attempt = 0
         last = "no response"
+        waits = []
+        endpoint = None
         while True:
             url, data = build_request()
+            endpoint = url.rsplit("/", 1)[-1].split("?")[0] or "ESAWebApp"
             result = self.reader.fetch_once(url, data)
             if result.ok:
                 if validate is None or validate(result.body):
+                    if attempt >= SLOW_RECOVERY_ATTEMPTS:
+                        # It worked, so staff see nothing. But ICOS needing this
+                        # many tries is how a bad afternoon starts, and knowing
+                        # before the complaints is the whole point of alerting.
+                        self._alert(
+                            alerts.SLOW_RECOVERY, endpoint=endpoint,
+                            attempts=attempt + 1,
+                            elapsed=_describe(self._monotonic() - started),
+                            backoff=_timeline(waits), status=result.status,
+                            note="The search went through, so nobody was told. "
+                                 "ICOS is degrading.")
                     return result.body
                 last = "unusable response"
             else:
                 last = result.outcome.lower()
 
+            # Only after login: before it, an unusable response is usually a
+            # rejected credential working as designed, which is not news.
+            if self.logged_in:
+                self._alert(alerts.BAD_RESPONSE, endpoint=endpoint,
+                            attempts=attempt + 1, status=result.status,
+                            **{'response size': '%db' % len(result.body)})
+
             elapsed = self._monotonic() - started
             wait = backoff_for(attempt)
             if elapsed + wait > self.budget:
+                self._alert(alerts.RETRY_EXHAUSTED, endpoint=endpoint,
+                            attempts=attempt + 1, elapsed=_describe(elapsed),
+                            backoff=_timeline(waits),
+                            note="Last result: %s. Staff were told to try again "
+                                 "later." % last)
                 raise IcosUnavailable(
                     "Iowa Courts Online did not respond after %d minutes of retrying "
                     "(last result: %s). The court site is likely down. Please try "
                     "again later." % (round(self.budget / 60), last))
             self._log(self._attempt_message(what, attempt, elapsed))
+            waits.append(wait)
             self._sleep(wait)
             attempt += 1
 
@@ -157,6 +214,12 @@ class IcosClient:
                 # the only thing that works.
                 elapsed = self._monotonic() - started
                 if elapsed + CONCURRENT_INTERVAL > self.concurrent_budget:
+                    self._alert(
+                        alerts.CONCURRENT_EXHAUSTED,
+                        account=alerts.username_prefix(username),
+                        elapsed=_describe(elapsed),
+                        note="ESA never released the lock. This is shared "
+                             "accounts colliding, not an ICOS fault.")
                     raise IcosAccountLocked(
                         "This Iowa Courts account is still logged in from another "
                         "session and Iowa Courts has not released it. Try again in a "

--- a/jobs.py
+++ b/jobs.py
@@ -92,16 +92,10 @@ def start(kind, target, *args, **kwargs):
             if message is None:
                 print("JOB %s %s crashed: %r" % (kind, job.id[:8], e), flush=True)
                 # Staff get an apology they cannot act on, so someone who can
-                # act has to hear about it. The exception type and job id are
-                # enough to find the traceback in the dyno log; the exception
-                # message is deliberately left out, because a parser failing on
-                # a case tends to quote that case.
-                alerts.raise_alert(
-                    "job-crash-%s" % kind,
-                    "Napier %s job crashed" % kind,
-                    "A %s job ended in an unhandled %s and the user was shown a "
-                    "generic apology. Job %s in the dyno log has the traceback."
-                    % (kind, type(e).__name__, job.id[:8]))
+                # act has to hear about it.
+                alerts.record(job.id[:8], kind, alerts.JOB_FAILED,
+                              progress=alerts.recent_progress(job),
+                              **{'traceback': alerts.safe_traceback(e)})
                 message = ("Something went wrong inside Napier. Please try again, "
                            "and let Clark Management Consulting know if it keeps "
                            "happening.")

--- a/tasks.py
+++ b/tasks.py
@@ -12,6 +12,7 @@ import platform
 from openpyxl import load_workbook
 from werkzeug.utils import secure_filename
 
+import alerts
 import case_parser
 import crs
 import icos_sessions
@@ -38,7 +39,7 @@ def group_cases(cases):
 
 
 def search_task(job, username, password, firstname, middlename, lastname):
-    client = IcosClient(log=job.log)
+    client = IcosClient(log=job.log, alert=alerts.emitter(job))
     keep_session = False
     try:
         client.login(username, password)
@@ -63,12 +64,14 @@ def search_task(job, username, password, firstname, middlename, lastname):
     finally:
         if not keep_session:
             client.logoff()
+        alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
 def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
     client = icos_sessions.get(session_token)
     if client is None:
         raise LookupError("session expired")
+    client.set_alert(alerts.emitter(job))
 
     try:
         case_ids = []
@@ -89,6 +92,13 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
                 # One unparseable case should not cost staff the whole run --
                 # collect it, report it, and build the CRS from the rest.
                 print("Case %s failed to parse: %r" % (case_id, e), flush=True)
+                # The case id is in the alert on purpose: it is court public
+                # record, and without it nobody can go look at the page that
+                # broke the parser.
+                alerts.record(job.id[:8], job.kind, alerts.PARSE_FAILURE,
+                              progress=alerts.recent_progress(job),
+                              case=case_id,
+                              **{'traceback': alerts.safe_traceback(e)})
                 failed.append(case_id)
                 continue
             cases.append(case)
@@ -114,6 +124,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         return "/job/%s/download" % job.id
     finally:
         icos_sessions.close(session_token)
+        alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
 def build_workbook(cases, def_name, def_dob, is_lite):

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -490,3 +490,27 @@ def test_a_case_that_will_not_parse_alerts_with_the_case_and_not_the_person(
     for message in mailbox:
         assert 'TESTER' not in message['text']      # privileged, never sent
         assert '01/01/1900' not in message['text']
+
+
+# -- bookkeeping does not grow forever ------------------------------------
+
+
+def test_a_digested_job_is_forgotten_entirely(mailbox):
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+    send(alerts.digest('job1234', 'search'))
+    assert 'job1234' not in alerts._pending
+    assert 'job1234' not in alerts._sent   # dedup state died with the job
+
+
+def test_the_web_error_path_cannot_grow_without_bound(mailbox):
+    # A request path is the job id here and there is no end-of-job digest to
+    # clean up after it, so a dyno that stays up for weeks would otherwise keep
+    # one entry per request that ever threw.
+    for i in range(alerts.MAX_TRACKED_JOBS * 2):
+        alerts.record('/job/%d/download' % i, 'web', alerts.UNHANDLED)
+    settle()
+    assert len(alerts._pending) == alerts.MAX_TRACKED_JOBS
+    assert len(alerts._sent) <= alerts.MAX_TRACKED_JOBS
+    # The survivors are the recent ones.
+    assert '/job/0/download' not in alerts._pending
+    assert '/job/%d/download' % (alerts.MAX_TRACKED_JOBS * 2 - 1) in alerts._pending

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,15 +1,21 @@
 """Alerting: does a failure nobody is watching actually reach someone.
 
-These tests run a real HTTP server and assert on the request that arrives on it,
-rather than on a mock having been called. A mock proves the code called what we
-told it to call. It does not prove an alert leaves the process, which is the
-only thing this feature is for.
+These tests point the Mailgun endpoint at a real local HTTP server and assert on
+the request that arrives on it, rather than on a mock having been called. A mock
+proves the code called what we told it to call. It does not prove an email
+leaves the process, which is the only thing this feature is for.
+
+The other thing under test here is what must never be in one. The search subject
+is privileged under Article 5, so an alert may carry a case number, which is
+court public record and without which a parse failure is not actionable, and may
+not carry a name, a date of birth, or a credential.
 """
 
+import base64
 import os
 import sys
 import threading
-import time
+import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
@@ -19,228 +25,468 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
 
 import alerts
-import app as app_module
-import jobs
+import icos
+import tasks
+from icos import IcosClient, IcosAccountLocked, IcosUnavailable
+from reader import FetchResult, OK, EMPTY
 
 
-class Collector(BaseHTTPRequestHandler):
+class Mailgun(BaseHTTPRequestHandler):
     received = []
     status = 200
 
     def do_POST(self):
         length = int(self.headers.get('Content-Length') or 0)
-        Collector.received.append({
-            'body': self.rfile.read(length).decode('utf-8'),
-            'title': self.headers.get('Title'),
-            'priority': self.headers.get('Priority'),
-            'tags': self.headers.get('Tags'),
+        fields = urllib.parse.parse_qs(self.rfile.read(length).decode('utf-8'))
+        Mailgun.received.append({
+            'path': self.path,
+            'auth': self.headers.get('Authorization'),
+            'to': fields.get('to', [''])[0],
+            'from': fields.get('from', [''])[0],
+            'subject': fields.get('subject', [''])[0],
+            'text': fields.get('text', [''])[0],
         })
-        self.send_response(Collector.status)
+        self.send_response(Mailgun.status)
         self.end_headers()
-        self.wfile.write(b'ok')
+        self.wfile.write(b'{"id":"ok"}')
 
     def log_message(self, *args):
         pass
 
 
 @pytest.fixture
-def endpoint(monkeypatch):
-    """A real listening socket standing in for the ntfy topic."""
-    Collector.received = []
-    Collector.status = 200
-    server = HTTPServer(('127.0.0.1', 0), Collector)
-    # serve_forever polls at half a second by default, which is half a second
-    # of teardown on every test in this file.
+def mailbox(monkeypatch):
+    """A real listening socket standing in for api.mailgun.net."""
+    Mailgun.received = []
+    Mailgun.status = 200
+    server = HTTPServer(('127.0.0.1', 0), Mailgun)
+    # serve_forever polls at half a second by default, which would be half a
+    # second of teardown on every test in this file.
     threading.Thread(target=server.serve_forever, kwargs={'poll_interval': 0.01},
                      daemon=True).start()
-    monkeypatch.setenv(alerts.ALERT_URL_ENV,
-                       'http://127.0.0.1:%d/napier' % server.server_port)
+    monkeypatch.setattr(alerts, 'MAILGUN_ENDPOINT',
+                        'http://127.0.0.1:%d/v3/%%s/messages' % server.server_port)
+    monkeypatch.setenv('MAILGUN_DOMAIN', 'mg.example.org')
+    monkeypatch.setenv('MAILGUN_API_KEY', 'key-test')
+    monkeypatch.setenv('ALERT_EMAIL_TO', 'alerts@example.org')
     alerts.reset()
-    yield Collector.received
+    yield Mailgun.received
     server.shutdown()
     alerts.reset()
 
 
-def test_an_alert_actually_leaves_the_process(endpoint):
-    assert alerts.raise_alert('t', 'ICOS is down', 'Nothing is answering.') is True
-    assert len(endpoint) == 1
-    assert endpoint[0]['title'] == 'ICOS is down'
-    assert endpoint[0]['body'] == 'Nothing is answering.'
-    assert endpoint[0]['priority'] == 'high'
+def send(thread):
+    """Wait for one alert's daemon thread, so assertions are not racing it."""
+    assert thread is not None, "expected an alert to be sent"
+    thread.join(timeout=5)
+    assert not thread.is_alive()
 
 
-def test_a_repeat_within_the_hour_is_not_sent_again(endpoint):
-    alerts.raise_alert('t', 'ICOS is down', 'first')
-    for _ in range(20):
-        alerts.raise_alert('t', 'ICOS is down', 'again')
-    # A 20-second keepalive loop would otherwise send 180 pages an hour.
-    assert len(endpoint) == 1
+def settle(timeout=5):
+    """Wait out every in-flight send.
 
-
-def test_a_lasting_failure_reminds_once_the_cooldown_passes(endpoint, monkeypatch):
-    alerts.raise_alert('t', 'ICOS is down', 'first')
-    monkeypatch.setattr(alerts, 'REMINDER_SECONDS', 0)
-    alerts.raise_alert('t', 'ICOS is down', 'still going')
-    assert len(endpoint) == 2
-    assert endpoint[1]['title'] == 'ICOS is down (still)'
-
-
-def test_recovery_is_announced_only_if_something_broke(endpoint):
-    assert alerts.clear_alert('t', 'all clear', 'nothing was wrong') is False
-    assert endpoint == []
-    alerts.raise_alert('t', 'ICOS is down', 'broken')
-    assert alerts.clear_alert('t', 'ICOS is back', 'recovered') is True
-    assert len(endpoint) == 2
-    assert endpoint[1]['title'] == 'ICOS is back'
-    assert endpoint[1]['priority'] == 'default'
-
-
-def test_recovery_rearms_the_alert(endpoint):
-    alerts.raise_alert('t', 'down', 'a')
-    alerts.clear_alert('t', 'up', 'b')
-    # Second outage inside the cooldown window must still page.
-    assert alerts.raise_alert('t', 'down', 'c') is True
-    assert len(endpoint) == 3
-
-
-def test_an_invalid_priority_is_downgraded_rather_than_dropped(endpoint):
-    # ntfy accepts six priority words and silently 400s on anything else, so a
-    # typo here would mean an outage page that never arrives.
-    alerts.raise_alert('t', 'ICOS is down', 'body', priority='critical')
-    assert endpoint[0]['priority'] == 'default'
-
-
-@pytest.mark.parametrize('priority', alerts.PRIORITIES)
-def test_every_documented_priority_is_passed_through(endpoint, priority):
-    alerts.reset()
-    alerts.raise_alert('p-%s' % priority, 't', 'b', priority=priority)
-    assert endpoint[-1]['priority'] == priority
-
-
-def test_no_endpoint_configured_is_a_silent_no_op(monkeypatch):
-    monkeypatch.delenv(alerts.ALERT_URL_ENV, raising=False)
-    alerts.reset()
-    assert alerts.raise_alert('t', 'title', 'body') is False
-
-
-def test_a_dead_endpoint_does_not_take_the_caller_down(monkeypatch):
-    monkeypatch.setenv(alerts.ALERT_URL_ENV, 'http://127.0.0.1:1/nope')
-    alerts.reset()
-    assert alerts.raise_alert('t', 'title', 'body') is False
-    # The condition still counts as firing, so recovery is still announced.
-    assert alerts.is_firing('t')
-
-
-def test_a_rejecting_endpoint_does_not_take_the_caller_down(endpoint):
-    Collector.status = 500
-    assert alerts.raise_alert('t', 'title', 'body') is False
-
-
-# --- the two conditions actually wired up -------------------------------
-
-
-@pytest.fixture
-def keepalive(monkeypatch):
-    """Drive the keepalive cycle with a scripted sequence of ping outcomes."""
-    outcomes = []
-
-    def fake_ping(timeout=6):
-        return 0.1, outcomes.pop(0) if outcomes else True
-
-    monkeypatch.setattr(app_module, '_keepalive_ping', fake_ping)
-    return outcomes
-
-
-def test_icos_going_cold_pages_someone(endpoint, keepalive):
-    keepalive.extend([False] * (app_module.KEEPALIVE_BURST + 1))
-    app_module._keepalive_cycle({'ok': True, 'logged_at': 0.0, 'cold_since': None})
-    assert len(endpoint) == 1
-    assert 'cannot reach ICOS' in endpoint[0]['title']
-    assert endpoint[0]['priority'] == 'urgent'
-
-
-def test_a_ping_that_recovers_inside_the_burst_pages_nobody(endpoint, keepalive):
-    keepalive.extend([False, False, True])
-    app_module._keepalive_cycle({'ok': True, 'logged_at': 0.0, 'cold_since': None})
-    assert endpoint == []
-
-
-def test_icos_coming_back_says_so_and_says_how_long(endpoint, keepalive):
-    state = {'ok': True, 'logged_at': 0.0, 'cold_since': None}
-    keepalive.extend([False] * (app_module.KEEPALIVE_BURST + 1))
-    app_module._keepalive_cycle(state, now=1000.0)
-    app_module._keepalive_cycle(state, now=1000.0 + 25 * 60)
-    assert len(endpoint) == 2
-    assert 'reach ICOS again' in endpoint[1]['title']
-    assert '25 minutes' in endpoint[1]['body']
-    assert state['cold_since'] is None
-
-
-def test_a_healthy_keepalive_stops_logging_every_ping(endpoint, keepalive, capsys):
-    state = {'ok': None, 'logged_at': 0.0, 'cold_since': None}
-    now = 10000.0
-    for _ in range(30):
-        app_module._keepalive_cycle(state, now=now)
-        now += app_module.KEEPALIVE_SECS
-    lines = [l for l in capsys.readouterr().out.splitlines() if 'KEEPALIVE ok' in l]
-    # Ten minutes of pings. One line for the first success, none after, because
-    # a line every 20 seconds buries the JOB and ICOS lines in the same log.
-    assert len(lines) == 1
-
-
-def test_a_healthy_keepalive_still_says_so_periodically(endpoint, keepalive):
-    state = {'ok': True, 'logged_at': 1000.0, 'cold_since': None}
-    app_module._keepalive_cycle(state, now=1000.0 + app_module.KEEPALIVE_LOG_SECS)
-    assert state['logged_at'] == 1000.0 + app_module.KEEPALIVE_LOG_SECS
-
-
-def test_a_crashing_job_pages_someone(endpoint):
-    def explode(job):
-        raise ValueError('TESTER, PAT Q had an unparseable charge row')
-
-    job = jobs.start('search', explode)
-    for _ in range(200):
-        if job.status == jobs.FAILED:
-            break
-        time.sleep(0.01)
-    assert job.status == jobs.FAILED
-    assert len(endpoint) == 1
-    assert endpoint[0]['title'] == 'Napier search job crashed'
-    assert 'ValueError' in endpoint[0]['body']
-
-
-def test_a_crash_alert_carries_no_case_data(endpoint):
-    """The endpoint is a third-party service and the payload is court records.
-
-    An exception raised while parsing a case usually quotes that case, so the
-    alert reports the exception type and nothing else from it.
+    Alerts fired from inside IcosClient are dispatched to a daemon thread whose
+    handle the caller throws away, so asserting on the mailbox straight after
+    is a race. Every send thread is started synchronously inside record(), so by
+    the time the client call has returned they all exist and can be joined.
     """
-    def explode(job):
-        raise ValueError('TESTER, PAT Q 01311 FECR000000 01/01/1900')
-
-    job = jobs.start('crs', explode)
-    for _ in range(200):
-        if job.status == jobs.FAILED:
-            break
-        time.sleep(0.01)
-    assert job.status == jobs.FAILED
-    sent = endpoint[0]['title'] + endpoint[0]['body']
-    for leak in ('TESTER', 'PAT Q', 'FECR000000', '01/01/1900'):
-        assert leak not in sent
+    for thread in threading.enumerate():
+        if thread.name == 'alert':
+            thread.join(timeout)
 
 
-def test_a_handled_failure_pages_nobody(endpoint):
-    """Failures already phrased for staff are the app working, not breaking."""
-    class Handled(Exception):
-        message = 'That user ID or password was not accepted by Iowa Courts.'
+class FakeJob:
+    def __init__(self, kind='search'):
+        self.id = 'abcdef0123456789'
+        self.kind = kind
+        self.progress = [{'message': 'Connecting to Iowa Courts Online...'},
+                         {'message': 'Iowa Courts is slow, retrying (attempt 4)...'}]
 
-    def refuse(job):
-        raise Handled()
+    def log(self, message):
+        self.progress.append({'message': message})
 
-    job = jobs.start('search', refuse)
-    for _ in range(200):
-        if job.status == jobs.FAILED:
-            break
-        time.sleep(0.01)
-    assert job.status == jobs.FAILED
-    assert endpoint == []
+
+# -- delivery -------------------------------------------------------------
+
+
+def test_an_alert_actually_leaves_the_process(mailbox):
+    send(alerts.record('job1234', 'search', alerts.RETRY_EXHAUSTED,
+                       endpoint='TrialCaseSearchResultServlet', attempts=9))
+    assert len(mailbox) == 1
+    assert mailbox[0]['path'] == '/v3/mg.example.org/messages'
+    assert mailbox[0]['to'] == 'alerts@example.org'
+    assert alerts.RETRY_EXHAUSTED in mailbox[0]['subject']
+    assert 'TrialCaseSearchResultServlet' in mailbox[0]['text']
+    assert 'job1234' in mailbox[0]['text']
+
+
+def test_it_authenticates_the_way_mailgun_expects(mailbox):
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+    scheme, _, token = mailbox[0]['auth'].partition(' ')
+    assert scheme == 'Basic'
+    assert base64.b64decode(token).decode() == 'api:key-test'
+
+
+def test_the_from_address_defaults_into_the_sending_domain(mailbox):
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+    assert 'napier@mg.example.org' in mailbox[0]['from']
+
+
+def test_an_explicit_from_address_wins(mailbox, monkeypatch):
+    monkeypatch.setenv('ALERT_EMAIL_FROM', 'Napier <napier@clarkmc.example>')
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+    assert mailbox[0]['from'] == 'Napier <napier@clarkmc.example>'
+
+
+@pytest.mark.parametrize('missing', ['MAILGUN_DOMAIN', 'MAILGUN_API_KEY',
+                                     'ALERT_EMAIL_TO'])
+def test_incomplete_config_is_a_logged_no_op(mailbox, monkeypatch, missing):
+    monkeypatch.delenv(missing)
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+    assert mailbox == []
+
+
+def test_a_rejecting_mailgun_does_not_take_the_caller_down(mailbox):
+    Mailgun.status = 500
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+    # Delivery failed, the caller lived, and the event is still on the digest.
+    send(alerts.digest('job1234', 'search'))
+
+
+def test_an_unreachable_mailgun_does_not_take_the_caller_down(mailbox, monkeypatch):
+    monkeypatch.setattr(alerts, 'MAILGUN_ENDPOINT', 'http://127.0.0.1:1/v3/%s/messages')
+    send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
+
+
+# -- rate limiting --------------------------------------------------------
+
+
+def test_one_email_per_job_per_failure_class(mailbox):
+    send(alerts.record('job1234', 'search', alerts.BAD_RESPONSE, attempts=1))
+    for attempt in range(2, 40):
+        assert alerts.record('job1234', 'search', alerts.BAD_RESPONSE,
+                             attempts=attempt) is None
+    # A 45-minute budget at escalating backoff is dozens of attempts.
+    assert len(mailbox) == 1
+
+
+def test_a_different_class_on_the_same_job_still_gets_through(mailbox):
+    send(alerts.record('job1234', 'search', alerts.BAD_RESPONSE))
+    send(alerts.record('job1234', 'search', alerts.RETRY_EXHAUSTED))
+    assert len(mailbox) == 2
+
+
+def test_a_second_job_inside_the_floor_is_suppressed(mailbox):
+    send(alerts.record('job1234', 'search', alerts.BAD_RESPONSE, now=1000.0))
+    # A clinic morning puts several staff behind the same broken ICOS.
+    assert alerts.record('job5678', 'search', alerts.BAD_RESPONSE,
+                         now=1000.0 + 60) is None
+    assert len(mailbox) == 1
+
+
+def test_a_second_job_past_the_floor_gets_through(mailbox):
+    send(alerts.record('job1234', 'search', alerts.BAD_RESPONSE, now=1000.0))
+    send(alerts.record('job5678', 'search', alerts.BAD_RESPONSE,
+                       now=1000.0 + alerts.CLASS_FLOOR_SECONDS + 1))
+    assert len(mailbox) == 2
+
+
+# -- the end-of-job digest ------------------------------------------------
+
+
+def test_a_clean_job_sends_no_digest(mailbox):
+    assert alerts.digest('job1234', 'search') is None
+    assert mailbox == []
+
+
+def test_the_digest_carries_events_that_were_never_emailed(mailbox):
+    send(alerts.record('job1234', 'search', alerts.BAD_RESPONSE, attempts=1))
+    for attempt in range(2, 6):
+        alerts.record('job1234', 'search', alerts.BAD_RESPONSE, attempts=attempt)
+    send(alerts.digest('job1234', 'search',
+                       ['Iowa Courts is slow, retrying (attempt 4)...']))
+    body = mailbox[-1]['text']
+    # Suppressing an email must not lose the event.
+    assert '5 problems' in mailbox[-1]['subject']
+    assert 'attempts 5' in body
+    assert 'retrying (attempt 4)' in body
+
+
+def test_the_digest_is_sent_once(mailbox):
+    alerts.record('job1234', 'search', alerts.JOB_FAILED)
+    alerts.digest('job1234', 'search')
+    assert alerts.digest('job1234', 'search') is None
+    settle()
+
+
+# -- what may and may not be in an alert ----------------------------------
+
+
+def test_an_esa_account_is_reported_as_a_family_not_an_account(mailbox):
+    assert alerts.username_prefix('ILA04') == 'ILA##'
+    assert alerts.username_prefix('ila01') == 'ILA##'
+    assert alerts.username_prefix('drakelegalclinic7') == 'drakelegalclinic'
+    assert alerts.username_prefix('') == 'unknown'
+    send(alerts.record('job1234', 'search', alerts.CONCURRENT_EXHAUSTED,
+                       account=alerts.username_prefix('ILA04')))
+    assert 'ILA##' in mailbox[0]['text']
+    assert 'ILA04' not in mailbox[0]['text']
+
+
+def _parser_that_quotes_the_case(row):
+    # Shaped like the real thing: the message is built from a value, so what
+    # ends up in the traceback's source line is this literal and not the row.
+    raise ValueError('unreadable charge row: %s' % row)
+
+
+def test_a_traceback_keeps_its_frames_and_drops_its_message(mailbox):
+    """A parser that dies on a case usually quotes that case back."""
+    # Held in a variable so the calling frame's source line does not contain it
+    # either. A traceback shows source, and source is ours; it never shows the
+    # values that flowed through it, which is the whole basis of this guard.
+    row = 'TESTER, PAT Q 01/01/1900 FECR000000'
+    try:
+        _parser_that_quotes_the_case(row)
+    except ValueError as e:
+        text = alerts.safe_traceback(e)
+    assert 'ValueError' in text
+    assert 'test_alerts.py' in text                     # the frame survives
+    assert 'unreadable charge row' in text              # so does our source line
+    assert 'TESTER' not in text                         # the value does not
+    assert '01/01/1900' not in text
+
+
+def test_an_exception_we_authored_keeps_its_message(mailbox):
+    # IcosError messages are written by us for staff and carry no case data,
+    # and they are the single most useful line in an alert.
+    try:
+        raise IcosAccountLocked('This Iowa Courts account is still logged in.')
+    except IcosAccountLocked as e:
+        text = alerts.safe_traceback(e)
+    assert 'still logged in' in text
+
+
+def test_a_case_number_is_allowed_through(mailbox):
+    # Court public record, and a parse-failure alert without it is not
+    # actionable. Flagged in the plan as a call to confirm with Sandi.
+    send(alerts.record('job1234', 'crs', alerts.PARSE_FAILURE,
+                       case='01311 FECR000000'))
+    assert '01311 FECR000000' in mailbox[0]['text']
+
+
+def test_no_password_can_reach_an_alert(mailbox):
+    client = IcosClient(reader=_reader_that('concurrent'),
+                        concurrent_budget_seconds=1, sleep=lambda s: None,
+                        monotonic=_clock(), alert=alerts.emitter(FakeJob()))
+    with pytest.raises(IcosAccountLocked):
+        client.login('ILA04', 'hunter2-not-a-real-password')
+    settle()
+    assert mailbox, "expected the lockout alert, otherwise this proves nothing"
+    for message in mailbox:
+        assert 'hunter2' not in message['text']
+        assert 'ILA04' not in message['text']
+
+
+# -- the classifier hooks -------------------------------------------------
+
+
+def _clock():
+    ticks = iter(range(0, 100000, 30))
+    return lambda: next(ticks)
+
+
+def _reader_that(mode, ok_after=None):
+    """A Reader stub that returns a scripted outcome for every fetch."""
+    login_ok = (b'x' * 30000)
+    concurrent = b'Concurrent Login Error' + b'x' * 3000
+
+    class Stub:
+        def __init__(self):
+            self.calls = 0
+
+        def fetch_once(self, url, data=None, timeout=8):
+            self.calls += 1
+            if mode == 'empty':
+                if ok_after is not None and self.calls > ok_after:
+                    return FetchResult(OK, login_ok, 200, 0.1)
+                return FetchResult(EMPTY, b'', 200, 0.1)
+            if mode == 'concurrent':
+                if 'EUACustomLoginServlet' in url:
+                    return FetchResult(OK, concurrent, 200, 0.1)
+                return FetchResult(OK, login_ok, 200, 0.1)
+            return FetchResult(OK, login_ok, 200, 0.1)
+
+        def init_request(self):
+            return 'https://x/ESAWebApp/ESALogin.jsp', None
+
+        def login_request(self, username, password):
+            return 'https://x/ESAWebApp/EUACustomLoginServlet', b'd'
+
+        def search_request(self, *a):
+            return 'https://x/ESAWebApp/TrialCaseSearchResultServlet', b'd'
+
+    return Stub()
+
+
+def test_running_out_of_retry_budget_emails_the_timeline(mailbox):
+    client = IcosClient(reader=_reader_that('empty'), budget_seconds=200,
+                        sleep=lambda s: None, monotonic=_clock(),
+                        alert=alerts.emitter(FakeJob()))
+    with pytest.raises(IcosUnavailable):
+        client.login('ILA04', 'pw')
+    settle()
+    subjects = [m['subject'] for m in mailbox]
+    assert any(alerts.RETRY_EXHAUSTED in s for s in subjects)
+    body = [m for m in mailbox if alerts.RETRY_EXHAUSTED in m['subject']][0]['text']
+    assert 'ESALogin.jsp' in body
+    assert 'backoff:' in body
+
+
+def test_a_run_that_recovers_late_is_an_early_warning(mailbox):
+    # Nobody complained, because it worked. That is exactly when we want to know.
+    client = IcosClient(reader=_reader_that('empty', ok_after=4),
+                        budget_seconds=10000, sleep=lambda s: None,
+                        monotonic=_clock(), alert=alerts.emitter(FakeJob()))
+    client._retry('search', client.reader.init_request)
+    settle()
+    assert any(alerts.SLOW_RECOVERY in m['subject'] for m in mailbox)
+
+
+def test_a_run_that_recovers_immediately_emails_nobody(mailbox):
+    client = IcosClient(reader=_reader_that('ok'), sleep=lambda s: None,
+                        monotonic=_clock(), alert=alerts.emitter(FakeJob()))
+    client._retry('search', client.reader.init_request)
+    settle()
+    assert mailbox == []
+
+
+def test_a_locked_account_emails_once_the_wait_gives_up(mailbox):
+    client = IcosClient(reader=_reader_that('concurrent'),
+                        concurrent_budget_seconds=1, sleep=lambda s: None,
+                        monotonic=_clock(), alert=alerts.emitter(FakeJob()))
+    with pytest.raises(IcosAccountLocked):
+        client.login('ILA04', 'pw')
+    settle()
+    assert any(alerts.CONCURRENT_EXHAUSTED in m['subject'] for m in mailbox)
+
+
+def test_a_bad_password_emails_nobody(mailbox):
+    # High volume, always a typo, no diagnostic value.
+    from icos import IcosBadCredentials
+
+    class Stub(object):
+        def fetch_once(self, url, data=None, timeout=8):
+            if 'EUACustomLoginServlet' in url:
+                return FetchResult(
+                    OK, b'The userID or password could not be validated'
+                        + b'x' * 9000, 200, 0.1)
+            return FetchResult(OK, b'x' * 30000, 200, 0.1)
+
+        def init_request(self):
+            return 'https://x/ESAWebApp/ESALogin.jsp', None
+
+        def login_request(self, username, password):
+            return 'https://x/ESAWebApp/EUACustomLoginServlet', b'd'
+
+    client = IcosClient(reader=Stub(), sleep=lambda s: None, monotonic=_clock(),
+                        alert=alerts.emitter(FakeJob()))
+    with pytest.raises(IcosBadCredentials):
+        client.login('ILA04', 'wrong')
+    settle()
+    assert mailbox == []
+
+
+def test_the_client_can_be_repointed_at_another_job(mailbox):
+    # The CRS job inherits the search job's live session.
+    client = IcosClient(reader=_reader_that('concurrent'),
+                        concurrent_budget_seconds=1, sleep=lambda s: None,
+                        monotonic=_clock(), alert=alerts.emitter(FakeJob('search')))
+    crs_job = FakeJob('crs')
+    crs_job.id = '99887766aabbccdd'
+    client.set_alert(alerts.emitter(crs_job))
+    with pytest.raises(IcosAccountLocked):
+        client.login('ILA04', 'pw')
+    settle()
+    assert '99887766' in mailbox[0]['text']
+
+
+# -- the web hook ---------------------------------------------------------
+
+
+def test_a_bug_in_a_request_path_emails_somebody(mailbox):
+    import app as app_module
+    from werkzeug.exceptions import NotFound
+
+    # Registered against the real app, so this fails if the hook is ever
+    # dropped rather than only if the function body changes.
+    handlers = app_module.app.error_handler_spec[None][None]
+    assert handlers[Exception] is app_module.unhandled
+
+    with app_module.app.test_request_context('/job/abc123/download'):
+        try:
+            raise RuntimeError('boom')
+        except RuntimeError as e:
+            # Re-raised so Flask still produces its own 500 and still logs the
+            # traceback; the alert is a side channel, not a replacement.
+            with pytest.raises(RuntimeError):
+                app_module.unhandled(e)
+    settle()
+    assert alerts.UNHANDLED in mailbox[0]['subject']
+    assert '/job/abc123/download' in mailbox[0]['text']
+    assert 'RuntimeError' in mailbox[0]['text']
+
+    # A 404 is routing, not breakage.
+    with app_module.app.test_request_context('/nope'):
+        assert isinstance(app_module.unhandled(NotFound()), NotFound)
+    settle()
+    assert len(mailbox) == 1
+
+
+# -- a case that will not parse -------------------------------------------
+
+
+def test_a_case_that_will_not_parse_alerts_with_the_case_and_not_the_person(
+        mailbox, monkeypatch):
+    import case_parser
+    import icos_sessions
+
+    class Stub:
+        logged_in = True
+
+        def set_alert(self, alert):
+            self.alert = alert
+
+        def case_bundle(self, case_id):
+            return b'<summary>', b'<charges>', b'<financials>'
+
+        def logoff(self):
+            pass
+
+    def explode(body, case):
+        # The shape the real parser fails in: the offending row is a value.
+        row = 'TESTER, PAT Q 01/01/1900'
+        raise ValueError('unreadable charge row: %s' % row)
+
+    monkeypatch.setattr(icos_sessions, 'get', lambda token: Stub())
+    monkeypatch.setattr(icos_sessions, 'close', lambda token: None)
+    monkeypatch.setattr(case_parser, 'parse_case_summary', explode)
+
+    job = FakeJob('crs')
+    with pytest.raises(ValueError):
+        tasks.crs_task(job, 'tok', ['1900-01-01 TESTER, PAT Q'],
+                       {'1900-01-01 TESTER, PAT Q': ['01311 FECR000000']},
+                       'TESTER, PAT Q', '01/01/1900', False)
+    settle()
+
+    # The failure and the digest, each on its own send thread, so arrival order
+    # is whichever socket finished first.
+    assert len(mailbox) == 2
+    by_subject = {m['subject']: m for m in mailbox}
+    failure = [m for s, m in by_subject.items() if alerts.PARSE_FAILURE in s]
+    assert len(failure) == 1
+    assert '01311 FECR000000' in failure[0]['text']  # public record, needed
+    assert 'ValueError' in failure[0]['text']
+    assert any('1 problem' in s for s in by_subject)
+    for message in mailbox:
+        assert 'TESTER' not in message['text']      # privileged, never sent
+        assert '01/01/1900' not in message['text']

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -37,12 +37,18 @@ class FakeClient:
     login_error = None
     search_error = None
 
-    def __init__(self, log=None, **kwargs):
+    def __init__(self, log=None, alert=None, **kwargs):
         self.log = log or (lambda m: None)
+        self.alert = alert
         self.logged_in = False
         self.logged_off = False
         self.cases = []
         FakeClient.instances.append(self)
+
+    def set_alert(self, alert):
+        # The CRS job inherits the search job's session and rebinds alerting
+        # to itself; a stub that skipped this would hide a break in that.
+        self.alert = alert
 
     def login(self, username, password):
         if FakeClient.login_error:


### PR DESCRIPTION
Replaces the alerting that #45 shipped. That version worked, but I built it from memory instead of from `NAPIER_RESILIENCE_PLAN.md`, and it diverged from the signed plan on transport, coverage, hook points, rate limiting, and what a redaction rule is supposed to redact. This is the same feature rebuilt against the spec.

### What changed from #45

| | #45 | here |
|---|---|---|
| Transport | ntfy webhook | Mailgun HTTP API over `urllib` |
| Failure classes covered | 2 | 7 |
| Keepalive | fired an alert | logs only, per spec |
| Hook points | `jobs.py`, `app.py` keepalive | `icos.py` classifier, `tasks.py` per-case, `jobs.py`, Flask `errorhandler` |
| End-of-job digest | none | one closing email with the full timeline |
| Rate limiting | 60 min global per event | per job per class, plus a 10 min class floor |
| Case numbers | stripped | included, which the plan asks for |

### Transport

One POST on a daemon thread with its own timeout. No SMTP handshake to stall a worker, no new dependency, and no Heroku add-on, which Service Exclusions rules out. A failed send is logged and dropped, because a mail outage must not become a failed search.

### What fires

Retry budget exhausted, an ESA lock that never released, a run that succeeded but needed three or more attempts, an unusable response once signed in, a per-case parse failure, a job crash, and an unhandled exception in a request path.

What does not fire: a bad password, a single transient retry, and a cold keepalive. The keepalive one matters. A cold path to ICOS is the normal state of an idle dyno and it recovers on its own, so alerting on it would train everyone to ignore Napier's mail. It logs instead, demoted to one heartbeat every ten minutes, which is the log hygiene the plan asks to ship in the same release.

### Redaction

Alerts carry case numbers and never carry people. A case number is court public record and a parse-failure alert without one gives nobody a page to go look at. The defendant's name and DOB are the privileged part under Article 5 and are never assembled into an alert. Exception messages are dropped for the same reason, since a parser dying on a case tends to quote that case back; the traceback frames survive because they are our own source.

Both guards were mutation tested. Breaking `safe_traceback` fails the leak test, breaking `username_prefix` fails two, and restoring them returns the suite to green.

### Tests

99 pass, up from 71. The alerting tests point the Mailgun endpoint at a real local HTTP server and assert on the request that arrives on it. A mock would only prove the code called what we told it to call, not that an email leaves the process, which is the only thing this feature is for.

### Before this does anything in production

Three config vars on `napier-dev` and later `crs-napier`: `MAILGUN_DOMAIN`, `MAILGUN_API_KEY`, `ALERT_EMAIL_TO`. With any of them unset the whole module is a logged no-op, so merging this changes nothing until they are set. Nothing here has been proven against real Mailgun yet, only against a local server speaking the same protocol.

One open item for the client message: the plan says to confirm the case-numbers-in-alerts call with Sandi. That has not happened yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t