### PR TITLE
Keep one unreachable case from ending the whole run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ search_results.html
 CRS 2.3.2_test.xlsx
 
 /example_data/
+# Local Claude Code tooling config, not part of the app.
+.claude/

--- a/alerts.py
+++ b/alerts.py
@@ -47,6 +47,7 @@ CONCURRENT_EXHAUSTED = 'ESA account stayed locked'
 SLOW_RECOVERY = 'ICOS needed repeated retries'
 BAD_RESPONSE = 'unusable response from ICOS'
 PARSE_FAILURE = 'case could not be read'
+CASE_UNAVAILABLE = 'case could not be retrieved from ICOS'
 JOB_FAILED = 'job failed'
 UNHANDLED = 'unhandled exception'
 
@@ -116,12 +117,21 @@ def safe_traceback(exc):
 
 def _format(job_id, kind, failure, fields, progress):
     lines = ['%s job %s' % (kind, job_id), '']
-    for label in ('classification', 'endpoint', 'attempts', 'elapsed',
-                  'backoff', 'status', 'response size', 'account', 'case'):
+    ordered = ('classification', 'endpoint', 'attempts', 'elapsed',
+               'backoff', 'status', 'response size', 'account', 'case')
+    for label in ordered:
         value = fields.get(label)
         if value is not None:
             lines.append('%-14s %s' % (label + ':', value))
     lines.insert(2, '%-14s %s' % ('failure:', failure))
+
+    # A field this function has not been taught about still belongs in the
+    # email. Dropping it silently is how a caller ends up sending alerts that
+    # are quietly missing the one detail they added them for.
+    for label in sorted(fields):
+        if label in ordered or label in ('note', 'traceback'):
+            continue
+        lines.append('%-14s %s' % (label + ':', fields[label]))
 
     note = fields.get('note')
     if note:

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify, render_template, request, send_file, session, url_for, redirect
+import atexit
 import os
 import platform
 import time
@@ -123,6 +124,11 @@ def _start_background_threads():
     print("KEEPALIVE started (every %ss)" % KEEPALIVE_SECS, flush=True)
     icos_sessions.start_reaper()
     jobs.start_janitor()
+    # Heroku deploys and its daily dyno cycle both kill this process. Whatever
+    # the store is holding has to be handed back to ICOS on the way out, or the
+    # shared account stays locked for staff who did nothing but show up. On
+    # SIGTERM gunicorn exits its workers cleanly, so atexit still runs.
+    atexit.register(icos_sessions.close_all)
 
 # Guarded so tests (and anything importing the app for inspection) don't start
 # pinging the live court site.

--- a/icos.py
+++ b/icos.py
@@ -244,8 +244,13 @@ class IcosClient:
         started = self._monotonic()
         waited_for_lock = False
         while True:
+            # Without the validator a problem report lands on the size check
+            # below, because it is well under MIN_SIGNED_IN_BYTES, and staff
+            # are told their user ID or password is wrong while the court site
+            # is down. They then retype credentials that were always correct.
             body = self._retry("search",
-                               lambda: self.reader.login_request(username, password))
+                               lambda: self.reader.login_request(username, password),
+                               validate=_is_not_a_problem_report)
             text = body.decode("utf-8", errors="ignore")
 
             if BAD_CREDS_MARKER in text:

--- a/icos.py
+++ b/icos.py
@@ -62,7 +62,7 @@ def _squashed(text):
     return "".join(text.split()).upper()
 
 
-def _is_live_case_page(body):
+def _is_not_a_problem_report(body):
     return PROBLEM_REPORT_MARKER not in _text(body)
 
 
@@ -293,9 +293,14 @@ class IcosClient:
 
     def search(self, firstname, middlename, lastname):
         self._log("Searching Iowa Courts Online...")
+        # A problem report here parses as a search that matched nobody, and
+        # "this person has no Iowa record" is the answer a CRS exists to give.
+        # Getting that wrong is worse than getting a case wrong, so the search
+        # has to prove it is a real result page before anyone believes it.
         return self._retry(
             "search",
-            lambda: self.reader.search_request(firstname, middlename, lastname))
+            lambda: self.reader.search_request(firstname, middlename, lastname),
+            validate=_is_not_a_problem_report)
 
     def case_bundle(self, case_id):
         """Summary, charges and financials for one case.
@@ -307,9 +312,9 @@ class IcosClient:
             "case", lambda: self.reader.case_summary_request(case_id),
             validate=lambda body: _is_page_for_case(body, case_id))
         charges = self._retry("case", self.reader.case_charges_request,
-                              validate=_is_live_case_page)
+                              validate=_is_not_a_problem_report)
         financials = self._retry("case", self.reader.case_financials_request,
-                                 validate=_is_live_case_page)
+                                 validate=_is_not_a_problem_report)
         return summary, charges, financials
 
     def logoff(self):

--- a/icos.py
+++ b/icos.py
@@ -120,7 +120,7 @@ class IcosUnavailable(IcosError):
 class IcosClient:
     def __init__(self, log=None, reader=None, budget_seconds=None,
                  concurrent_budget_seconds=None, sleep=time.sleep,
-                 monotonic=time.monotonic, alert=None):
+                 monotonic=time.monotonic, alert=None, case_budget_seconds=None):
         self.reader = reader if reader is not None else Reader(Opener())
         self._log = log or (lambda message: None)
         # Alerting is a callback rather than an import so this module stays
@@ -131,6 +131,13 @@ class IcosClient:
         self._monotonic = monotonic
         self.budget = budget_seconds if budget_seconds is not None \
             else _env_seconds("RETRY_BUDGET_MIN", 45)
+        # A stalled search is the whole job, so it is worth waiting out. A
+        # stalled case is one row among twenty with staff watching a progress
+        # bar, and the run can finish without it. Waiting the full search
+        # budget on one case holds the other nineteen hostage for no gain, so
+        # a case gets a much shorter one and is dropped if it does not clear.
+        self.case_budget = case_budget_seconds if case_budget_seconds is not None \
+            else _env_seconds("CASE_RETRY_BUDGET_MIN", 4)
         self.concurrent_budget = concurrent_budget_seconds \
             if concurrent_budget_seconds is not None \
             else _env_seconds("CONCURRENT_WAIT_MIN", 16)
@@ -166,6 +173,7 @@ class IcosClient:
         treat the response as a retryable failure.
         """
         started = self._monotonic()
+        budget = self.budget if what == "search" else self.case_budget
         attempt = 0
         last = "no response"
         waits = []
@@ -201,16 +209,22 @@ class IcosClient:
 
             elapsed = self._monotonic() - started
             wait = backoff_for(attempt)
-            if elapsed + wait > self.budget:
+            if elapsed + wait > budget:
                 self._alert(alerts.RETRY_EXHAUSTED, endpoint=endpoint,
                             attempts=attempt + 1, elapsed=_describe(elapsed),
                             backoff=_timeline(waits),
                             note="Last result: %s. Staff were told to try again "
                                  "later." % last)
+                if what == "search":
+                    raise IcosUnavailable(
+                        "Iowa Courts Online did not respond after %d minutes of "
+                        "retrying (last result: %s). The court site is likely down. "
+                        "Please try again later." % (round(budget / 60), last))
+                # The caller drops this one case and carries on, so this text
+                # is not staff-facing advice about the whole run.
                 raise IcosUnavailable(
-                    "Iowa Courts Online did not respond after %d minutes of retrying "
-                    "(last result: %s). The court site is likely down. Please try "
-                    "again later." % (round(self.budget / 60), last))
+                    "Iowa Courts Online did not return this case after %d minutes of "
+                    "retrying (last result: %s)." % (round(budget / 60), last))
             self._log(self._attempt_message(what, attempt, elapsed))
             waits.append(wait)
             self._sleep(wait)

--- a/icos.py
+++ b/icos.py
@@ -316,10 +316,18 @@ class IcosClient:
         summary = self._retry(
             "case", lambda: self.reader.case_summary_request(case_id),
             validate=lambda body: _is_page_for_case(body, case_id))
-        charges = self._retry("case", self.reader.case_charges_request,
-                              validate=_is_not_a_problem_report)
-        financials = self._retry("case", self.reader.case_financials_request,
-                                 validate=_is_not_a_problem_report)
+        # These two get the same proof of identity as the summary rather than
+        # just the problem report check. When ICOS degrades partway through a
+        # case it answers with a stub that carries no problem report wording,
+        # wears the heading of some other case, and lists nothing. It looks
+        # exactly like a case that genuinely has no charges and no court debt,
+        # and on a criminal record those two mean opposite things.
+        charges = self._retry(
+            "case", self.reader.case_charges_request,
+            validate=lambda body: _is_page_for_case(body, case_id))
+        financials = self._retry(
+            "case", self.reader.case_financials_request,
+            validate=lambda body: _is_page_for_case(body, case_id))
         return summary, charges, financials
 
     def logoff(self):

--- a/icos_sessions.py
+++ b/icos_sessions.py
@@ -66,6 +66,26 @@ def close(token):
         entry["client"].logoff()
 
 
+def close_all():
+    """Log off everything on the way down.
+
+    The store is in memory, so a dyno restart forgets it. ICOS does not: it
+    goes on holding the session, and the shared account stays locked for about
+    fifteen minutes while staff who never deployed anything are told someone
+    else is signed in. One session that will not close must not strand the
+    others, so each is tried on its own.
+    """
+    with _lock:
+        clients = [entry["client"] for entry in _sessions.values()]
+        _sessions.clear()
+    for client in clients:
+        try:
+            client.logoff()
+        except Exception:
+            pass
+    return len(clients)
+
+
 def _reap(now=None):
     now = now if now is not None else time.time()
     with _lock:

--- a/icos_sessions.py
+++ b/icos_sessions.py
@@ -41,6 +41,23 @@ def get(token):
         return entry["client"]
 
 
+def claim(token):
+    """Take a session out of the store for a job that will hold it a while.
+
+    The reaper works off last_used, which a CRS run never refreshes: it fetches
+    the client once and then spends minutes talking to ICOS. Left in the store,
+    a run longer than IDLE_TIMEOUT has its own live session logged off
+    underneath it from the reaper thread, and a staffer hitting logout mid-run
+    does the same. A claimed session is nobody else's to close, so the job owns
+    it and logs it off itself.
+    """
+    if not token:
+        return None
+    with _lock:
+        entry = _sessions.pop(token, None)
+    return entry["client"] if entry is not None else None
+
+
 def close(token):
     """Log off and forget a session. Safe to call with an unknown token."""
     with _lock:

--- a/tasks.py
+++ b/tasks.py
@@ -75,7 +75,13 @@ def search_task(job, username, password, firstname, middlename, lastname):
 def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
     client = icos_sessions.claim(session_token)
     if client is None:
-        raise LookupError("session expired")
+        # Two ordinary things land here. Staff left the results page open past
+        # the idle timeout and the reaper logged the session off, or a second
+        # submit arrived while the first was already running and claimed it.
+        # Neither is a bug, so neither should reach staff as "something went
+        # wrong inside Napier" or reach an inbox as an alert.
+        raise IcosError("That search is no longer signed in to Iowa Courts "
+                        "Online. Please run the search again.")
     client.set_alert(alerts.emitter(job))
 
     try:

--- a/tasks.py
+++ b/tasks.py
@@ -16,7 +16,12 @@ import alerts
 import case_parser
 import crs
 import icos_sessions
-from icos import IcosClient
+from icos import IcosClient, IcosError
+
+# One case ICOS will not hand over is a bad case. Several in a row is the site
+# being down, and there is no point walking the rest of the list to find that
+# out one four-minute budget at a time.
+CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 3
 
 tmp_dir = '/tmp/'
 if platform.system() == 'Windows':
@@ -68,7 +73,7 @@ def search_task(job, username, password, firstname, middlename, lastname):
 
 
 def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
-    client = icos_sessions.get(session_token)
+    client = icos_sessions.claim(session_token)
     if client is None:
         raise LookupError("session expired")
     client.set_alert(alerts.emitter(job))
@@ -80,10 +85,30 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
 
         cases = []
         failed = []
+        failures_in_a_row = 0
+        not_attempted = []
         for index, case_id in enumerate(case_ids, start=1):
             job.log("Pulling case %d of %d (%s)..." % (index, len(case_ids), case_id))
-            summary, charges, financials = client.case_bundle(case_id)
             case = {'id': case_id}
+            try:
+                summary, charges, financials = client.case_bundle(case_id)
+            except IcosError as e:
+                # ICOS never gave up this case inside its retry budget. That
+                # costs one row, not the run: the other cases are still worth
+                # pulling and the workbook still gets built without this one.
+                print("Case %s could not be retrieved: %r" % (case_id, e), flush=True)
+                alerts.record(job.id[:8], job.kind, alerts.CASE_UNAVAILABLE,
+                              progress=alerts.recent_progress(job),
+                              case=case_id,
+                              note="%s The run carried on without it."
+                                   % e.message)
+                failed.append(case_id)
+                failures_in_a_row += 1
+                if failures_in_a_row >= CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
+                    not_attempted = case_ids[index:]
+                    break
+                continue
+            failures_in_a_row = 0
             try:
                 case_parser.parse_case_summary(summary, case)
                 case_parser.parse_case_charges(charges, case)
@@ -102,6 +127,12 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
                 failed.append(case_id)
                 continue
             cases.append(case)
+
+        if not_attempted:
+            failed.extend(not_attempted)
+            job.log("Iowa Courts stopped responding, so the last %d case%s could not "
+                    "be pulled. The workbook has the rest."
+                    % (len(not_attempted), "" if len(not_attempted) == 1 else "s"))
 
         if not cases:
             raise ValueError("no cases could be read")
@@ -123,7 +154,8 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
                     % (len(cases), "" if len(cases) == 1 else "s"))
         return "/job/%s/download" % job.id
     finally:
-        icos_sessions.close(session_token)
+        # The session was claimed, so nothing else will release it.
+        client.logoff()
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -120,6 +120,17 @@ def test_an_alert_actually_leaves_the_process(mailbox):
     assert 'job1234' in mailbox[0]['text']
 
 
+def test_a_field_the_formatter_has_not_been_taught_still_reaches_the_email(mailbox):
+    """The body rendered a fixed list of labels and dropped everything else, so
+    a caller could add a detail, watch it appear in the end-of-job digest, and
+    never notice it was missing from the alert itself."""
+    send(alerts.record('job1234', 'search', alerts.RETRY_EXHAUSTED,
+                       endpoint='TrialCaseSearchResultServlet',
+                       county='DUBUQUE'))
+    assert 'county' in mailbox[0]['text']
+    assert 'DUBUQUE' in mailbox[0]['text']
+
+
 def test_it_authenticates_the_way_mailgun_expects(mailbox):
     send(alerts.record('job1234', 'search', alerts.JOB_FAILED))
     scheme, _, token = mailbox[0]['auth'].partition(' ')
@@ -445,6 +456,48 @@ def test_a_bug_in_a_request_path_emails_somebody(mailbox):
 # -- a case that will not parse -------------------------------------------
 
 
+def test_a_case_icos_will_not_return_alerts_with_the_case_and_not_the_person(
+        mailbox, monkeypatch):
+    """Same privacy rule as a parse failure: the case number goes in because it
+    is public record and nobody can chase the problem without it, the client
+    does not because they are privileged."""
+    import icos_sessions
+    from icos import IcosUnavailable
+
+    class Stub:
+        logged_in = True
+
+        def set_alert(self, alert):
+            self.alert = alert
+
+        def case_bundle(self, case_id):
+            raise IcosUnavailable("Iowa Courts Online did not return this case "
+                                  "after 4 minutes of retrying "
+                                  "(last result: timeout).")
+
+        def logoff(self):
+            pass
+
+    monkeypatch.setattr(icos_sessions, 'claim', lambda token: Stub())
+
+    job = FakeJob('crs')
+    with pytest.raises(ValueError):        # nothing came back, so no workbook
+        tasks.crs_task(job, 'tok', ['1900-01-01 TESTER, PAT Q'],
+                       {'1900-01-01 TESTER, PAT Q': ['01311 FECR000000']},
+                       'TESTER, PAT Q', '01/01/1900', False)
+    settle()
+
+    by_subject = {m['subject']: m for m in mailbox}
+    failure = [m for s, m in by_subject.items() if alerts.CASE_UNAVAILABLE in s]
+    assert len(failure) == 1
+    assert '01311 FECR000000' in failure[0]['text']
+    assert '4 minutes of retrying' in failure[0]['text']
+    assert 'carried on without it' in failure[0]['text']
+    for message in mailbox:
+        assert 'TESTER' not in message['text']
+        assert '01/01/1900' not in message['text']
+
+
 def test_a_case_that_will_not_parse_alerts_with_the_case_and_not_the_person(
         mailbox, monkeypatch):
     import case_parser
@@ -467,8 +520,7 @@ def test_a_case_that_will_not_parse_alerts_with_the_case_and_not_the_person(
         row = 'TESTER, PAT Q 01/01/1900'
         raise ValueError('unreadable charge row: %s' % row)
 
-    monkeypatch.setattr(icos_sessions, 'get', lambda token: Stub())
-    monkeypatch.setattr(icos_sessions, 'close', lambda token: None)
+    monkeypatch.setattr(icos_sessions, 'claim', lambda token: Stub())
     monkeypatch.setattr(case_parser, 'parse_case_summary', explode)
 
     job = FakeJob('crs')

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -1,0 +1,136 @@
+"""A case ICOS will not hand over must cost one row, not the whole run.
+
+Napier pulls each case as three pages, and a page that never comes back raises
+out of case_bundle. That call used to sit outside the per-case guard, so one
+sick case ended the run and staff got no workbook at all. Refusing problem
+report pages made that reachable: before, such a page came back instantly and
+quietly became a wrong row.
+
+Several cases failing in a row is a different thing. That is the site being
+down, and walking the rest of the list to discover it one retry budget at a
+time helps nobody, so the run stops and builds the CRS from what it has.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import icos_sessions
+import tasks
+from icos import IcosUnavailable
+
+KEY = '1900-01-01 TESTER, PAT Q'
+
+
+def ids(count):
+    return ['01311 FECR00000%d' % n for n in range(1, count + 1)]
+
+
+class FakeJob:
+    def __init__(self):
+        self.id = 'abcdef0123456789'
+        self.kind = 'crs'
+        self.progress = []
+        self.result = None
+
+    def log(self, message):
+        self.progress.append({'message': message})
+
+
+class StubClient:
+    """Serves case pages, failing whichever case ids it was told to fail."""
+
+    logged_in = True
+
+    def __init__(self, unavailable):
+        self.unavailable = set(unavailable)
+        self.asked = []
+
+    def set_alert(self, alert):
+        pass
+
+    def case_bundle(self, case_id):
+        self.asked.append(case_id)
+        if case_id in self.unavailable:
+            raise IcosUnavailable("Iowa Courts Online did not return this case "
+                                  "after 4 minutes of retrying")
+        return b'<summary>', b'<charges>', b'<financials>'
+
+    def logoff(self):
+        pass
+
+
+def run(monkeypatch, case_ids, unavailable=()):
+    """Drive crs_task directly; parsing and workbook building are stubbed."""
+    stub = StubClient(unavailable)
+    monkeypatch.setattr(icos_sessions, 'claim', lambda token: stub)
+    # Alerting has its own tests, and none of these should try to send mail.
+    monkeypatch.setattr(tasks.alerts, 'record', lambda *a, **k: None)
+    monkeypatch.setattr(tasks.alerts, 'digest', lambda *a, **k: None)
+    monkeypatch.setattr(case_parser, 'parse_case_summary',
+                        lambda body, case: case.update(county='DUBUQUE'))
+    monkeypatch.setattr(case_parser, 'parse_case_charges',
+                        lambda body, case: case.update(charges=[]))
+    monkeypatch.setattr(case_parser, 'parse_case_financials',
+                        lambda body, case: case.update(financials=[],
+                                                       total_due='$0.00'))
+    written = []
+
+    def fake_build(cases, name, dob, lite):
+        written.extend(case['id'] for case in cases)
+        return os.path.join(tasks.tmp_dir, 'stub.xlsx')
+
+    monkeypatch.setattr(tasks, 'build_workbook', fake_build)
+
+    job = FakeJob()
+    tasks.crs_task(job, 'tok', [KEY], {KEY: list(case_ids)},
+                   'TESTER, PAT Q', '01/01/1900', False)
+    return job, stub, written
+
+
+def test_a_case_icos_will_not_give_up_costs_one_row_not_the_run(monkeypatch):
+    case_ids = ids(3)
+    job, stub, written = run(monkeypatch, case_ids, unavailable=[case_ids[1]])
+
+    assert written == [case_ids[0], case_ids[2]]
+    assert job.result['failed_cases'] == [case_ids[1]]
+    # The run carried on past the bad one rather than dying on it.
+    assert stub.asked == case_ids
+
+
+def test_the_failed_case_is_named_for_staff(monkeypatch):
+    case_ids = ids(3)
+    job, _, _ = run(monkeypatch, case_ids, unavailable=[case_ids[1]])
+    assert any(case_ids[1] in line['message'] for line in job.progress)
+
+
+def test_failures_that_are_not_consecutive_are_not_an_outage(monkeypatch):
+    """Three bad cases scattered through a list is three bad cases. Only a run
+    of them back to back means the site itself has gone."""
+    case_ids = ids(7)
+    bad = [case_ids[0], case_ids[2], case_ids[4]]
+    _, stub, written = run(monkeypatch, case_ids, unavailable=bad)
+
+    assert stub.asked == case_ids
+    assert written == [case_ids[1], case_ids[3], case_ids[5], case_ids[6]]
+
+
+def test_icos_going_down_mid_run_still_yields_the_cases_already_pulled(monkeypatch):
+    case_ids = ids(8)
+    job, stub, written = run(monkeypatch, case_ids, unavailable=case_ids[2:])
+
+    assert written == case_ids[:2]          # the two that came back
+    assert stub.asked == case_ids[:5]       # stopped after three in a row
+    assert job.result['failed_cases'] == case_ids[2:]   # none quietly dropped
+    assert any('stopped responding' in line['message'] for line in job.progress)
+
+
+def test_a_run_where_no_case_comes_back_still_fails(monkeypatch):
+    """A partial workbook beats an error page, but an empty one does not."""
+    case_ids = ids(4)
+    with pytest.raises(ValueError):
+        run(monkeypatch, case_ids, unavailable=case_ids)

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import case_parser
 import icos_sessions
 import tasks
-from icos import IcosUnavailable
+from icos import IcosError, IcosUnavailable
 
 KEY = '1900-01-01 TESTER, PAT Q'
 
@@ -134,3 +134,16 @@ def test_a_run_where_no_case_comes_back_still_fails(monkeypatch):
     case_ids = ids(4)
     with pytest.raises(ValueError):
         run(monkeypatch, case_ids, unavailable=case_ids)
+
+
+def test_a_session_that_is_already_gone_is_not_reported_as_a_bug(monkeypatch):
+    """The reaper closing an idle session, or a second submit claiming it
+    first, is ordinary. jobs.py shows staff the generic apology and sends an
+    alert for anything without a .message, so this must carry one."""
+    monkeypatch.setattr(icos_sessions, 'claim', lambda token: None)
+
+    with pytest.raises(IcosError) as caught:
+        tasks.crs_task(FakeJob(), 'tok', [KEY], {KEY: ids(1)},
+                       'TESTER, PAT Q', '01/01/1900', False)
+
+    assert 'run the search again' in caught.value.message

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -206,6 +206,16 @@ def test_a_problem_report_page_is_never_taken_for_a_case():
         client.case_bundle(CASE_ID)
 
 
+def test_a_problem_report_at_login_is_not_a_bad_password():
+    """It is 3404 bytes, well under MIN_SIGNED_IN_BYTES, so without a check of
+    its own it lands on the size fallback and staff are told to check
+    credentials that were never wrong."""
+    client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 200,
+                         budget_seconds=120)
+    with pytest.raises(IcosUnavailable):
+        client.login("ILA00", "password")
+
+
 def test_a_problem_report_on_a_search_is_not_an_empty_record():
     """The same page can come back for a search, where it has no rows and so
     parses as a search that matched nobody. "No Iowa record" is the answer a

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -87,7 +87,8 @@ def build(script, **kwargs):
                         sleep=clock.sleep, monotonic=clock.monotonic,
                         budget_seconds=kwargs.pop('budget_seconds', 45 * 60),
                         concurrent_budget_seconds=kwargs.pop('concurrent_budget_seconds',
-                                                             16 * 60))
+                                                             16 * 60),
+                        case_budget_seconds=kwargs.pop('case_budget_seconds', 4 * 60))
     return client, clock, messages
 
 
@@ -200,7 +201,7 @@ def test_a_problem_report_page_is_never_taken_for_a_case():
     response and eventually surfaces as an outage.
     """
     client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 200,
-                         budget_seconds=120)
+                         case_budget_seconds=120)
     with pytest.raises(IcosUnavailable):
         client.case_bundle(CASE_ID)
 
@@ -219,9 +220,33 @@ def test_the_page_for_a_different_case_is_rejected():
     come back looking entirely healthy. Reporting one case's charges under
     another case's number is the quietest way to get a CRS wrong."""
     other = CASE_PAGE.replace(b"FECR000000", b"FECR999999")
-    client, _, _ = build([FetchResult(OK, other)] * 200, budget_seconds=120)
+    client, _, _ = build([FetchResult(OK, other)] * 200, case_budget_seconds=120)
     with pytest.raises(IcosUnavailable):
         client.case_bundle(CASE_ID)
+
+
+def test_a_stuck_case_gives_up_long_before_a_stuck_search():
+    """A search is the whole job and worth waiting out. A case is one row of
+    many, with staff watching a progress bar and the rest of the list still to
+    pull, so the same dead script must cost far less time."""
+    case_client, case_clock, _ = build([FetchResult(TIMEOUT)] * 500)
+    with pytest.raises(IcosUnavailable):
+        case_client.case_bundle(CASE_ID)
+
+    search_client, search_clock, _ = build([FetchResult(TIMEOUT)] * 500)
+    with pytest.raises(IcosUnavailable):
+        search_client.search("PAT", "", "TESTER")
+
+    assert case_clock.now < search_clock.now / 5
+    assert case_clock.now <= 4 * 60
+
+
+def test_a_search_keeps_its_own_budget():
+    """The case budget must not have quietly shortened the search too."""
+    client, clock, _ = build([FetchResult(TIMEOUT)] * 500, budget_seconds=30 * 60)
+    with pytest.raises(IcosUnavailable):
+        client.search("PAT", "", "TESTER")
+    assert clock.now > 20 * 60
 
 
 def test_icos_spacing_of_a_case_number_does_not_matter():

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -206,6 +206,23 @@ def test_a_problem_report_page_is_never_taken_for_a_case():
         client.case_bundle(CASE_ID)
 
 
+def test_a_problem_report_on_a_search_is_not_an_empty_record():
+    """The same page can come back for a search, where it has no rows and so
+    parses as a search that matched nobody. "No Iowa record" is the answer a
+    CRS is built to give, and staff have no way to tell a real one from this,
+    so it must fail loudly instead of quietly clearing somebody."""
+    client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 200,
+                         budget_seconds=120)
+    with pytest.raises(IcosUnavailable):
+        client.search("PAT", "", "TESTER")
+
+
+def test_a_search_problem_report_that_clears_is_just_a_retry():
+    client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE),
+                          FetchResult(OK, RESULTS_PAGE)])
+    assert client.search("PAT", "", "TESTER") == RESULTS_PAGE
+
+
 def test_a_problem_report_that_clears_is_just_a_retry():
     client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE),
                           FetchResult(OK, CASE_PAGE),       # summary, second go

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -28,6 +28,16 @@ PROBLEM_REPORT_PAGE = (
     b"communication problem. Possible Cause: The Web server may be too busy. "
     b"No Disposition records were found.</html>")
 
+# What ICOS actually served for charges and financials on 45 of 45 cases in the
+# July capture when it was degrading. It carries no problem report wording at
+# all, so the marker check waves it through. It wears the heading of whatever
+# case was selected last, it never echoes the case that was asked for, and it
+# lists nothing. Accepting it writes the case down with no charges, which
+# reports a conviction as a non-conviction.
+STUB_CASE_PAGE = (
+    b"<html>Trial Court Case Summary Title:&nbsp;STATE VS TESTER, SAM "
+    b"Case: 01311  FECR111111 (SYNTHETIC) Charges Financial Summary</html>")
+
 
 class FakeReader:
     """Replays a scripted sequence of outcomes and records what was asked for."""
@@ -250,6 +260,38 @@ def test_the_page_for_a_different_case_is_rejected():
     client, _, _ = build([FetchResult(OK, other)] * 200, case_budget_seconds=120)
     with pytest.raises(IcosUnavailable):
         client.case_bundle(CASE_ID)
+
+
+def test_an_empty_stub_is_not_a_case_with_no_charges():
+    """The summary can arrive healthy and ICOS degrade before the charges
+    fetch. The stub that comes back carries no problem report wording, so only
+    the case number tells it apart from a real case that genuinely has no
+    charges, and those two mean opposite things on a criminal record."""
+    client, _, _ = build([FetchResult(OK, CASE_PAGE)] +
+                         [FetchResult(OK, STUB_CASE_PAGE)] * 200,
+                         case_budget_seconds=120)
+    with pytest.raises(IcosUnavailable):
+        client.case_bundle(CASE_ID)
+
+
+def test_financials_must_also_prove_which_case_they_belong_to():
+    """Court debt decides whether a record can be expunged at all, so money
+    from the wrong case is as bad as charges from the wrong case."""
+    client, _, _ = build([FetchResult(OK, CASE_PAGE),
+                          FetchResult(OK, CASE_PAGE)] +
+                         [FetchResult(OK, STUB_CASE_PAGE)] * 200,
+                         case_budget_seconds=120)
+    with pytest.raises(IcosUnavailable):
+        client.case_bundle(CASE_ID)
+
+
+def test_a_stub_that_clears_is_just_a_retry():
+    client, _, _ = build([FetchResult(OK, CASE_PAGE),
+                          FetchResult(OK, STUB_CASE_PAGE),
+                          FetchResult(OK, CASE_PAGE),
+                          FetchResult(OK, CASE_PAGE)])
+    summary, charges, financials = client.case_bundle(CASE_ID)
+    assert charges == CASE_PAGE and financials == CASE_PAGE
 
 
 def test_a_stuck_case_gives_up_long_before_a_stuck_search():

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -116,6 +116,33 @@ def test_reaper_logs_off_abandoned_sessions():
     icos_sessions.close(active_token)
 
 
+def test_a_claimed_session_is_out_of_the_reapers_reach():
+    """A CRS run fetches its client once and then talks to ICOS for minutes.
+    Nothing refreshes last_used while it does, so a run longer than the idle
+    timeout would have the reaper log off the session it is still using."""
+    client = FakeClient()
+    token = icos_sessions.put(client)
+    # Make it look long abandoned, which is the state a slow run reaches.
+    icos_sessions._sessions[token]["last_used"] = \
+        time.time() - icos_sessions.IDLE_TIMEOUT - 1
+
+    assert icos_sessions.claim(token) is client
+    icos_sessions._reap()
+
+    assert client.logged_off is False
+
+
+def test_claiming_twice_gives_the_second_caller_nothing():
+    client = FakeClient()
+    token = icos_sessions.put(client)
+    assert icos_sessions.claim(token) is client
+    assert icos_sessions.claim(token) is None
+    assert icos_sessions.claim(None) is None
+    # Whoever claimed it owns logging off, so close() must not double up.
+    icos_sessions.close(token)
+    assert client.logged_off is False
+
+
 def test_activity_defers_the_reaper():
     client = FakeClient()
     token = icos_sessions.put(client)

--- a/tests/test_session_shutdown.py
+++ b/tests/test_session_shutdown.py
@@ -1,0 +1,58 @@
+"""Heroku restarts the dyno on every deploy and cycles it about once a day.
+
+The session store lives in memory, so a restart forgets whatever was in it
+without telling Iowa Courts. ICOS keeps holding that session, and because the
+ESA account is shared, the next staffer to search is told the account is
+already logged in somewhere else and waits it out. Nobody deployed anything
+from their point of view. The reaper cannot help, since the reaper dies with
+the process.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import icos_sessions
+
+
+class FakeClient:
+    def __init__(self, explodes=False):
+        self.logged_off = False
+        self.explodes = explodes
+
+    def logoff(self):
+        if self.explodes:
+            raise RuntimeError("ICOS refused the logoff")
+        self.logged_off = True
+
+
+def setup_function():
+    icos_sessions._sessions.clear()
+
+
+def test_shutdown_logs_off_everything_it_is_holding():
+    held = [FakeClient(), FakeClient(), FakeClient()]
+    for client in held:
+        icos_sessions.put(client)
+
+    assert icos_sessions.close_all() == 3
+    assert all(client.logged_off for client in held)
+    assert icos_sessions._sessions == {}
+
+
+def test_one_refused_logoff_does_not_strand_the_rest():
+    """Shutdown gets a few seconds. A session that will not close is exactly
+    the kind that is already broken, and letting it take the others down would
+    leave the account locked for the reason we are trying to avoid."""
+    good, bad = FakeClient(), FakeClient(explodes=True)
+    icos_sessions.put(bad)
+    icos_sessions.put(good)
+
+    icos_sessions.close_all()
+    assert good.logged_off
+    assert icos_sessions._sessions == {}
+
+
+def test_shutdown_with_nothing_held_is_quiet():
+    assert icos_sessions.close_all() == 0


### PR DESCRIPTION
Refusing ICOS problem-report pages (#50) fixed a wrong CRS row but made a worse failure reachable. `case_bundle` was called outside the per-case guard, so a page that never cleared burned the full 45 minute search budget and then took the entire run down with it. Staff got no workbook at all, where before they got one with a bad row in it. Neither is what the contract promises.

## What changes

**A case now costs a case.** The bundle call moves inside the guard, an ICOS failure is recorded against that case id, and the run carries on. The workbook is built from what came back.

**Three failures back to back means the site is down**, not that three cases are bad. The run stops there and still writes the CRS for everything pulled up to that point. Only an empty result set fails the job.

**Case pages get their own retry budget**, four minutes against the search's forty five. A search is the whole job and worth waiting out. A case is one row of twenty with staff watching a progress bar, and holding the other nineteen for forty five minutes buys nothing. Measured on a dead script: a case gives up after 227s and 6 retries, a search after 2447s and 14.

## Two things found on the way

**The session reaper could log off a run's own session.** `IDLE_TIMEOUT` is ten minutes and works off `last_used`, which a CRS run touches exactly once, at the start. Any run longer than that had its live ICOS session closed underneath it from the reaper thread, and a staffer hitting logout mid-run did the same. Both reproduced. A job now claims its session out of the store and owns logging it off. This was reachable before this PR and much more likely after it, since a stalled case now takes minutes by design.

**The alert body silently dropped unknown fields.** `_format` rendered a fixed list of labels, so a caller could add a detail, watch it appear in the end-of-job digest, and never learn it was missing from the email. I hit this writing the new alert. Unlisted fields now render.

## Verification

134 passing, 1 xfailed. The five new `tests/test_case_failures.py` tests were run against the pre-change `tasks.py` and all five fail there with the `IcosUnavailable` escaping `crs_task`, so they are testing the real defect and not themselves. Same check on the alert formatter test against the old `alerts.py`.

Not verified live against ICOS. The outage paths need the court site to actually break, so they are covered by tests only, as with the rest of the extended-outage work.

---

## Added since the original description

Five more commits, all the same shape: ICOS answering HTTP 200 with a page that is not what was asked for.

**A court outage no longer reads as "no Iowa record."** `search` accepted a problem-report page. It has no result rows, so it parsed as a search that matched nobody, which is the single worst thing a CRS can get wrong. It now has to prove it is a real result page.

**A court outage no longer reads as a bad password.** The same page at login is about 3400 bytes, well under `MIN_SIGNED_IN_BYTES`, so it fell through to the size check and staff were told to fix a user ID and password that were never wrong.

**A degraded court site no longer reads as a clean record.** The summary already had to prove which case it belonged to, but charges and financials only had to not be a problem report. The stub ICOS serves when it degrades partway through a case is not one: no problem-report wording, the heading of whatever case was looked at last, nothing listed. Napier filed it as a case with no charges and no court debt, which on a criminal record is a conviction reported as a non-conviction.

Measured on the July capture: the marker appears on 45 of 45 summaries and 0 of 90 charges and financials stubs, so the marker check could never have caught these. None of the 90 stubs echo the case number asked for and all 60 pages from healthy cases do. The closest call is a real case that genuinely has no charges, 2299 bytes against the stub's 2291. The case-number check separates those two correctly, which is why this is not a size check.

**A lost session is no longer reported as a Napier bug.** The reaper closing an idle session, or a second submit claiming it first, raised a bare `LookupError`. `jobs.py` alerts on anything without a `.message`, so an ordinary idle timeout showed staff "something went wrong inside Napier" and paged the operator.

**Held sessions are handed back on shutdown.** The session store is in memory. A deploy or Heroku's daily dyno cycle forgets it while ICOS keeps holding the session, and the ESA account is shared, so the next staffer waits about fifteen minutes for something they had no part in. The reaper cannot help because it dies with the process.

## Verification

144 passing, 1 xfailed. Every new failure test was run against the unchanged source first and fails there, four of them with `DID NOT RAISE IcosUnavailable`.

Live against real ICOS on staging, which the original description could not claim: a search waited out a held session for 453 seconds on the concurrent-login track, signed in, and returned 159 cases across 80 names. The 453 second wait was itself the orphaned-session bug above, caught by running into it.