### PR TITLE
Stop the charge logic writing to the log and to its caller

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -25,40 +25,32 @@ charge_code_map = {
 
 
 def get_dominant_charge(charges):
+    """Pick the one disposition code that represents the whole case.
+
+    ICOS lists a disposition per count, so a plea deal shows up as a guilty
+    alongside several dismissals. The CRS has one column for it, and the
+    ranking in charge_code_map decides which count speaks for the case.
+
+    Returns a copy. The caller's charge keeps its list of dispositions, so
+    calling this twice on the same case gives the same answer both times.
+    """
     if len(charges) == 0:
         return None
-    iterator = 0
-    delisted = charges[0]
+    delisted = dict(charges[0])
     raw_charge = delisted['disposition']
-    print("raw_charge: "+str(raw_charge))
     charge_dict = {}
-    while iterator <= len(raw_charge)-1:
-        disposition = raw_charge[iterator].replace("DNU-", "")
+    for disposition in raw_charge:
+        disposition = disposition.replace("DNU-", "")
         if not disposition:
             charge_dict["NOTF"] = 0
-            #try a get function instead that defaults to 'OTH'
         elif disposition not in charge_code_map:
             charge_dict["OTH"] = 3
         else:
-            charge_pair = charge_code_map.get(disposition)
-            print("charge_code_map.get(disposition):"+str(charge_code_map.get(disposition)))
-            charge_key = str(charge_pair.keys())
-            charge_key = charge_key.replace("dict_keys(['","")
-            charge_key = charge_key.replace("'])","")
-            print(str(iterator)+": " + str(charge_key))
-            charge_dict[charge_key] = charge_pair.get(charge_key) 
-        print("charge_dict: "+str(charge_dict))
-        iterator += 1
-    #sorted_tuples = sorted(charge_dict.items(), reverse=True, key=lambda item: item[1])
-    sorted_tuples = sorted(charge_dict.items(), reverse=True, key=lambda item: item[1] if item[1] is not None else float('inf'))
-    print("sorted_tuples: " + str(sorted_tuples))
-    sorted_charge = sorted_tuples[0]
-    #sorted_charge = {k: v for k, v in sorted_tuples}
-    print("sorted_charge: " + str(sorted_charge))
-    #(dominant_charge, score) = sorted_charge.popitem()
-    dominant_charge = sorted_charge[0]
-    delisted['disposition'] = dominant_charge
-    print("dominant_charge:" + str(dominant_charge))
+            charge_key, rank = next(iter(charge_code_map[disposition].items()))
+            charge_dict[charge_key] = rank
+    sorted_tuples = sorted(charge_dict.items(), reverse=True,
+                           key=lambda item: item[1] if item[1] is not None else float('inf'))
+    delisted['disposition'] = sorted_tuples[0][0]
     return delisted
 
 

--- a/tests/test_charges.py
+++ b/tests/test_charges.py
@@ -1,0 +1,81 @@
+"""Which disposition speaks for the case: column G of the CRS.
+
+A plea deal reaches ICOS as several counts with different outcomes, one
+guilty and the rest dismissed. The CRS has a single column for it, so
+get_dominant_charge ranks them and picks one. That ranking had no tests on
+it at all, and it decides whether a case reads as a conviction.
+
+Sampled against seventy real cases in July 2026: eight of them carried more
+than one distinct disposition, and the shapes below are the ones that
+actually turned up. Identifiers here are synthetic; this repo is public.
+"""
+
+import io
+import os
+import sys
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+
+
+def _charge(*dispositions):
+    return [{'description': 'SYNTHETIC OFFENSE', 'disposition': list(dispositions),
+             'offense_date': '01/01/1900', 'disposition_date': '02/02/1901'}]
+
+
+def test_a_guilty_count_outranks_the_dismissed_ones():
+    """The shape of a plea deal. Pleading to one count dismisses the rest."""
+    charge = _charge('DISMISSED BY COURT', 'GUILTY - NEGOTIATED/VOLUN PLEA',
+                     'DISMISSED BY COURT')
+    assert crs.get_dominant_charge(charge)['disposition'] == 'GPL'
+
+
+def test_the_dnu_prefix_does_not_hide_a_conviction():
+    """ICOS prefixes some dispositions DNU-. It is not part of the outcome."""
+    assert crs.get_dominant_charge(
+        _charge('DNU-DISMISSED', 'DNU-GUILTY'))['disposition'] == 'GTR'
+
+
+def test_a_count_with_no_disposition_does_not_outrank_one_with_a_disposition():
+    """Seen on a real felony case: a blank alongside a dismissal and a guilty."""
+    assert crs.get_dominant_charge(
+        _charge('', 'DNU-DISMISSED', 'DNU-GUILTY'))['disposition'] == 'GTR'
+
+
+def test_a_disposition_icos_uses_that_we_do_not_map_reads_as_other():
+    """CHANGE OF VENUE is real and is not in the map. It must not crash."""
+    assert crs.get_dominant_charge(
+        _charge('CHANGE OF VENUE'))['disposition'] == 'OTH'
+
+
+def test_a_case_with_no_charges_is_not_a_criminal_case():
+    assert crs.get_dominant_charge([]) is None
+
+
+def test_the_answer_does_not_change_when_you_ask_twice():
+    """It used to overwrite the caller's disposition list with its own answer.
+
+    One pass through the workbook hid it. Anything that builds a CRS twice
+    from the same parsed cases got 'GTR' back the first time and 'OTH' the
+    second, because it then walked the string G, T, R as three dispositions.
+    """
+    charge = _charge('DISMISSED BY COURT', 'GUILTY - NEGOTIATED/VOLUN PLEA')
+    first = crs.get_dominant_charge(charge)['disposition']
+    second = crs.get_dominant_charge(charge)['disposition']
+    assert first == second == 'GPL'
+
+
+def test_the_charge_it_was_handed_comes_back_untouched():
+    charge = _charge('DNU-DISMISSED', 'DNU-GUILTY')
+    crs.get_dominant_charge(charge)
+    assert charge[0]['disposition'] == ['DNU-DISMISSED', 'DNU-GUILTY']
+
+
+def test_working_out_a_disposition_does_not_write_to_the_log():
+    """Six debug lines a case buried real failures in the Heroku log."""
+    noise = io.StringIO()
+    with redirect_stdout(noise):
+        crs.get_dominant_charge(_charge('DNU-DISMISSED', 'DNU-GUILTY'))
+    assert noise.getvalue() == ''


### PR DESCRIPTION
`get_dominant_charge` picks the one disposition that stands for the whole case, which is column G of the CRS. It had no test coverage at all.

**What was wrong**

Six `print()` calls per case went to stdout. The seventy-case run against live ICOS put 476 lines in the Heroku log, which is the same log a real failure has to be found in.

It also did `delisted['disposition'] = dominant_charge` on the caller's own charge dict, replacing a list of dispositions with a single code. Call it twice on the same case and the second call iterates the string `GTR` character by character, so a conviction comes back as `OTH`. Production only calls it once, so this was never live. It broke my own verification harness, which is how I found it.

**What did not change**

The ranking. Eight of the seventy real captured cases carry more than one distinct disposition, and the guilty count wins on all eight, before and after.

**Evidence**

- The three regression tests were run against the pre-fix `crs.py` and fail there: `assert 'GPL' == 'OTH'`, `assert 'GTR' == ['DNU-DISMISSED', 'DNU-GUILTY']`, and stdout not empty. The five behavioural tests pass on both sides.
- Workbook built from all seventy captured cases before and after, fresh parse each side: 15,693 populated cells, 0 differing.
- Suite: 119 passed, 1 xfailed.

**Not changed, flagged instead**

`get_primary_charge` has no callers anywhere in the repo. It also sets `charge['code']` to a string in two branches and to a dict in the third, so it would not work if anything did call it. Left alone rather than deleted.

An unmapped disposition scores 3, above a guilty at 1, so an unrecognised string outranks a conviction. One real case hit this (`CHANGE OF VENUE`, which is not an outcome at all) and `OTH` is arguably the right answer there. On a case mixing an unknown disposition with a guilty it would report `OTH` and hide the conviction. That is a call about what the CRS should say, not a bug to fix quietly, so the behaviour is unchanged and covered by a test that documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t