### PR TITLE
Credit instalment payments to the fee they paid, and keep a bucket's category

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -230,13 +230,17 @@ def reconcile_financials(case):
         return None, None
 
     # Partition the itemization, carrying the last detail across continuation
-    # rows the way itemized_financials does.
+    # rows the way itemized_financials does. A continuation row has no detail
+    # and no amount, only a payment against the line above it, so its payment
+    # is credited to that line rather than dropped.
     buckets = {name: [] for name in ICOS_BUCKETS}
     last_detail = None
+    current = None
     for row in rows:
         detail = row.get('detail') or ''
         if is_excluded_fee(detail):
             last_detail = None
+            current = None
             continue
         if not detail.strip():
             if last_detail is None:
@@ -245,16 +249,21 @@ def reconcile_financials(case):
         else:
             last_detail = detail
         amount = row.get('amount')
+        paid = row.get('paid')
         if amount is None:
+            # Continuation row: a further payment against the line above.
+            if current is not None and paid is not None:
+                current[2] += Decimal(str(paid))
             continue
-        buckets[get_summary_bucket(detail)].append(
-            (detail, Decimal(str(amount))))
+        current = [detail, Decimal(str(amount)),
+                   Decimal(str(paid)) if paid is not None else Decimal(0)]
+        buckets[get_summary_bucket(detail)].append(current)
 
     # Every bucket must add up to what the summary says was assessed. If it
     # does not, the partition is wrong and any payment we attributed off it
     # would be wrong too.
     for name in ICOS_BUCKETS:
-        assessed = sum((amt for _, amt in buckets[name]), Decimal(0))
+        assessed = sum((entry[1] for entry in buckets[name]), Decimal(0))
         if abs(assessed - summary[name]['original']) > Decimal('0.01'):
             return None, None
 
@@ -265,18 +274,40 @@ def reconcile_financials(case):
         if not entries:
             continue
         paid = summary[name].get('paid') or Decimal(0)
-        amounts = [amt for _, amt in entries]
+
+        # The itemization's own Paid column is blank on most fees, but not on
+        # all of them: restitution in particular is paid down in instalments
+        # that ICOS lists line by line. Where those line payments account for
+        # everything the summary says was paid in this bucket, there is nothing
+        # to infer and no ambiguity to flag.
+        by_line = sum((entry[2] for entry in entries), Decimal(0))
+        if abs(by_line - paid) <= Decimal('0.01'):
+            for detail, amount, line_paid in entries:
+                owed = amount - line_paid
+                if owed <= 0:
+                    continue
+                column = get_finance_column(detail)
+                columns[column] = columns.get(column, Decimal(0)) + owed
+            continue
+
+        amounts = [entry[1] for entry in entries]
         settled = _unique_paid_subset(amounts, paid)
         if settled is None:
-            # Cannot say which line was paid. Report the bucket's balance in
-            # MISC rather than guessing a fee it might not belong to.
+            # Cannot say which line was paid. The balance still belongs to this
+            # bucket, though, so it goes to the column the bucket's lines share
+            # and only falls back to MISC when they disagree. Sending a
+            # restitution balance to MISC because a partial payment could not be
+            # split across instalments was losing the one distinction the
+            # spreadsheet most needs to keep.
             unresolved.append(name)
             due = summary[name].get('due')
             if due is None:
                 due = sum(amounts, Decimal(0)) - paid
-            columns['O'] = columns.get('O', Decimal(0)) + due
+            shared = {get_finance_column(entry[0]) for entry in entries}
+            column = shared.pop() if len(shared) == 1 else 'O'
+            columns[column] = columns.get(column, Decimal(0)) + due
             continue
-        for index, (detail, amount) in enumerate(entries):
+        for index, (detail, amount, _line_paid) in enumerate(entries):
             owed = Decimal(0) if index in settled else amount
             if owed == 0:
                 continue
@@ -287,7 +318,7 @@ def reconcile_financials(case):
     if unresolved:
         note = ("ICOS records payments per category, not per fee. The payment "
                 "in %s could not be tied to a specific line, so that balance "
-                "is reported under MISC."
+                "is reported as a category total rather than per fee."
                 % ", ".join(unresolved))
     return columns, note
 

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -251,3 +251,87 @@ def test_summary_bucket_classification(detail, bucket):
 ])
 def test_parse_money(text, expected):
     assert case_parser.parse_money(text) == expected
+
+
+def _five_buckets(**due):
+    """The five-bucket summary ICOS prints, with everything zero by default."""
+    rows = []
+    for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER'):
+        original, paid = due.get(label, (Decimal('0'), Decimal('0')))
+        rows.append({'label': label, 'original': original, 'paid': paid,
+                     'due': original - paid})
+    return rows
+
+
+def test_instalment_payments_are_credited_to_the_line_they_paid():
+    """Restitution is paid down in instalments and ICOS lists each one.
+
+    The instalments arrive as continuation rows: no detail, no amount, just a
+    payment against the line above. Those rows were being skipped, so a bucket
+    whose payments were sitting right there on the page looked unattributable,
+    and a restitution balance went to MISC. Found by running seventy real
+    captured cases through this function; it moved $3,227.97 of restitution
+    into MISC across thirty-six of them.
+    """
+    case = {
+        'total_due': '$1108.20',
+        'summary_categories': _five_buckets(
+            RESTITUTION=(Decimal('1200.00'), Decimal('91.80'))),
+        'financials': [
+            {'detail': 'RESTITUTIONS', 'amount': '1200.00', 'paid': '28.17'},
+            {'detail': None, 'amount': None, 'paid': '4.36'},
+            {'detail': None, 'amount': None, 'paid': '9.60'},
+            {'detail': None, 'amount': None, 'paid': '15.37'},
+            {'detail': None, 'amount': None, 'paid': '10.18'},
+            {'detail': None, 'amount': None, 'paid': '10.83'},
+            {'detail': None, 'amount': None, 'paid': '0.10'},
+            {'detail': None, 'amount': None, 'paid': '13.19'},
+        ],
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert note is None, 'the payments are on the page; nothing to flag'
+    assert columns == {'S': Decimal('1108.20')}
+
+
+def test_an_unattributable_payment_keeps_its_category():
+    """A bucket we cannot split by line is still a bucket we can name.
+
+    Two restitution lines and a payment that could have been either. Which fee
+    was paid is unknowable, but that the balance is restitution is not, and
+    restitution is the one distinction the spreadsheet cannot afford to lose:
+    it drives expungement and 910.7 eligibility, not just the debt total.
+    """
+    case = {
+        'total_due': '$75.00',
+        'summary_categories': _five_buckets(
+            RESTITUTION=(Decimal('100.00'), Decimal('25.00'))),
+        'financials': [
+            {'detail': 'RESTITUTIONS', 'amount': '50.00', 'paid': None},
+            {'detail': 'RESTITUTIONS', 'amount': '50.00', 'paid': None},
+        ],
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert columns == {'S': Decimal('75.00')}, 'not MISC'
+    assert note is not None and 'RESTITUTION' in note
+
+
+def test_an_unattributable_payment_across_different_fees_still_falls_to_misc():
+    """The old behaviour, kept for the case that actually warrants it.
+
+    When the lines in an unsplittable bucket map to different columns there is
+    no honest column to put the balance in, so MISC it is.
+    """
+    case = {
+        'total_due': '$25.00',
+        'summary_categories': _five_buckets(
+            OTHER=(Decimal('50.00'), Decimal('25.00'))),
+        'financials': [
+            {'detail': 'DELINQUENT REVOLVING FUND OBLIGATION',
+             'amount': '25.00', 'paid': None},
+            {'detail': 'IOWA DEPT OF REVENUE COLLECTIONS FEE',
+             'amount': '25.00', 'paid': None},
+        ],
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert columns == {'O': Decimal('25.00')}
+    assert note is not None


### PR DESCRIPTION
`reconcile_financials` had one real case behind it. There are seventy in the
capture from the live-fire run, and running all of them through it found two
problems that a single case cannot show.

### ICOS lists a payment plan as continuation rows

No detail, no amount, just a payment against the line above. The partition loop
skipped any row without an amount, so those payments were dropped. A restitution
balance being paid down in instalments then looked unattributable, even though
every instalment was on the page and summed exactly to what the bucket reported
as paid.

On one real case: RESTITUTION assessed 1200.00, paid 91.80. The itemization has a
single 1200.00 line, so the subset-sum found nothing, gave up, and sent 1108.20
to MISC. The eight payments underneath it add to 91.80 to the cent.

### An unattributable payment still has a category

When a payment genuinely cannot be tied to a line, the balance went to MISC.
Which fee was paid may be unknowable, but which bucket it came from is printed
on the page. The balance now goes to the column the bucket's lines share, and
falls back to MISC only when they disagree.

This matters most for restitution, which drives expungement and 910.7
eligibility rather than just the debt total. Burying it in MISC loses the one
distinction the spreadsheet cannot afford to lose.

### Measured across the seventy captured cases

Thirty-nine carry a balance, thirty-six of those reconcile.

| | before | after |
|---|---|---|
| restitution reported | $500.00 | **$3,727.97** (matches ICOS) |
| in named columns | $6,995.92 | $10,395.73 |
| in MISC / UNKNOWN | $6,620.57 | $3,220.76 |
| rows flagged ambiguous | 6 | 0 |
| cases tying to the ICOS total | 36 of 36 | 36 of 36 |

### Scope

The summary path is still the default and is untouched; it ties to the ICOS
total on all seventy cases. This only makes the alternative a fair comparison,
because as it stood reconciliation was quietly worse than the thing it was
offered against.

Three tests added. Two of them fail against the pre-fix code, verified by
swapping the old `crs.py` back in and re-running. Suite is 111 passed, 1 xfailed.