### PR TITLE
Actually release the court session when the dyno goes down

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 from flask import Flask, jsonify, render_template, request, send_file, session, url_for, redirect
-import atexit
 import os
 import platform
 import time
@@ -126,9 +125,8 @@ def _start_background_threads():
     jobs.start_janitor()
     # Heroku deploys and its daily dyno cycle both kill this process. Whatever
     # the store is holding has to be handed back to ICOS on the way out, or the
-    # shared account stays locked for staff who did nothing but show up. On
-    # SIGTERM gunicorn exits its workers cleanly, so atexit still runs.
-    atexit.register(icos_sessions.close_all)
+    # shared account stays locked for staff who did nothing but show up.
+    icos_sessions.install_shutdown_hooks()
 
 # Guarded so tests (and anything importing the app for inspection) don't start
 # pinging the live court site.

--- a/icos_sessions.py
+++ b/icos_sessions.py
@@ -78,6 +78,12 @@ def close_all():
     with _lock:
         clients = [entry["client"] for entry in _sessions.values()]
         _sessions.clear()
+    if clients:
+        # Says so in the dyno log because the alternative is a locked account
+        # with nothing anywhere explaining why. The reaper announces itself for
+        # the same reason.
+        print("Shutting down: logging off %d Iowa Courts session(s)"
+              % len(clients), flush=True)
     for client in clients:
         try:
             client.logoff()

--- a/icos_sessions.py
+++ b/icos_sessions.py
@@ -11,6 +11,8 @@ logs off anything nobody came back to. The browser holds only an opaque token
 cookie jar inside the client is what carries the session.
 """
 
+import atexit
+import signal
 import threading
 import time
 import uuid
@@ -90,6 +92,33 @@ def close_all():
         except Exception:
             pass
     return len(clients)
+
+
+def install_shutdown_hooks():
+    """Release held sessions when the platform says the process is going away.
+
+    It has to be SIGTERM rather than atexit. Gunicorn takes its full thirty
+    second graceful timeout on the way down and Heroku SIGKILLs at that mark,
+    so an atexit handler runs in the same instant the process dies: it gets to
+    print and nothing more, and the logoff request never leaves the dyno. That
+    is measured, not assumed -- an R12 exit timeout with no EPALogout to show
+    for it, and the account still locked afterwards. SIGTERM lands thirty
+    seconds earlier, which is the entire budget for doing this properly.
+
+    Gunicorn's own handler is left in place behind ours so its shutdown still
+    runs. atexit stays as a backstop for the exits that never see a SIGTERM.
+    """
+    atexit.register(close_all)
+    previous = signal.getsignal(signal.SIGTERM)
+
+    def release_then_continue(signum, frame):
+        try:
+            close_all()
+        finally:
+            if callable(previous):
+                previous(signum, frame)
+
+    signal.signal(signal.SIGTERM, release_then_continue)
 
 
 def _reap(now=None):

--- a/tests/test_session_shutdown.py
+++ b/tests/test_session_shutdown.py
@@ -56,3 +56,27 @@ def test_one_refused_logoff_does_not_strand_the_rest():
 
 def test_shutdown_with_nothing_held_is_quiet():
     assert icos_sessions.close_all() == 0
+
+
+def test_sigterm_releases_sessions_before_the_server_starts_shutting_down():
+    """Measured on Heroku: registering this on atexit is too late. Gunicorn
+    takes its full thirty second graceful timeout, Heroku SIGKILLs at exactly
+    that mark, and the handler runs in the same instant the process dies. It
+    printed but never got the logoff request out, and the account stayed
+    locked. SIGTERM arrives thirty seconds earlier, which is the whole budget.
+    """
+    import signal
+
+    client = FakeClient()
+    icos_sessions.put(client)
+    served = []
+    previous = signal.signal(signal.SIGTERM, lambda *a: served.append('gunicorn'))
+    try:
+        icos_sessions.install_shutdown_hooks()
+        handler = signal.getsignal(signal.SIGTERM)
+        handler(signal.SIGTERM, None)
+    finally:
+        signal.signal(signal.SIGTERM, previous)
+
+    assert client.logged_off, "the session must be released on SIGTERM"
+    assert served == ['gunicorn'], "gunicorn's own shutdown must still happen"


### PR DESCRIPTION
#51 added a shutdown hook to log held ICOS sessions off, on `atexit`. I asserted that was enough because gunicorn exits its workers cleanly on SIGTERM. It is not enough, and staging proved it.

## What the dyno actually does

Gunicorn takes its full thirty second graceful timeout. Heroku gives up at exactly that mark:

```
Error R12 (Exit timeout) -> At least one process failed to exit within 30 seconds of SIGTERM
Stopping remaining processes with SIGKILL
[8] [INFO] Worker exiting (pid: 8)
Shutting down: logging off 1 Iowa Courts session(s)
[2] [INFO] Shutting down: Master
```

Three log lines inside 4ms, at the instant of the SIGKILL. The handler got to print and nothing more. There is no `EPALogout` anywhere in that window, so the logoff never left the dyno, and the next search waited **679 seconds** on the concurrent-login track for ICOS to time the orphan out on its own.

## The change

Release on SIGTERM instead, which lands thirty seconds before any of that. Gunicorn's handler stays installed behind ours so its shutdown is unchanged, and `atexit` stays as a backstop for exits that never see a signal. The shutdown also says so in the log now, because a locked shared account with nothing explaining it is how this went unnoticed to begin with.

## Verification

145 passing, 1 xfailed. The new SIGTERM test fails against the unchanged source.

Measured on staging, same sequence both times: leave a signed-in session parked on the results page, restart the dyno, then search.

| | before | after |
|---|---|---|
| logoff reaches ICOS | no `EPALogout` at all | `ICOS EPALogout status=200`, 262ms after the shutdown line |
| exit | R12 timeout, SIGKILL | clean |
| next search signs in | 679s | 3.5s |

The mechanism was checked separately too: a throwaway gunicorn app on the same 26.0.0 with the same worker class confirms `atexit` does run in the gthread worker on SIGTERM. It runs, it is just far too late to make an HTTP request.