### PR TITLE
Pin soupsieve so the build stops choosing it for us

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,13 @@ MarkupSafe==3.0.3
 openpyxl==3.1.5
 selenium==4.46.0
 six==1.17.0
+# Pulled in by beautifulsoup4, which asks only for >=1.6.1 and so would take
+# whatever the build happened to resolve. That is how 2.6 ended up deployed and
+# flagged (CVE-2026-49476 and CVE-2026-49477, ReDoS in the CSS selector parser,
+# fixed in 2.8.4). Napier never calls .select() or soupsieve.compile(), so the
+# vulnerable parser is imported and never reached, but every other indirect
+# dependency here is pinned and this one was simply missed.
+soupsieve==2.9.1
 urllib3==2.7.0
 webencodings==0.5.1
 Werkzeug==3.1.8


### PR DESCRIPTION
Closes #41.

The issue title says beautifulsoup4 4.11.1, which is stale: `requirements.txt` has been on 4.15.0 for a while. The package that actually carries the two advisories is **soupsieve**, an indirect dependency, and it was the only indirect dependency missing from `requirements.txt`. beautifulsoup4 asks for `soupsieve>=1.6.1`, so every build was free to resolve whatever it liked. It resolved 2.6, which is what the scanner found.

CVE-2026-49476 and CVE-2026-49477 are the same bug: a regex in soupsieve's CSS selector parser backtracks catastrophically on an attribute selector with an unterminated quote. 300 bytes buys more than three seconds of CPU, and each extra byte roughly doubles it. Fixed in 2.8.4.

**Napier cannot reach it.** The vulnerable code path is `soupsieve.compile()`, which is only entered through `.select()` or `.select_one()`. Neither appears anywhere in this codebase, so the parser is imported and never called, and there is no route by which a user could hand Napier a CSS selector in the first place. This is not an exposure that needed an emergency fix.

Pinning it regardless, because the reason an old version was deployed is that nothing was holding it in place, and that would have stayed true for the next advisory.

Verified rather than assumed: the advisory ships a proof of concept, and against the pinned 2.9.1 the malformed selector that is supposed to hang returns in 0.3ms.

```
soupsieve 2.9.1
  well-formed          306 bytes -> 0.0034s
  unterminated quote   304 bytes -> 0.0003s
```

145 tests pass, 1 xfail, unchanged.
