### PR TITLE
Give Napier an interface that looks like it was made on purpose

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,13 +1,293 @@
-﻿<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="UTF-8">
-        <title>NAPIER</title>
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-    </head>
-    <body>
-        <div class="container">
-            {% block content %}{% endblock %}
-        </div>
-    </body>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% block title %}Napier{% endblock %}</title>
+<style>
+/* Everything the page needs is in this file. Nothing is fetched from a CDN.
+   Legal aid offices sit behind filtered networks, and the previous version
+   pulled its stylesheet and jQuery from two outside hosts, so a blocked domain
+   meant an unstyled page or a search button that did nothing. */
+
+:root {
+  --ink: #151a21;
+  --ink-soft: #5a6472;
+  --ink-faint: #8b95a3;
+  --page: #eef1f5;
+  --surface: #ffffff;
+  --line: #dde3ea;
+  --line-soft: #eaeef3;
+  --brand: #17314f;
+  --brand-bright: #24507f;
+  --accent: #b98900;
+  --focus: #2f6fbf;
+  --warn-ink: #7a4b00;
+  --warn-bg: #fdf4e2;
+  --warn-line: #ecd9ab;
+  --stop-ink: #8a2b2b;
+  --stop-bg: #fceeee;
+  --stop-line: #eec9c9;
+  --shadow: 0 1px 2px rgba(16,24,40,.05), 0 8px 24px -12px rgba(16,24,40,.18);
+  --radius: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e8ecf2;
+    --ink-soft: #a3adbb;
+    --ink-faint: #78828f;
+    --page: #10141a;
+    --surface: #171d25;
+    --line: #2a323d;
+    --line-soft: #222932;
+    --brand: #0f1c2c;
+    --brand-bright: #3d78bd;
+    --accent: #d9a520;
+    --focus: #5f9de0;
+    --warn-ink: #e5c072;
+    --warn-bg: #2a2318;
+    --warn-line: #4a3d22;
+    --stop-ink: #e79a9a;
+    --stop-bg: #2c1c1c;
+    --stop-line: #4d2f2f;
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 10px 28px -14px rgba(0,0,0,.7);
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 16px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+        "Helvetica Neue", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* --- masthead ---------------------------------------------------------- */
+
+.masthead {
+  background: var(--brand);
+  border-bottom: 3px solid var(--accent);
+}
+
+.masthead-inner {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  align-items: baseline;
+  gap: .85rem;
+  flex-wrap: wrap;
+}
+
+.wordmark {
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: #fff;
+  margin: 0;
+}
+
+.wordmark-sub {
+  font-size: .82rem;
+  color: #b9c6d6;
+  letter-spacing: .01em;
+}
+
+/* --- layout ------------------------------------------------------------ */
+
+main {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 1.75rem 1.25rem 4rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1.6rem;
+}
+
+.card + .card { margin-top: 1.1rem; }
+
+h1 {
+  font-size: 1.4rem;
+  line-height: 1.3;
+  margin: 0 0 .3rem;
+  letter-spacing: -.01em;
+}
+
+.lede {
+  color: var(--ink-soft);
+  margin: 0 0 1.4rem;
+  font-size: .95rem;
+}
+
+/* --- forms ------------------------------------------------------------- */
+
+fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0 0 1.35rem;
+}
+
+legend {
+  padding: 0;
+  font-size: .74rem;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: .7rem;
+}
+
+.row {
+  display: grid;
+  gap: .85rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 40rem) {
+  .row-name { grid-template-columns: 1fr .55fr 1fr; }
+  .row-two  { grid-template-columns: 1fr 1fr; }
+}
+
+label { display: block; }
+
+.field-label {
+  display: block;
+  font-size: .82rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  margin-bottom: .3rem;
+}
+
+input[type=text], input[type=password] {
+  width: 100%;
+  padding: .6rem .7rem;
+  font: inherit;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  transition: border-color .12s, box-shadow .12s;
+}
+
+input[type=text]:focus, input[type=password]:focus {
+  outline: none;
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus) 22%, transparent);
+}
+
+.check {
+  display: flex;
+  align-items: flex-start;
+  gap: .6rem;
+  padding: .75rem .85rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line-soft);
+  cursor: pointer;
+}
+
+.check input { margin: .25rem 0 0; flex: none; }
+.check-text { font-size: .92rem; }
+.check-note { display: block; color: var(--ink-soft); font-size: .84rem; }
+
+/* --- buttons ----------------------------------------------------------- */
+
+.actions {
+  display: flex;
+  gap: .65rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  font: inherit;
+  font-weight: 600;
+  padding: .58rem 1.15rem;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: background .12s, border-color .12s, color .12s;
+}
+
+.btn:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--focus) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.btn-primary { background: var(--brand-bright); color: #fff; }
+.btn-primary:hover { background: var(--brand); }
+
+@media (prefers-color-scheme: dark) {
+  .btn-primary:hover { background: #4a87cc; }
+}
+
+.btn-primary[disabled] {
+  background: var(--ink-faint);
+  cursor: not-allowed;
+}
+
+.btn-quiet {
+  background: transparent;
+  color: var(--ink-soft);
+  border-color: var(--line);
+}
+
+.btn-quiet:hover { color: var(--ink); border-color: var(--ink-faint); }
+
+/* --- notices ----------------------------------------------------------- */
+
+.notice {
+  border: 1px solid var(--warn-line);
+  background: var(--warn-bg);
+  color: var(--warn-ink);
+  border-radius: 8px;
+  padding: .85rem 1rem;
+  margin-bottom: 1.2rem;
+  font-size: .93rem;
+}
+
+.notice p { margin: 0 0 .5rem; }
+.notice p:last-child { margin-bottom: 0; }
+.notice-title { font-weight: 700; }
+
+.notice-stop {
+  border-color: var(--stop-line);
+  background: var(--stop-bg);
+  color: var(--stop-ink);
+}
+
+footer {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 0 1.25rem 2.5rem;
+  color: var(--ink-faint);
+  font-size: .82rem;
+}
+</style>
+{% block head %}{% endblock %}
+</head>
+<body>
+<header class="masthead">
+  <div class="masthead-inner">
+    <p class="wordmark">Napier</p>
+    <span class="wordmark-sub">Iowa criminal record search for Iowa Legal Aid</span>
+  </div>
+</header>
+<main>
+{% block content %}{% endblock %}
+</main>
+<footer>Case data comes from Iowa Courts Online. Check anything you rely on against the court record.</footer>
+</body>
 </html>

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -1,68 +1,191 @@
 {% extends 'base.html' %}
+{% block title %}Working: Napier{% endblock %}
+
+{% block head %}
+<style>
+.track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--line-soft);
+  overflow: hidden;
+  margin: 1.1rem 0 1.2rem;
+}
+
+.track-fill {
+  height: 100%;
+  width: 38%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--brand-bright), var(--accent));
+  animation: slide 1.5s ease-in-out infinite;
+}
+
+@keyframes slide {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(300%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .track-fill { animation: none; width: 100%; opacity: .55; }
+}
+
+.status {
+  font-size: 1.02rem;
+  margin: 0;
+  min-height: 1.55rem;
+}
+
+.elapsed {
+  color: var(--ink-faint);
+  font-size: .84rem;
+  font-variant-numeric: tabular-nums;
+  margin: .45rem 0 0;
+}
+
+details {
+  margin-top: 1.4rem;
+  border-top: 1px solid var(--line-soft);
+  padding-top: 1rem;
+}
+
+summary {
+  cursor: pointer;
+  font-size: .85rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+}
+
+summary::marker { color: var(--ink-faint); }
+
+.log {
+  list-style: none;
+  margin: .9rem 0 0;
+  padding: 0 0 0 1.1rem;
+  border-left: 2px solid var(--line);
+}
+
+.log li {
+  position: relative;
+  padding: 0 0 .55rem .2rem;
+  font-size: .88rem;
+  color: var(--ink-soft);
+}
+
+.log li::before {
+  content: "";
+  position: absolute;
+  left: -1.42rem;
+  top: .52rem;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--line);
+}
+
+.log li:last-child { color: var(--ink); padding-bottom: 0; }
+.log li:last-child::before { background: var(--accent); }
+</style>
+{% endblock %}
 
 {% block content %}
-    <h3 id="headline">Working...</h3>
+<div class="card">
+  <h1 id="headline">Working on it</h1>
+  <p class="lede">
+    This runs on the server, so you can close this tab or shut the laptop and
+    the work carries on. Iowa Courts is slow at times and Napier waits it out.
+  </p>
 
-    <div id="spinner" class="my-3">
-        <div class="progress">
-            <div class="progress-bar progress-bar-striped progress-bar-animated" style="width: 100%"></div>
-        </div>
-    </div>
+  <div id="track" class="track"><div class="track-fill"></div></div>
 
-    <p id="status" class="lead">{{ job.message }}</p>
+  <p id="status" class="status" role="status" aria-live="polite">{{ job.message }}</p>
+  <p id="elapsed" class="elapsed"></p>
 
-    <div id="failed" class="alert alert-warning" style="display: none"></div>
+  <div id="failed" class="notice notice-stop" role="alert" hidden></div>
 
-    <details class="mt-3">
-        <summary>Details</summary>
-        <ul id="log" class="mt-2 text-muted"></ul>
-    </details>
+  <details>
+    <summary>Show what it has done so far</summary>
+    <ul id="log" class="log"></ul>
+  </details>
 
-    <p class="mt-3">
-        <a href="/logout" class="btn btn-outline-secondary">Cancel and start over</a>
-    </p>
+  <div class="actions" style="margin-top:1.4rem">
+    <a href="/logout" class="btn btn-quiet">Cancel and start over</a>
+  </div>
+</div>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script>
-        var jobId = {{ job.id|tojson }};
+<script>
+var jobId = {{ job.id|tojson }};
+var started = Date.now();
+var timer = null;
 
-        function render(state) {
-            $("#status").text(state.message || "");
-            var log = $("#log").empty();
-            $.each(state.progress || [], function (_, line) {
-                log.append($("<li>").text(line));
-            });
-        }
+function tick() {
+  var s = Math.round((Date.now() - started) / 1000);
+  var text;
+  if (s < 60) {
+    text = s + (s === 1 ? " second" : " seconds");
+  } else {
+    var m = Math.floor(s / 60);
+    var r = s % 60;
+    text = m + (m === 1 ? " minute " : " minutes ") + r + "s";
+  }
+  document.getElementById("elapsed").textContent = "Running for " + text;
+}
 
-        function poll() {
-            $.getJSON("/job/" + jobId)
-                .done(function (state) {
-                    render(state);
-                    if (state.status === "done") {
-                        $("#headline").text("Finished");
-                        window.location = state.next_url;
-                        return;
-                    }
-                    if (state.status === "failed") {
-                        $("#headline").text("Search stopped");
-                        $("#spinner").hide();
-                        $("#failed").text(state.error).show();
-                        return;
-                    }
-                    setTimeout(poll, 2000);
-                })
-                .fail(function (xhr) {
-                    // A restarted dyno loses in-flight searches; say so plainly
-                    // instead of spinning forever.
-                    var state = xhr.responseJSON;
-                    $("#headline").text("Search stopped");
-                    $("#spinner").hide();
-                    $("#failed").text(state && state.error
-                        ? state.error
-                        : "Lost contact with Napier. Please run the search again.").show();
-                });
-        }
+function render(state) {
+  document.getElementById("status").textContent = state.message || "";
+  var log = document.getElementById("log");
+  log.textContent = "";
+  (state.progress || []).forEach(function (line) {
+    var li = document.createElement("li");
+    li.textContent = line;
+    log.appendChild(li);
+  });
+}
 
-        $(document).ready(poll);
-    </script>
+function stop(headline, message) {
+  document.getElementById("headline").textContent = headline;
+  document.getElementById("track").hidden = true;
+  document.getElementById("elapsed").hidden = true;
+  if (timer) { clearInterval(timer); }
+  if (message) {
+    var box = document.getElementById("failed");
+    box.textContent = message;
+    box.hidden = false;
+  }
+}
+
+function poll() {
+  fetch("/job/" + encodeURIComponent(jobId), {
+    headers: { "Accept": "application/json" }
+  }).then(function (response) {
+    return response.json().catch(function () { return null; })
+      .then(function (state) { return { ok: response.ok, state: state }; });
+  }).then(function (result) {
+    var state = result.state;
+    // A restarted dyno loses in-flight searches, and the server says so in the
+    // body of a 410. Say the same thing rather than spinning forever.
+    if (!result.ok || !state) {
+      stop("Search stopped", (state && state.error) ||
+           "Lost contact with Napier. Please run the search again.");
+      return;
+    }
+    render(state);
+    if (state.status === "done") {
+      stop("Finished", null);
+      window.location = state.next_url;
+      return;
+    }
+    if (state.status === "failed") {
+      stop("Search stopped", state.error);
+      return;
+    }
+    setTimeout(poll, 2000);
+  }).catch(function () {
+    stop("Search stopped",
+         "Lost contact with Napier. Please run the search again.");
+  });
+}
+
+tick();
+timer = setInterval(tick, 1000);
+poll();
+</script>
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,73 +1,217 @@
 {% extends 'base.html' %}
+{% block title %}Results: Napier{% endblock %}
+
+{% block head %}
+<style>
+.result-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.1rem;
+}
+
+.bulk {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-size: .85rem;
+  color: var(--brand-bright);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.people { display: grid; gap: .5rem; margin-bottom: 1.5rem; }
+
+.person {
+  display: flex;
+  align-items: center;
+  gap: .8rem;
+  padding: .8rem .95rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color .12s, background .12s;
+}
+
+.person:hover { border-color: var(--ink-faint); }
+
+.person:has(input:checked) {
+  border-color: var(--brand-bright);
+  background: color-mix(in srgb, var(--brand-bright) 7%, var(--surface));
+}
+
+.person input { flex: none; margin: 0; }
+.person-main { flex: 1 1 auto; min-width: 0; }
+
+.person-name {
+  font-weight: 600;
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.person-dob {
+  display: block;
+  font-size: .83rem;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.tally {
+  flex: none;
+  font-size: .8rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  background: var(--line-soft);
+  border-radius: 999px;
+  padding: .2rem .65rem;
+  white-space: nowrap;
+}
+
+.selected-count {
+  font-size: .88rem;
+  color: var(--ink-soft);
+  margin: 0;
+}
+</style>
+{% endblock %}
 
 {% block content %}
-    <h3>Results</h3>
+<div class="card">
+  <div class="result-head">
+    <div>
+      <h1>Who is your client?</h1>
+      <p class="lede" style="margin-bottom:0">
+        Iowa Courts groups cases by name and date of birth. Pick every entry
+        that is the same person and Napier will build one workbook from all of
+        them.
+      </p>
+    </div>
+  </div>
 
-    {% if too_many_results %}
-        <div class="alert alert-warning">
-            <div>Your query returned more than 200 records.</div>
-            <div>A subset of the results (the first 200 records found) is shown below.</div>
-            <div>Cases where the person's role is an attorney or other non-party designation are automatically excluded from the list below.</div>
-            <div>However, the 200-record limit may have prevented some of your client's actual cases from appearing.</div>
-            <div>To get more complete results, go back to the search screen and add a middle name or other details to narrow your search.</div>
-        </div>
-    {% endif %}
+  {% if too_many_results %}
+    <div class="notice" role="alert">
+      <p class="notice-title">Iowa Courts stopped counting at 200 records.</p>
+      <p>
+        Only the first 200 are shown, so some of your client's cases may be
+        missing. Cases where the person is an attorney or another non-party are
+        left out of this list on purpose.
+      </p>
+      <p>
+        Go back and add a middle name or more of the name to narrow it down.
+      </p>
+    </div>
+  {% endif %}
 
-    <form id="crs">
-        {% for key in keys %}
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="caseId" value="{{ key }}">
-                <label class="form-check-label">
-                    {{ key }} <span class="text-muted">({{ cases[key] | length }} case{{ cases[key] | length | pluralize("","s") }})</span>
-                </label>
-            </div>
-        {% endfor %}
-        <button id="crs-submit-button" type="submit" class="btn btn-primary">Create CRS</button>
-    </form>
-    <a href="/logout" class="btn">New Search</a>
+  <form id="crs">
+    <div class="result-head" style="margin-bottom:.6rem">
+      <p class="selected-count" id="count">Nothing picked yet</p>
+      <button type="button" class="bulk" id="toggle-all">Select all</button>
+    </div>
 
-    <div id="status" class="mt-2"></div>
+    <div class="people">
+      {% for key in keys %}
+        {% set parts = key.split(' ', 1) %}
+        <label class="person">
+          <input type="checkbox" name="caseId" value="{{ key }}">
+          <span class="person-main">
+            <span class="person-name">{{ parts[1] if parts|length > 1 else key }}</span>
+            {% if parts|length > 1 %}
+              <span class="person-dob">Born {{ parts[0] }}</span>
+            {% endif %}
+          </span>
+          <span class="tally">{{ cases[key] | length }} case{{ cases[key] | length | pluralize("","s") }}</span>
+        </label>
+      {% endfor %}
+    </div>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script>
-        var searchJobId = {{ search_job_id|tojson }};
+    <div class="actions">
+      <button id="crs-submit-button" type="submit" class="btn btn-primary">Create the CRS</button>
+      <a href="/logout" class="btn btn-quiet">Start a new search</a>
+    </div>
+  </form>
 
-        // The cases are pulled from Iowa Courts and the workbook is built on the
-        // server, so the run survives a closed laptop; this page just hands off
-        // the selection and follows the job's progress page.
-        $(document).ready(function () {
-            $("#crs").submit(function (e) {
-                e.preventDefault();
-                var keys = $("input[name='caseId']:checked").map(function () {
-                    return $(this).val();
-                }).get();
-                if (!keys.length) {
-                    $("#status").text("Pick a name first.");
-                    return false;
-                }
-                $("#crs-submit-button").attr("disabled", true);
-                $("#status").text("Starting...");
+  <div id="status" class="notice notice-stop" role="alert" hidden></div>
+</div>
 
-                $.ajax({
-                    type: "POST",
-                    url: "/crs-job",
-                    data: JSON.stringify({ 'search_job_id': searchJobId, 'keys': keys }),
-                    contentType: "application/json; charset=utf-8",
-                    dataType: "json"
-                })
-                .done(function (response) {
-                    window.location = response.progress_url;
-                })
-                .fail(function (xhr) {
-                    var response = xhr.responseJSON;
-                    $("#crs-submit-button").attr("disabled", false);
-                    $("#status").text(response && response.error
-                        ? response.error
-                        : "Could not start the CRS. Please try again.");
-                });
-                return false;
-            });
-        });
-    </script>
+<script>
+var searchJobId = {{ search_job_id|tojson }};
+var form = document.getElementById("crs");
+var button = document.getElementById("crs-submit-button");
+var statusBox = document.getElementById("status");
+var countLine = document.getElementById("count");
+var toggleAll = document.getElementById("toggle-all");
 
+function boxes() {
+  return Array.prototype.slice.call(
+    form.querySelectorAll("input[name='caseId']"));
+}
+
+function picked() {
+  return boxes().filter(function (b) { return b.checked; });
+}
+
+function refresh() {
+  var n = picked().length;
+  countLine.textContent = n === 0
+    ? "Nothing picked yet"
+    : n + (n === 1 ? " name picked" : " names picked");
+  toggleAll.textContent = n === boxes().length && n > 0 ? "Clear all" : "Select all";
+}
+
+function say(message) {
+  statusBox.textContent = message;
+  statusBox.hidden = !message;
+}
+
+form.addEventListener("change", refresh);
+
+toggleAll.addEventListener("click", function () {
+  var turnOn = picked().length !== boxes().length;
+  boxes().forEach(function (b) { b.checked = turnOn; });
+  refresh();
+});
+
+// The cases are pulled from Iowa Courts and the workbook is built on the
+// server, so the run survives a closed laptop; this page just hands off the
+// selection and follows the job's progress page.
+form.addEventListener("submit", function (e) {
+  e.preventDefault();
+  var keys = picked().map(function (b) { return b.value; });
+  if (!keys.length) {
+    say("Pick at least one name first.");
+    return;
+  }
+  say("");
+  button.disabled = true;
+  button.textContent = "Starting...";
+
+  fetch("/crs-job", {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ search_job_id: searchJobId, keys: keys })
+  }).then(function (response) {
+    return response.json().catch(function () { return null; })
+      .then(function (body) { return { ok: response.ok, body: body }; });
+  }).then(function (result) {
+    if (result.ok && result.body && result.body.progress_url) {
+      window.location = result.body.progress_url;
+      return;
+    }
+    button.disabled = false;
+    button.textContent = "Create the CRS";
+    say((result.body && result.body.error) ||
+        "Could not start the CRS. Please try again.");
+  }).catch(function () {
+    button.disabled = false;
+    button.textContent = "Create the CRS";
+    say("Could not start the CRS. Please try again.");
+  });
+});
+
+refresh();
+</script>
 {% endblock %}

--- a/templates/start.html
+++ b/templates/start.html
@@ -1,39 +1,66 @@
 {% extends 'base.html' %}
+{% block title %}Search: Napier{% endblock %}
 
 {% block content %}
-    <h3>Welcome to Napier</h3>
-    {% if error %}
-        <div class="alert alert-warning">{{ error }}</div>
-    {% endif %}
-    <form action="/search" method="post">
-        <div class="form-row">
-            <div class="form-group col">
-                <label>First</label>
-                <input class="form-control" type="text" name="firstname">
-            </div>
-            <div class="form-group col-2">
-                <label>Middle</label>
-                <input class="form-control" type="text" name="middlename">
-            </div>
-            <div class="form-group col">
-                <label>Last</label>
-                <input class="form-control" type="text" name="lastname">
-            </div>
-        </div>
-        <div class="form-row">
-            <div class="form-group col">
-                <label>Username</label>
-                <input class="form-control" type="username" name="username">
-            </div>
-            <div class="form-group col">
-                <label>Password</label>
-                <input class="form-control" type="password" name="password">
-            </div>
-        </div>
-        <div class="form-group form-check">
-            <input type="checkbox" class="form-check-input" name="isLite" id="isLiteCheckbox">
-            <label class="form-check-label" for="isLiteCheckbox">Use Lite Version</label>
-        </div>
-        <button type="submit" class="btn btn-primary">Search</button>
-    </form>
+<div class="card">
+  <h1>Search for a client's Iowa cases</h1>
+  <p class="lede">
+    Napier signs in to Iowa Courts Online, collects every case it can find for
+    the name, and builds the criminal record summary workbook.
+  </p>
+
+  {% if error %}
+    <div class="notice notice-stop" role="alert">{{ error }}</div>
+  {% endif %}
+
+  <form action="/search" method="post">
+    <fieldset>
+      <legend>Who are you searching for</legend>
+      <div class="row row-name">
+        <label>
+          <span class="field-label">First name</span>
+          <input type="text" name="firstname" autocomplete="off" autofocus>
+        </label>
+        <label>
+          <span class="field-label">Middle</span>
+          <input type="text" name="middlename" autocomplete="off">
+        </label>
+        <label>
+          <span class="field-label">Last name</span>
+          <input type="text" name="lastname" autocomplete="off" required>
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Your Iowa Courts sign in</legend>
+      <div class="row row-two">
+        <label>
+          <span class="field-label">User ID</span>
+          <input type="text" name="username" autocomplete="username"
+                 autocapitalize="none" spellcheck="false" required>
+        </label>
+        <label>
+          <span class="field-label">Password</span>
+          <input type="password" name="password"
+                 autocomplete="current-password" required>
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <label class="check">
+        <input type="checkbox" name="isLite" id="isLiteCheckbox">
+        <span class="check-text">
+          Build the Lite workbook
+          <span class="check-note">Fewer sheets. Use it when you only need the case list and the money owed.</span>
+        </span>
+      </label>
+    </fieldset>
+
+    <div class="actions">
+      <button type="submit" class="btn btn-primary">Search Iowa Courts</button>
+    </div>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
A visual pass over all four screens. The old ones were stock Bootstrap with default spacing and no identity, which is right for a prototype and reads as unfinished for something staff use on real clients.

## No outside hosts

The stylesheet came from a Bootstrap CDN and jQuery from a second one. An office behind a filtered network therefore got an unstyled page and a Create CRS button that silently did nothing. That is a poor failure mode for a tool whose entire theme this quarter has been not failing quietly, so the CSS now lives in the page and the two scripts are plain `fetch`, which is all they were doing through jQuery anyway. The app now makes zero third-party requests.

## Changes staff will notice

The results list separates the name from the date of birth instead of running them together, since matching a person is the actual task on that screen and the date is what decides it. Selection has select all, clear all, and a running count, which starts to matter when a search comes back with seventy names.

The progress screen counts elapsed time. When the shared ESA account is locked that screen can sit for fifteen minutes repeating one sentence, and a number that keeps moving is the difference between someone waiting and someone reloading.

Dark mode follows the operating system. `prefers-reduced-motion` turns the animation off rather than just slowing it down.

## What did not change

Form field names, routes, and the job polling contract are identical, so nothing server side is aware this happened. 145 tests pass, 1 xfail, unchanged.

Checked in a real browser rather than by eye over the markup: both light and dark, select all and clear all, the checked row state, the expanded progress log, and the lost contact failure path.
