### PR TITLE
Refuse an ICOS problem-report page instead of filing it as a case

### DIFF
--- a/icos.py
+++ b/icos.py
@@ -36,11 +36,41 @@ CONCURRENT_MARKER = "Concurrent Login Error"
 
 # ESA does not always put the rejection message on a failed login -- a bad user
 # ID has come back as a bare ~700 byte page with no marker at all. Signed in,
-# ESA hands back the whole search screen (~28 KB); the concurrent-login error is
-# ~3.7 KB. So a small unmarked page means we are not signed in, and treating it
-# as success would leave the search retrying against a session that will never
-# work.
+# ESA hands back the whole search screen (~28 KB). Size is only a backstop for
+# unmarked pages: measured against live ESA in July 2026 the concurrent-login
+# error is about 685 bytes, the same band as a bad credential, so nothing can be
+# told apart by length alone. A small unmarked page means we are not signed in,
+# and treating it as success would leave the search retrying against a session
+# that will never work.
 MIN_SIGNED_IN_BYTES = 8000
+
+# ICOS answers a case request with HTTP 200 and a "Problem Report" page when it
+# cannot reach its own data source. The page keeps the heading of whichever case
+# was selected last, and lists no charges and no money, so it parses perfectly
+# well as a civil case with nothing owed. A criminal case quietly reported that
+# way is worse than one that fails outright, so a case page has to prove it is
+# the case that was asked for before it is accepted.
+PROBLEM_REPORT_MARKER = "There was a communication problem"
+
+
+def _text(body):
+    return body.decode("utf-8", "ignore") if isinstance(body, bytes) else body
+
+
+def _squashed(text):
+    """ICOS pads case numbers with runs of spaces that vary between pages."""
+    return "".join(text.split()).upper()
+
+
+def _is_live_case_page(body):
+    return PROBLEM_REPORT_MARKER not in _text(body)
+
+
+def _is_page_for_case(body, case_id):
+    page = _text(body)
+    if PROBLEM_REPORT_MARKER in page:
+        return False
+    return _squashed(case_id) in _squashed(page)
 
 
 def _env_seconds(name, default_minutes):
@@ -259,9 +289,13 @@ class IcosClient:
         The three pages must be fetched in this order: ICOS keys the charges and
         financials views off the case selected by the summary request.
         """
-        summary = self._retry("case", lambda: self.reader.case_summary_request(case_id))
-        charges = self._retry("case", self.reader.case_charges_request)
-        financials = self._retry("case", self.reader.case_financials_request)
+        summary = self._retry(
+            "case", lambda: self.reader.case_summary_request(case_id),
+            validate=lambda body: _is_page_for_case(body, case_id))
+        charges = self._retry("case", self.reader.case_charges_request,
+                              validate=_is_live_case_page)
+        financials = self._retry("case", self.reader.case_financials_request,
+                                 validate=_is_live_case_page)
         return summary, charges, financials
 
     def logoff(self):

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -16,6 +16,18 @@ CONCURRENT_PAGE = b"<html>Concurrent Login Error: A user is already logged on</h
 BAD_CREDS_PAGE = b"<html>The userID or password could not be validated</html>"
 RESULTS_PAGE = b"<html><table>results</table></html>"
 
+CASE_ID = "01311  FECR000000"
+CASE_PAGE = (b"<html>Trial Court Case Summary Title:&nbsp;STATE VS TESTER, PAT Q "
+             b"Case: 01311  FECR000000 (SYNTHETIC) Disposition Status</html>")
+
+# The shape of the real thing, with the wording that identifies it. ICOS serves
+# this with HTTP 200, under the heading of whatever case was selected last.
+PROBLEM_REPORT_PAGE = (
+    b"<html>Trial Court Case Summary Title:&nbsp;STATE VS TESTER, SAM "
+    b"Case: 01311  FECR111111 (SYNTHETIC) Problem Report: There was a "
+    b"communication problem. Possible Cause: The Web server may be too busy. "
+    b"No Disposition records were found.</html>")
+
 
 class FakeReader:
     """Replays a scripted sequence of outcomes and records what was asked for."""
@@ -173,9 +185,52 @@ def test_concurrent_login_gives_up_after_the_lock_window():
 
 
 def test_case_pages_are_fetched_in_icos_order():
-    client, _, _ = build([])
-    client.case_bundle("01311 FECR000000")
+    client, _, _ = build([FetchResult(OK, CASE_PAGE)] * 3)
+    client.case_bundle(CASE_ID)
     assert client.reader.calls == ["TViewCaseCivil", "TViewCharges", "TViewFinancials"]
+
+
+def test_a_problem_report_page_is_never_taken_for_a_case():
+    """ICOS returns this with HTTP 200 when its data source is unreachable.
+
+    Seen live in July 2026. The page carries the heading of whichever case was
+    selected last and lists no charges and no money, so it parses cleanly as a
+    civil case with nothing owed. Accepting it puts a wrong row in the CRS,
+    which is worse than the case failing, so it is retried like any other bad
+    response and eventually surfaces as an outage.
+    """
+    client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 200,
+                         budget_seconds=120)
+    with pytest.raises(IcosUnavailable):
+        client.case_bundle(CASE_ID)
+
+
+def test_a_problem_report_that_clears_is_just_a_retry():
+    client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE),
+                          FetchResult(OK, CASE_PAGE),       # summary, second go
+                          FetchResult(OK, CASE_PAGE),       # charges
+                          FetchResult(OK, CASE_PAGE)])      # financials
+    summary, charges, financials = client.case_bundle(CASE_ID)
+    assert summary == CASE_PAGE
+
+
+def test_the_page_for_a_different_case_is_rejected():
+    """ICOS keys the case views off the last selection, so the wrong case can
+    come back looking entirely healthy. Reporting one case's charges under
+    another case's number is the quietest way to get a CRS wrong."""
+    other = CASE_PAGE.replace(b"FECR000000", b"FECR999999")
+    client, _, _ = build([FetchResult(OK, other)] * 200, budget_seconds=120)
+    with pytest.raises(IcosUnavailable):
+        client.case_bundle(CASE_ID)
+
+
+def test_icos_spacing_of_a_case_number_does_not_matter():
+    """The search lists '01311  FECR000000'; the case page spaces it its own
+    way. Napier must not treat that as the wrong case."""
+    respaced = CASE_PAGE.replace(b"01311  FECR000000", b"01311\r\n\tFECR000000")
+    client, _, _ = build([FetchResult(OK, respaced)] * 3)
+    summary, _, _ = client.case_bundle(CASE_ID)
+    assert summary == respaced
 
 
 def test_logoff_is_silent_when_never_logged_in():


### PR DESCRIPTION
## What happens

ICOS answers a case request with HTTP 200 and a **Problem Report** page when it cannot reach its own data source. The visible text is "There was a communication problem. Possible Cause: The Web server may be too busy... The Web server may be unable to contact the data source server."

The page keeps the heading of whichever case was selected last, lists no charges, and lists no money.

Every parser in the repo accepts it without complaint. `get_dominant_charge` sees no charges and returns `None`, so `process_case` writes the case into the CRS as "other civil" with a zero balance. A criminal case reported that way understates both the record and the debt, in the direction that matters for expungement and 910.7 eligibility, and nothing tells anyone it happened.

## How it turned up

Widening the real-page sample past Polk County, which was 62 of the 70 cases behind every claim in this repo. Forty-five case requests came back as byte-identical 3404-byte pages, and all forty-five parsed clean and produced a civil case with nothing owed.

## The check

A real case page always echoes the case number it was asked for. Measured across 135 pages pulled from live ICOS:

| sample | pages | echo their own case number |
|---|---|---|
| original capture | 70 | 70 |
| fresh single-search pull | 20 | 20 |
| problem reports | 45 | 0 |

So the summary must prove it is the case that was requested, and all three pages must be free of the problem-report wording. Both run through the existing `validate` hook in `_retry`, so a busy server is retried on the normal backoff and only becomes an outage if it never clears.

ICOS pads case numbers with runs of spaces that differ between the search results and the case page, so the comparison ignores whitespace. There is a test for that, and it passes before and after, which is what shows the check is not simply rejecting everything.

## Deliberate consequence

`case_bundle` sits outside the per-case `try` in `tasks.py`, so a problem report that never clears now ends the run with the existing "try again later" message instead of producing a workbook. The page says the web server cannot reach its data source, which is a site-wide condition rather than a property of one case, and a run that stops is better than a CRS that is quietly wrong. Worth a second opinion if you disagree.

## Evidence

- Three of the four new tests fail against the pre-fix `icos.py` (`DID NOT RAISE IcosUnavailable` twice, and the retry case returning the problem report as if it were the case). The whitespace test passes on both sides by design.
- The fix accepts 90 of 90 real case pages and rejects 45 of 45 problem reports.
- Suite: 123 passed, 1 xfailed.

## Also in here

The comment describing the concurrent-login page as ~3.7 KB was stale. It is about 685 bytes, the same band as a bad credential, so length distinguishes them no better than a coin toss. That figure sent me looking for a bug in the login classifier that did not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t