### PR TITLE
Survive a lost connection, and say something when a run goes unclaimed

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -50,6 +50,12 @@ PARSE_FAILURE = 'case could not be read'
 CASE_UNAVAILABLE = 'case could not be retrieved from ICOS'
 JOB_FAILED = 'job failed'
 UNHANDLED = 'unhandled exception'
+# Both of these are runs the server thinks went fine. A staffer whose phone drops
+# the progress page sees a finished run as a broken one, gives up, and signs in
+# to pull the same cases again, and every server-side signal here stays quiet
+# because nothing server-side went wrong.
+UNCOLLECTED = 'workbook was built but never collected'
+CLIENT_LOST = 'progress page lost contact with Napier'
 
 # A run that eventually worked but took this many attempts is the early warning
 # that ICOS is degrading, which is worth one email before staff start noticing.

--- a/app.py
+++ b/app.py
@@ -150,6 +150,24 @@ def remember_job(job):
     session['job_ids'] = (session.get('job_ids', []) + [job.id])[-20:]
 
 
+@app.context_processor
+def waiting_workbook():
+    """The most recent finished workbook this browser has not picked up yet.
+
+    A phone that loses signal for ten seconds ends the run on screen while it
+    carries on and finishes on the server. Until this, the file was built, sat
+    in the job store for two hours and was thrown away unread, and the only way
+    forward was to sign in and pull every case again. So every page that can be
+    landed on offers the way back.
+    """
+    for job_id in reversed(session.get('job_ids', [])):
+        job = jobs.get(job_id)
+        if (job is not None and job.kind == 'crs' and job.status == jobs.DONE
+                and not job.collected):
+            return {"waiting_job": job}
+    return {"waiting_job": None}
+
+
 @app.route('/')
 def index():
     return render_template('start.html')
@@ -202,6 +220,33 @@ def job_status(job_id):
                         "error": RESTARTED_MESSAGE,
                         "message": RESTARTED_MESSAGE, "progress": []}), 410
     return jsonify(job.to_dict())
+
+
+@app.route('/job/<job_id>/lost', methods=['POST'])
+def lost_contact(job_id):
+    """The progress page reporting that it could not reach us for a while.
+
+    Sent once the browser is talking again, because a page with no connection
+    cannot report that it has no connection. Nothing here is a server failure,
+    which is the point: a staffer watching a working run appear to die is
+    exactly the kind of thing that never reaches a log we read.
+    """
+    job = own_job(job_id)
+    if job is None:
+        return ('', 204)
+    seconds = (request.get_json(silent=True) or {}).get('seconds')
+    try:
+        seconds = int(seconds)
+    except (TypeError, ValueError):
+        seconds = 0
+    alerts.record(job.id[:8], job.kind, alerts.CLIENT_LOST,
+                  progress=alerts.recent_progress(job),
+                  **{'out of contact': '%d seconds' % seconds,
+                     'job status': job.status,
+                     'note': ("The run was not affected. This is the staffer's "
+                              "connection to Napier, and it recovered on its "
+                              "own. Worth watching only if it keeps happening.")})
+    return ('', 204)
 
 
 @app.route('/results/<job_id>')
@@ -271,6 +316,9 @@ def download(job_id):
             or not path.endswith('.xlsx'):
         return "Bad session - invalid file"
 
+    # The run is only over once the file has reached someone. This is what stops
+    # the uncollected-workbook alert and takes the offer off the start page.
+    job.collected = True
     return send_file(path, as_attachment=True,
                      download_name=tasks.download_name(job.result['def_name'],
                                                        job.result['is_lite']))

--- a/app.py
+++ b/app.py
@@ -237,6 +237,23 @@ def crs_job():
     return jsonify({"job_id": job.id, "progress_url": url_for('progress', job_id=job.id)})
 
 
+@app.route('/done/<job_id>')
+def done(job_id):
+    job = own_job(job_id)
+    if job is None or job.status != jobs.DONE or job.kind != 'crs':
+        return render_template('start.html', error=RESTARTED_MESSAGE)
+
+    result = job.result
+    return render_template('done.html', job=job.to_dict(),
+                           def_name=result['def_name'],
+                           is_lite=result['is_lite'],
+                           written=result['written_cases'],
+                           requested=result['requested_cases'],
+                           failed=result['failed_cases'],
+                           filename=tasks.download_name(result['def_name'],
+                                                        result['is_lite']))
+
+
 @app.route('/job/<job_id>/download')
 def download(job_id):
     job = own_job(job_id)

--- a/app.py
+++ b/app.py
@@ -164,7 +164,11 @@ def logout():
 
 @app.route('/search', methods=['POST'])
 def search():
-    username = request.form['username']
+    # An ESA user ID is ILA## or drakelegalclinic and never has a space in it,
+    # so anything around it came from the keyboard or from autofill rather than
+    # from the person. Left alone it passes the check below, reaches ICOS as an
+    # unknown user, and comes back looking exactly like a wrong password.
+    username = request.form['username'].strip()
     password = request.form['password']
     session['isLite'] = 'isLite' in request.form
 

--- a/icos.py
+++ b/icos.py
@@ -15,6 +15,7 @@ Timing is injectable so the retry behaviour can be tested without real waits.
 """
 
 import os
+import re
 import time
 
 import alerts
@@ -64,6 +65,22 @@ def _squashed(text):
 
 def _is_not_a_problem_report(body):
     return PROBLEM_REPORT_MARKER not in _text(body)
+
+
+def _page_text(body, username=""):
+    """The visible words of a short ESA page, for the log.
+
+    ESA answers some refusals with a page carrying none of the markers below,
+    and until now all we recorded was its length, which is not enough to tell a
+    wrong user ID from an account that is still signed in somewhere else. The
+    user ID is taken back out because it identifies the office, and a failure
+    page has no reason to reach a log line naming it.
+    """
+    text = re.sub(r"<[^>]+>", " ", _text(body))
+    text = re.sub(r"\s+", " ", text).strip()
+    if username:
+        text = text.replace(username, "<user id>")
+    return text[:400]
 
 
 def _is_page_for_case(body, case_id):
@@ -243,6 +260,7 @@ class IcosClient:
 
         started = self._monotonic()
         waited_for_lock = False
+        retried_trimmed = False
         while True:
             # Without the validator a problem report lands on the size check
             # below, because it is well under MIN_SIGNED_IN_BYTES, and staff
@@ -287,9 +305,27 @@ class IcosClient:
             if len(body) < MIN_SIGNED_IN_BYTES:
                 print("ICOS login rejected: %db response, no marker" % len(body),
                       flush=True)
+                print("ICOS login page said: %s" % _page_text(body, username),
+                      flush=True)
+
+                # Typed on a phone, a password picks up a trailing space from
+                # the keyboard or from whatever autofilled it, and ESA answers
+                # an unmarked short page that is indistinguishable from a wrong
+                # password. Spend one more request before telling someone their
+                # working credentials are wrong.
+                if password != password.strip() and not retried_trimmed:
+                    retried_trimmed = True
+                    password = password.strip()
+                    print("ICOS login retrying without surrounding whitespace",
+                          flush=True)
+                    continue
+
                 raise IcosBadCredentials(
-                    "Iowa Courts Online did not sign in with that user ID and "
-                    "password. Please check them and try again.")
+                    "Iowa Courts Online turned down the sign in without saying "
+                    "why. Check the user ID and password. If they are right, "
+                    "this account may still be signed in from an earlier "
+                    "search, which Iowa Courts clears on its own within about "
+                    "15 minutes.")
 
             self.logged_in = True
             self.username = username

--- a/jobs.py
+++ b/jobs.py
@@ -36,13 +36,21 @@ class Job:
         self.result = None
         self.error = None
         self.next_url = None
+        # How far along the job is, when it knows. A CRS job pulls a case at a
+        # time and can count them; a search cannot, and leaves these None so
+        # the page shows an unmeasured bar instead of inventing a number.
+        self.count = None
+        self.total = None
         self.created_at = time.time()
         self.updated_at = self.created_at
         self._lock = threading.Lock()
 
-    def log(self, message):
+    def log(self, message, count=None, total=None):
         with self._lock:
             self.progress.append({"t": time.time(), "message": message})
+            if total is not None:
+                self.count = count
+                self.total = total
             self.updated_at = time.time()
         print("JOB %s %s: %s" % (self.kind, self.id[:8], message), flush=True)
 
@@ -55,6 +63,8 @@ class Job:
                 "progress": [p["message"] for p in self.progress],
                 "message": self.progress[-1]["message"] if self.progress else "Starting...",
                 "error": self.error,
+                "count": self.count,
+                "total": self.total,
                 "next_url": self.next_url,
                 "done": self.status in (DONE, FAILED),
             }

--- a/jobs.py
+++ b/jobs.py
@@ -26,6 +26,11 @@ FAILED = "failed"
 # job may run before the janitor stops tracking it.
 RETENTION_SECONDS = 2 * 60 * 60
 
+# A finished workbook nobody has downloaded after this long is a run that
+# succeeded here and failed on the staffer's screen. It is the only trace such a
+# run leaves, since every other alert in this app fires from something throwing.
+UNCOLLECTED_AFTER = 5 * 60
+
 
 class Job:
     def __init__(self, kind):
@@ -43,6 +48,11 @@ class Job:
         self.total = None
         self.created_at = time.time()
         self.updated_at = self.created_at
+        # Whether the file this job built ever reached the person who asked for
+        # it. A run is not finished when the server says so, it is finished when
+        # a staffer has the workbook.
+        self.collected = False
+        self.reported_uncollected = False
         self._lock = threading.Lock()
 
     def log(self, message, count=None, total=None):
@@ -130,13 +140,50 @@ def _janitor_pass(now=None):
     return len(stale)
 
 
-def start_janitor(interval=600):
+def _uncollected_pass(now=None):
+    """Email about workbooks that were built and then never picked up.
+
+    Everything else in this app alerts on something raising. This one alerts on
+    a run where nothing raised: the cases came back, the file got written, and
+    the staffer never saw any of it because their end of the conversation
+    dropped. Without this the failure is invisible until someone complains.
+    """
+    now = now if now is not None else time.time()
+    with _jobs_lock:
+        orphans = [job for job in _jobs.values()
+                   if job.kind == 'crs' and job.status == DONE
+                   and not job.collected and not job.reported_uncollected
+                   and now - job.updated_at > UNCOLLECTED_AFTER]
+        for job in orphans:
+            job.reported_uncollected = True
+
+    for job in orphans:
+        result = job.result or {}
+        alerts.record(job.id[:8], job.kind, alerts.UNCOLLECTED,
+                      progress=alerts.recent_progress(job),
+                      **{
+                          'cases written': result.get('written_cases'),
+                          'cases requested': result.get('requested_cases'),
+                          'waiting': '%d minutes' % int((now - job.updated_at) / 60),
+                          'note': ("The run itself succeeded. Either the staffer "
+                                   "closed the page before it finished or their "
+                                   "browser lost contact with Napier, so they may "
+                                   "be about to pull the same cases a second "
+                                   "time. The workbook is still on the server and "
+                                   "is offered again on Napier's first page for "
+                                   "two hours from the time it was built."),
+                      })
+    return len(orphans)
+
+
+def start_janitor(interval=60):
     def loop():
         while True:
             time.sleep(interval)
-            try:
-                _janitor_pass()
-            except Exception:
-                pass
+            for step in (_janitor_pass, _uncollected_pass):
+                try:
+                    step()
+                except Exception:
+                    pass
 
     threading.Thread(target=loop, name="job-janitor", daemon=True).start()

--- a/tasks.py
+++ b/tasks.py
@@ -94,7 +94,8 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         failures_in_a_row = 0
         not_attempted = []
         for index, case_id in enumerate(case_ids, start=1):
-            job.log("Pulling case %d of %d (%s)..." % (index, len(case_ids), case_id))
+            job.log("Pulling case %d of %d (%s)..." % (index, len(case_ids), case_id),
+                    count=index - 1, total=len(case_ids))
             case = {'id': case_id}
             try:
                 summary, charges, financials = client.case_bundle(case_id)
@@ -143,12 +144,14 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         if not cases:
             raise ValueError("no cases could be read")
 
-        job.log("Building the CRS workbook...")
+        job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
         path = build_workbook(cases, def_name, def_dob, is_lite)
         job.result = {
             "file": path,
             "def_name": def_name,
             "is_lite": is_lite,
+            "written_cases": len(cases),
+            "requested_cases": len(case_ids),
             "failed_cases": failed,
         }
 
@@ -158,7 +161,12 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         else:
             job.log("Done. %d case%s written."
                     % (len(cases), "" if len(cases) == 1 else "s"))
-        return "/job/%s/download" % job.id
+        # The finish page, not the file. Sending the browser straight at the
+        # download meant the line above -- the one naming the cases that are
+        # missing from the workbook -- flashed past and was gone, and a staffer
+        # who lost the file to a full disk or a stray click had to burn another
+        # ICOS session to get it back.
+        return "/done/%s" % job.id
     finally:
         # The session was claimed, so nothing else will release it.
         client.logoff()

--- a/templates/base.html
+++ b/templates/base.html
@@ -205,6 +205,11 @@ input[type=text]:focus, input[type=password]:focus {
 
 /* --- buttons ----------------------------------------------------------- */
 
+/* A class that sets display beats the browser's own rule for the hidden
+   attribute, so anything laid out with flex ignores being hidden until this
+   says otherwise. */
+[hidden] { display: none !important; }
+
 .actions {
   display: flex;
   gap: .65rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{% block title %}Napier{% endblock %}</title>
+<!-- Drawn here rather than served, so a run that takes fifteen minutes is
+     findable among a row of identical blank tabs without costing a request. -->
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%2317314f'/><path d='M10 23V9h3.1l5.8 8.4V9H22v14h-3.1L13.1 14.6V23z' fill='%23b98900'/></svg>">
 <style>
 /* Everything the page needs is in this file. Nothing is fetched from a CDN.
    Legal aid offices sit behind filtered networks, and the previous version

--- a/templates/done.html
+++ b/templates/done.html
@@ -1,0 +1,119 @@
+{% extends 'base.html' %}
+{% block title %}Ready: Napier{% endblock %}
+
+{% block head %}
+<style>
+.done-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--brand-bright) 14%, var(--surface));
+  color: var(--brand-bright);
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: .7rem;
+}
+
+.file {
+  display: flex;
+  align-items: center;
+  gap: .8rem;
+  padding: .85rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--line-soft);
+  margin-bottom: 1.3rem;
+}
+
+.file-name {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.file-what {
+  display: block;
+  font-size: .84rem;
+  font-weight: 400;
+  color: var(--ink-soft);
+}
+
+.missing {
+  list-style: none;
+  margin: .6rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+}
+
+.missing li {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .82rem;
+  background: var(--surface);
+  border: 1px solid var(--warn-line);
+  border-radius: 5px;
+  padding: .12rem .45rem;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card">
+  <span class="done-mark" aria-hidden="true">&check;</span>
+  <h1>The workbook is ready</h1>
+  <p class="lede">
+    The download starts on its own. If your browser blocked it, use the button.
+  </p>
+
+  <div class="file">
+    <span class="file-name">
+      {{ filename }}
+      <span class="file-what">
+        {{ "Lite" if is_lite else "Full" }} criminal record summary for
+        {{ def_name }}, {{ written }} case{{ written | pluralize("","s") }}.
+      </span>
+    </span>
+  </div>
+
+  {% if failed %}
+    <div class="notice" role="alert">
+      <p class="notice-title">
+        {{ failed | length }} case{{ failed | length | pluralize("","s") }}
+        {{ "is" if failed | length == 1 else "are" }} missing from this workbook.
+      </p>
+      <p>
+        Iowa Courts would not give {{ "it" if failed | length == 1 else "them" }}
+        up, or the page could not be read. The other {{ written }} of
+        {{ requested }} are in the file. Look
+        {{ "this one" if failed | length == 1 else "these" }} up by hand before
+        you rely on the summary being complete.
+      </p>
+      <ul class="missing">
+        {% for case_id in failed %}<li>{{ case_id }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <div class="actions">
+    <a href="/job/{{ job.id }}/download" class="btn btn-primary" id="again">Download the workbook</a>
+    <a href="/logout" class="btn btn-quiet">Search for someone else</a>
+  </div>
+
+  <p class="lede" style="margin:1.2rem 0 0">
+    This page keeps working for two hours, so you can come back and download the
+    file again without running the search a second time.
+  </p>
+</div>
+
+<iframe id="grab" title="download" hidden></iframe>
+
+<script>
+// Fetching it into a hidden frame keeps this page on screen, so the missing
+// case list above stays readable instead of being replaced by a file save.
+document.getElementById("grab").src = "/job/" +
+  encodeURIComponent({{ job.id|tojson }}) + "/download";
+</script>
+{% endblock %}

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -108,7 +108,12 @@ summary::marker { color: var(--ink-faint); }
   <p id="status" class="status" role="status" aria-live="polite">{{ job.message }}</p>
   <p id="elapsed" class="elapsed"></p>
 
+  <div id="warn" class="notice" role="status" hidden></div>
   <div id="failed" class="notice notice-stop" role="alert" hidden></div>
+
+  <div id="recheck" class="actions" hidden>
+    <button type="button" class="btn" id="recheck-btn">Check again</button>
+  </div>
 
   <details>
     <summary>Show what it has done so far</summary>
@@ -124,6 +129,20 @@ summary::marker { color: var(--ink-faint); }
 var jobId = {{ job.id|tojson }};
 var started = Date.now();
 var timer = null;
+
+// The run happens on the server and this page only watches it. A phone that
+// drops off the network for ten seconds, or locks its screen mid-poll, used to
+// end the run on screen while it carried on and finished out of sight, and the
+// only button left logged the browser out and took the finished workbook with
+// it. So a poll that does not come back is a connection problem until proven
+// otherwise, and the page keeps asking.
+var misses = 0;
+// About a minute and a half of asking before it stops on its own, which is
+// longer than most runs take to finish in the first place.
+var GIVE_UP_AFTER = 12;
+var waiting = false;
+var next = null;
+var lostSince = null;
 
 function tick() {
   var s = Math.round((Date.now() - started) / 1000);
@@ -177,21 +196,87 @@ function stop(headline, message) {
   }
 }
 
+function warn(message) {
+  var box = document.getElementById("warn");
+  box.textContent = message || "";
+  box.hidden = !message;
+}
+
+function later(seconds) {
+  if (next) { clearTimeout(next); }
+  next = setTimeout(poll, seconds * 1000);
+}
+
+function report() {
+  // Sent on the way back, since a page with no connection cannot report having
+  // no connection. Nobody would otherwise hear that a working run looked broken
+  // to the person watching it.
+  if (!lostSince) { return; }
+  var seconds = Math.round((Date.now() - lostSince) / 1000);
+  lostSince = null;
+  fetch("/job/" + encodeURIComponent(jobId) + "/lost", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ seconds: seconds })
+  }).catch(function () { /* diagnostics never get in the way of the run */ });
+}
+
+function missed() {
+  misses += 1;
+  if (!lostSince) { lostSince = Date.now(); }
+  if (misses >= GIVE_UP_AFTER) {
+    stop("Still waiting on Napier",
+         "This page cannot reach Napier. The run itself is on the server and " +
+         "is very likely finished, so check again once you have a signal " +
+         "rather than starting over.");
+    document.getElementById("recheck").hidden = false;
+    return;
+  }
+  warn("Lost the connection to this page. Napier is still working on the " +
+       "server, and this page is trying again.");
+  // Backs off so a phone in a lift is not asking every two seconds, and caps
+  // low enough that the page catches up quickly once the signal returns.
+  later(Math.min(10, 2 * misses));
+}
+
+function resume() {
+  document.getElementById("recheck").hidden = true;
+  document.getElementById("failed").hidden = true;
+  document.getElementById("track").hidden = false;
+  document.getElementById("elapsed").hidden = false;
+  document.getElementById("headline").textContent = "Working on it";
+  misses = 0;
+  if (!timer) { timer = setInterval(tick, 1000); }
+  poll();
+}
+
 function poll() {
+  if (waiting) { return; }
+  waiting = true;
   fetch("/job/" + encodeURIComponent(jobId), {
     headers: { "Accept": "application/json" }
   }).then(function (response) {
     return response.json().catch(function () { return null; })
-      .then(function (state) { return { ok: response.ok, state: state }; });
+      .then(function (state) { return { status: response.status, state: state }; });
   }).then(function (result) {
+    waiting = false;
     var state = result.state;
-    // A restarted dyno loses in-flight searches, and the server says so in the
-    // body of a 410. Say the same thing rather than spinning forever.
-    if (!result.ok || !state) {
-      stop("Search stopped", (state && state.error) ||
-           "Lost contact with Napier. Please run the search again.");
+    // 410 is the server itself saying this job is gone: a restarted dyno lost
+    // it, or it belongs to another browser. That is the one answer worth
+    // believing, because asking again will never produce a different one.
+    if (result.status === 410 && state && state.error) {
+      stop("Search stopped", state.error);
       return;
     }
+    // Anything else that is not a job is the network or Heroku in the way, not
+    // an answer about the job.
+    if (!state || !state.status) {
+      missed();
+      return;
+    }
+    misses = 0;
+    warn(null);
+    report();
     render(state);
     if (state.status === "done") {
       stop("Finished", null);
@@ -202,12 +287,22 @@ function poll() {
       stop("Search stopped", state.error);
       return;
     }
-    setTimeout(poll, 2000);
+    later(2);
   }).catch(function () {
-    stop("Search stopped",
-         "Lost contact with Napier. Please run the search again.");
+    waiting = false;
+    missed();
   });
 }
+
+document.getElementById("recheck-btn").addEventListener("click", resume);
+
+// A locked screen or a backgrounded tab suspends the timer above, and the
+// network coming back is the moment worth asking again rather than waiting out
+// whatever backoff was running when it went away.
+window.addEventListener("online", function () { if (misses) { resume(); } });
+document.addEventListener("visibilitychange", function () {
+  if (!document.hidden && misses) { resume(); }
+});
 
 tick();
 timer = setInterval(tick, 1000);

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -19,6 +19,13 @@
   animation: slide 1.5s ease-in-out infinite;
 }
 
+/* Once the job knows how many cases it is pulling, the bar stops pretending
+   and starts measuring. */
+.track-fill.measured {
+  animation: none;
+  transition: width .3s ease-out;
+}
+
 @keyframes slide {
   0%   { transform: translateX(-100%); }
   100% { transform: translateX(300%); }
@@ -94,7 +101,9 @@ summary::marker { color: var(--ink-faint); }
     the work carries on. Iowa Courts is slow at times and Napier waits it out.
   </p>
 
-  <div id="track" class="track"><div class="track-fill"></div></div>
+  <div id="track" class="track" role="progressbar" aria-label="Search progress">
+    <div id="fill" class="track-fill"></div>
+  </div>
 
   <p id="status" class="status" role="status" aria-live="polite">{{ job.message }}</p>
   <p id="elapsed" class="elapsed"></p>
@@ -131,6 +140,21 @@ function tick() {
 
 function render(state) {
   document.getElementById("status").textContent = state.message || "";
+
+  // A CRS run is measurable and a search is not, so only claim a number when
+  // the server gave one.
+  var track = document.getElementById("track");
+  var fill = document.getElementById("fill");
+  if (state.total) {
+    var pct = Math.round((state.count || 0) / state.total * 100);
+    fill.className = "track-fill measured";
+    fill.style.width = Math.max(pct, 3) + "%";
+    track.setAttribute("aria-valuenow", String(pct));
+    // Staff open this, then go do other work. The tab label is the only part
+    // of the page they can still see once it is in the background.
+    document.title = (state.count || 0) + " of " + state.total + " cases: Napier";
+  }
+
   var log = document.getElementById("log");
   log.textContent = "";
   (state.progress || []).forEach(function (line) {
@@ -144,6 +168,7 @@ function stop(headline, message) {
   document.getElementById("headline").textContent = headline;
   document.getElementById("track").hidden = true;
   document.getElementById("elapsed").hidden = true;
+  document.title = headline + ": Napier";
   if (timer) { clearInterval(timer); }
   if (message) {
     var box = document.getElementById("failed");

--- a/templates/search.html
+++ b/templates/search.html
@@ -76,6 +76,42 @@
   color: var(--ink-soft);
   margin: 0;
 }
+
+.filter {
+  width: 100%;
+  padding: .55rem .7rem;
+  font: inherit;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  margin-bottom: .8rem;
+}
+
+.filter:focus {
+  outline: none;
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus) 22%, transparent);
+}
+
+.person[hidden] { display: none; }
+
+.empty {
+  color: var(--ink-soft);
+  font-size: .9rem;
+  padding: .8rem 0;
+  margin: 0;
+}
+
+/* With sixty names on screen the button is far below the fold, and the count
+   of what is picked is the thing you need while scrolling. */
+.actions-stuck {
+  position: sticky;
+  bottom: 0;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  padding: .9rem 0 .2rem;
+}
 </style>
 {% endblock %}
 
@@ -107,10 +143,20 @@
   {% endif %}
 
   <form id="crs">
+    {% if keys | length > 8 %}
+      <label>
+        <span class="field-label">Narrow the list</span>
+        <input type="search" class="filter" id="filter" autocomplete="off"
+               placeholder="Type part of a name or a date of birth">
+      </label>
+    {% endif %}
+
     <div class="result-head" style="margin-bottom:.6rem">
       <p class="selected-count" id="count">Nothing picked yet</p>
       <button type="button" class="bulk" id="toggle-all">Select all</button>
     </div>
+
+    <p class="empty" id="empty" hidden>No name here matches what you typed.</p>
 
     <div class="people">
       {% for key in keys %}
@@ -128,7 +174,7 @@
       {% endfor %}
     </div>
 
-    <div class="actions">
+    <div class="actions actions-stuck">
       <button id="crs-submit-button" type="submit" class="btn btn-primary">Create the CRS</button>
       <a href="/logout" class="btn btn-quiet">Start a new search</a>
     </div>
@@ -144,6 +190,8 @@ var button = document.getElementById("crs-submit-button");
 var statusBox = document.getElementById("status");
 var countLine = document.getElementById("count");
 var toggleAll = document.getElementById("toggle-all");
+var filterBox = document.getElementById("filter");
+var emptyLine = document.getElementById("empty");
 
 function boxes() {
   return Array.prototype.slice.call(
@@ -154,12 +202,45 @@ function picked() {
   return boxes().filter(function (b) { return b.checked; });
 }
 
+function shown() {
+  return boxes().filter(function (b) { return !b.closest(".person").hidden; });
+}
+
 function refresh() {
   var n = picked().length;
-  countLine.textContent = n === 0
+  var text = n === 0
     ? "Nothing picked yet"
     : n + (n === 1 ? " name picked" : " names picked");
-  toggleAll.textContent = n === boxes().length && n > 0 ? "Clear all" : "Select all";
+
+  // A name stays checked when the filter hides it, and it still goes into the
+  // workbook. Saying so beats a surprise in the finished file.
+  var hiddenPicks = picked().filter(function (b) {
+    return b.closest(".person").hidden;
+  }).length;
+  if (hiddenPicks) {
+    text += " (" + hiddenPicks + " not shown here)";
+  }
+  countLine.textContent = text;
+
+  var visible = shown();
+  var allOn = visible.length > 0 && visible.every(function (b) { return b.checked; });
+  toggleAll.textContent = allOn ? "Clear all" : "Select all";
+  toggleAll.hidden = visible.length === 0;
+}
+
+if (filterBox) {
+  filterBox.addEventListener("input", function () {
+    var needle = filterBox.value.trim().toLowerCase();
+    var visible = 0;
+    boxes().forEach(function (b) {
+      var row = b.closest(".person");
+      var match = !needle || row.textContent.toLowerCase().indexOf(needle) !== -1;
+      row.hidden = !match;
+      if (match) { visible++; }
+    });
+    emptyLine.hidden = visible !== 0;
+    refresh();
+  });
 }
 
 function say(message) {
@@ -169,9 +250,12 @@ function say(message) {
 
 form.addEventListener("change", refresh);
 
+// Acts on what is on screen. With a filter applied, "select all" meaning
+// "including the forty you filtered out" would be a trap.
 toggleAll.addEventListener("click", function () {
-  var turnOn = picked().length !== boxes().length;
-  boxes().forEach(function (b) { b.checked = turnOn; });
+  var visible = shown();
+  var turnOn = !visible.every(function (b) { return b.checked; });
+  visible.forEach(function (b) { b.checked = turnOn; });
   refresh();
 });
 

--- a/templates/start.html
+++ b/templates/start.html
@@ -46,6 +46,13 @@
                  autocomplete="current-password" required>
         </label>
       </div>
+      <label class="check" style="margin-top:.8rem">
+        <input type="checkbox" id="remember">
+        <span class="check-text">
+          Remember my user ID on this computer
+          <span class="check-note">The user ID only. The password is never stored.</span>
+        </span>
+      </label>
     </fieldset>
 
     <fieldset>
@@ -63,4 +70,34 @@
     </div>
   </form>
 </div>
+
+<script>
+// The shared ICOS user IDs get retyped a dozen times a day. Only the ID is
+// kept, only when asked for, and nothing about the client ever is: the names
+// staff search for are privileged and have no business sitting in a browser
+// store on a machine other people use.
+(function () {
+  var KEY = "napier.userid";
+  var user = document.querySelector("input[name='username']");
+  var remember = document.getElementById("remember");
+  var saved = null;
+
+  try { saved = window.localStorage.getItem(KEY); } catch (e) { return; }
+
+  if (saved) {
+    user.value = saved;
+    remember.checked = true;
+  }
+
+  document.querySelector("form").addEventListener("submit", function () {
+    try {
+      if (remember.checked && user.value) {
+        window.localStorage.setItem(KEY, user.value);
+      } else {
+        window.localStorage.removeItem(KEY);
+      }
+    } catch (e) { /* private window, or storage is full. Not worth a message. */ }
+  });
+})();
+</script>
 {% endblock %}

--- a/templates/start.html
+++ b/templates/start.html
@@ -13,6 +13,21 @@
     <div class="notice notice-stop" role="alert">{{ error }}</div>
   {% endif %}
 
+  {# A run whose progress page died still built its workbook. Offering it here
+     is the difference between one wasted minute and signing back in to pull
+     every case a second time. #}
+  {% if waiting_job %}
+    <div class="notice" role="status">
+      <p class="notice-title">You have a workbook waiting</p>
+      <p>
+        Napier finished a criminal record summary for
+        {{ waiting_job.result.def_name }} and nothing has downloaded it yet.
+        It keeps for two hours.
+      </p>
+      <p><a href="/done/{{ waiting_job.id }}">Open that workbook</a></p>
+    </div>
+  {% endif %}
+
   <form action="/search" method="post">
     <fieldset>
       <legend>Who are you searching for</legend>

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -102,7 +102,7 @@ class FakeJob:
         self.progress = [{'message': 'Connecting to Iowa Courts Online...'},
                          {'message': 'Iowa Courts is slow, retrying (attempt 4)...'}]
 
-    def log(self, message):
+    def log(self, message, count=None, total=None):
         self.progress.append({'message': message})
 
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -15,6 +15,7 @@ import base64
 import os
 import sys
 import threading
+import time
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -566,3 +567,119 @@ def test_the_web_error_path_cannot_grow_without_bound(mailbox):
     # The survivors are the recent ones.
     assert '/job/0/download' not in alerts._pending
     assert '/job/%d/download' % (alerts.MAX_TRACKED_JOBS * 2 - 1) in alerts._pending
+
+
+# -- a run that succeeded here and failed on the staffer's screen ----------
+
+
+def finished_crs_job(age_seconds, collected=False):
+    """A CRS job that finished and has been sitting there since.
+
+    The real Job class rather than a stub, because the whole point of these two
+    tests is that a run where nothing raised still reaches somebody, and a stub
+    would let a change to how success is recorded pass unnoticed.
+    """
+    import jobs
+    job = jobs.Job('crs')
+    job.status = jobs.DONE
+    job.collected = collected
+    job.result = {'file': '/tmp/x.xlsx', 'def_name': 'TESTER, PAT Q',
+                  'is_lite': False, 'written_cases': 70, 'requested_cases': 70,
+                  'failed_cases': []}
+    job.log("Pulling case 70 of 70 (01311 FECR000000)...")
+    job.log("Done. 70 cases written.")
+    job.updated_at = time.time() - age_seconds
+    with jobs._jobs_lock:
+        jobs._jobs[job.id] = job
+    return job
+
+
+@pytest.fixture(autouse=True)
+def empty_job_store():
+    import jobs
+    with jobs._jobs_lock:
+        jobs._jobs.clear()
+    yield
+    with jobs._jobs_lock:
+        jobs._jobs.clear()
+
+
+def test_a_workbook_nobody_collected_reaches_somebody(mailbox):
+    """The failure this app had no signal for at all.
+
+    Every other alert here fires from something raising. This run raised
+    nothing: the cases came back, the file was written, and the staffer saw a
+    dead page because their phone dropped the connection. Silence looked like
+    success.
+    """
+    import jobs
+    job = finished_crs_job(jobs.UNCOLLECTED_AFTER + 60)
+    assert jobs._uncollected_pass() == 1
+    settle()
+
+    assert len(mailbox) == 1
+    assert alerts.UNCOLLECTED in mailbox[0]['subject']
+    text = mailbox[0]['text']
+    assert '70' in text
+    assert 'pull the same cases a second time' in text
+    # A case number is court public record. The person is not.
+    assert '01311 FECR000000' in text
+    assert 'TESTER' not in text
+    assert job.reported_uncollected is True
+
+
+def test_the_same_workbook_is_only_reported_once(mailbox):
+    import jobs
+    finished_crs_job(jobs.UNCOLLECTED_AFTER + 60)
+    assert jobs._uncollected_pass() == 1
+    assert jobs._uncollected_pass() == 0
+    settle()
+    assert len(mailbox) == 1
+
+
+def test_a_collected_workbook_is_nobody_s_problem(mailbox):
+    import jobs
+    finished_crs_job(jobs.UNCOLLECTED_AFTER + 60, collected=True)
+    assert jobs._uncollected_pass() == 0
+    settle()
+    assert mailbox == []
+
+
+def test_a_workbook_built_a_moment_ago_is_left_alone(mailbox):
+    """Staff take a few seconds to hit download. That is not a failure."""
+    import jobs
+    finished_crs_job(5)
+    assert jobs._uncollected_pass() == 0
+    settle()
+    assert mailbox == []
+
+
+def test_a_page_that_lost_contact_says_so_once_it_can(mailbox):
+    import app as app_module
+    import jobs
+
+    job = finished_crs_job(1)
+    client = app_module.app.test_client()
+    app_module.app.secret_key = 'test'
+    with client.session_transaction() as s:
+        s['job_ids'] = [job.id]
+
+    response = client.post('/job/%s/lost' % job.id, json={'seconds': 47})
+    assert response.status_code == 204
+    settle()
+    assert alerts.CLIENT_LOST in mailbox[0]['subject']
+    assert '47 seconds' in mailbox[0]['text']
+    assert 'The run was not affected' in mailbox[0]['text']
+
+
+def test_another_browser_cannot_make_napier_send_mail(mailbox):
+    """Unauthenticated and free to call, so it is a way to send us email from
+    the outside unless it is gated on owning the job the same as every other
+    job route."""
+    import app as app_module
+    job = finished_crs_job(1)
+    response = app_module.app.test_client().post('/job/%s/lost' % job.id,
+                                                 json={'seconds': 47})
+    assert response.status_code == 204
+    settle()
+    assert mailbox == []

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -37,7 +37,7 @@ class FakeJob:
         self.progress = []
         self.result = None
 
-    def log(self, message):
+    def log(self, message, count=None, total=None):
         self.progress.append({'message': message})
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -18,7 +18,7 @@ import app as app_module
 import icos_sessions
 import jobs
 import tasks
-from icos import IcosBadCredentials
+from icos import IcosBadCredentials, IcosError
 
 SEARCH_RESULTS = b"""
 <html><table>
@@ -43,6 +43,7 @@ class FakeClient:
         self.logged_in = False
         self.logged_off = False
         self.cases = []
+        self.fail_cases = []
         FakeClient.instances.append(self)
 
     def set_alert(self, alert):
@@ -63,6 +64,8 @@ class FakeClient:
 
     def case_bundle(self, case_id):
         self.cases.append(case_id)
+        if case_id in self.fail_cases:
+            raise IcosError("Iowa Courts did not answer for this case.")
         return b"<summary>", b"<charges>", b"<financials>"
 
     def logoff(self):
@@ -192,17 +195,57 @@ def test_crs_job_pulls_cases_and_offers_a_download(client):
     crs_job_id = response.get_json()['job_id']
     state = await_job(client, crs_job_id)
     assert state['status'] == 'done'
-    assert state['next_url'] == '/job/%s/download' % crs_job_id
+    assert state['next_url'] == '/done/%s' % crs_job_id
 
     search_client = FakeClient.instances[0]
     assert search_client.cases == ['01311 FECR000000', '01311 SRCR012345']
     # The workbook is built server-side, so closing the laptop no longer costs
     # staff the run.
     assert any('Pulling case 1 of 2' in line for line in state['progress'])
+    assert state['total'] == 2
 
-    download = client.get(state['next_url'])
+    finished = client.get(state['next_url'])
+    assert finished.status_code == 200
+    page = finished.get_data(as_text=True)
+    assert '/job/%s/download' % crs_job_id in page
+
+    download = client.get('/job/%s/download' % crs_job_id)
     assert download.status_code == 200
     assert 'TESTER' in download.headers['Content-Disposition']
+
+
+def test_the_finish_page_names_the_cases_missing_from_the_workbook(client):
+    """A case Iowa Courts would not give up is left out of the file. Staff have
+    to be told which one, or they will read a short summary as a complete one."""
+    search_job_id, _ = run_search(client)
+    client.get('/results/' + search_job_id)
+    FakeClient.instances[0].fail_cases = ['01311 SRCR012345']
+
+    response = client.post('/crs-job', json={
+        'search_job_id': search_job_id,
+        'keys': ['1900-01-01 TESTER, PAT Q'],
+    })
+    state = await_job(client, response.get_json()['job_id'])
+    assert state['status'] == 'done'
+
+    page = client.get(state['next_url']).get_data(as_text=True)
+    assert '01311 SRCR012345' in page
+    assert 'missing from this workbook' in page
+
+
+def test_the_finish_page_needs_the_session_that_made_the_job(client):
+    search_job_id, _ = run_search(client)
+    client.get('/results/' + search_job_id)
+    response = client.post('/crs-job', json={
+        'search_job_id': search_job_id,
+        'keys': ['1900-01-01 TESTER, PAT Q'],
+    })
+    job_id = response.get_json()['job_id']
+    await_job(client, job_id)
+
+    client.get('/logout')
+    page = client.get('/done/' + job_id).get_data(as_text=True)
+    assert 'workbook is ready' not in page
 
 
 def test_crs_job_always_releases_the_session(client):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -312,3 +312,47 @@ def test_download_rejects_a_path_outside_tmp(client):
 
     jobs.get(crs_job_id).result['file'] = '/etc/passwd'
     assert 'invalid file' in client.get('/job/%s/download' % crs_job_id).get_data(as_text=True)
+
+
+def build_a_workbook(client):
+    search_job_id, _ = run_search(client)
+    client.get('/results/' + search_job_id)
+    response = client.post('/crs-job', json={
+        'search_job_id': search_job_id,
+        'keys': ['1900-01-01 TESTER, PAT Q'],
+    })
+    crs_job_id = response.get_json()['job_id']
+    await_job(client, crs_job_id)
+    return crs_job_id
+
+
+def test_a_workbook_survives_the_page_that_was_watching_it(client):
+    """A phone that loses signal ends the run on screen while it finishes on the
+    server. Without a way back to the file, the only option was to sign in and
+    pull every case a second time."""
+    crs_job_id = build_a_workbook(client)
+
+    page = client.get('/').get_data(as_text=True)
+    assert 'workbook waiting' in page
+    assert '/done/%s' % crs_job_id in page
+
+
+def test_the_offer_goes_away_once_the_file_has_been_collected(client):
+    crs_job_id = build_a_workbook(client)
+    client.get('/job/%s/download' % crs_job_id)
+    assert 'workbook waiting' not in client.get('/').get_data(as_text=True)
+
+
+def test_the_offer_is_made_on_the_page_that_says_the_search_is_gone(client):
+    """The dyno-restart page is where a staffer lands after the thing they were
+    watching died, which is exactly when the workbook is worth mentioning."""
+    crs_job_id = build_a_workbook(client)
+    page = client.get('/progress/nosuchjob').get_data(as_text=True)
+    assert 'workbook waiting' in page
+    assert '/done/%s' % crs_job_id in page
+
+
+def test_one_browser_is_never_offered_another_s_workbook(client):
+    build_a_workbook(client)
+    other = app_module.app.test_client()
+    assert 'workbook waiting' not in other.get('/').get_data(as_text=True)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -214,6 +214,17 @@ def test_crs_job_pulls_cases_and_offers_a_download(client):
     assert 'TESTER' in download.headers['Content-Disposition']
 
 
+def test_a_user_id_typed_on_a_phone_still_signs_in(client):
+    """Autofill and phone keyboards put a space around the user ID. It used to
+    ride through to ICOS, which answered like a wrong password."""
+    response = client.post('/search', data={
+        'username': '  ILA01  ', 'password': 'secret',
+        'firstname': 'PAT', 'middlename': '', 'lastname': 'TESTER',
+    })
+    assert response.status_code == 302
+    assert '/progress/' in response.headers['Location']
+
+
 def test_the_finish_page_names_the_cases_missing_from_the_workbook(client):
     """A case Iowa Courts would not give up is left out of the file. Staff have
     to be told which one, or they will read a short summary as a complete one."""

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -45,6 +45,7 @@ class FakeReader:
     def __init__(self, script):
         self.script = list(script)
         self.calls = []
+        self.credentials = []
 
     def fetch_once(self, url, data=None, timeout=8):
         name = url.rsplit("/", 1)[-1].split("?")[0]
@@ -57,6 +58,7 @@ class FakeReader:
 
     def login_request(self, username, password):
         assert password, "login must actually carry the password"
+        self.credentials.append((username, password))
         return "https://icos/ESAWebApp/EUACustomLoginServlet", "userid=" + username
 
     def logoff_request(self):
@@ -154,8 +156,62 @@ def test_unmarked_rejection_is_not_mistaken_for_success():
     ])
     with pytest.raises(IcosBadCredentials) as excinfo:
         client.login("ILA99", "dummy")
-    assert "check them and try again" in excinfo.value.message.lower()
+    said = excinfo.value.message.lower()
+    # ESA did not say why, so neither should we. Naming the password sends
+    # staff off to reset one that was never wrong.
+    assert "check the user id and password" in said
+    assert "still be signed in" in said
     assert client.logged_in is False
+
+
+def test_a_password_with_a_stray_space_gets_one_more_try():
+    """Phone keyboards and autofill add a trailing space, and ESA answers that
+    with the same unmarked page it uses for a wrong password. Staff were being
+    sent to reset a password that worked."""
+    client, _, _ = build([
+        FetchResult(OK, LOGIN_OK),                # ESALogin.jsp
+        FetchResult(OK, b"<html>ESA Login</html>"),  # rejected as typed
+        FetchResult(OK, LOGIN_OK),                # accepted once trimmed
+    ])
+    client.login("ILA99", "correcthorse ")
+    assert client.logged_in is True
+    assert client.reader.credentials == [("ILA99", "correcthorse "),
+                                         ("ILA99", "correcthorse")]
+
+
+def test_the_trimmed_retry_happens_only_once():
+    client, _, _ = build([
+        FetchResult(OK, LOGIN_OK),
+        FetchResult(OK, b"<html>ESA Login</html>"),
+        FetchResult(OK, b"<html>ESA Login</html>"),
+    ])
+    with pytest.raises(IcosBadCredentials):
+        client.login("ILA99", "wrong ")
+    assert len(client.reader.credentials) == 2
+
+
+def test_a_clean_password_is_not_retried():
+    client, _, _ = build([
+        FetchResult(OK, LOGIN_OK),
+        FetchResult(OK, b"<html>ESA Login</html>"),
+    ])
+    with pytest.raises(IcosBadCredentials):
+        client.login("ILA99", "wrong")
+    assert len(client.reader.credentials) == 1
+
+
+def test_the_login_page_text_is_logged_without_the_user_id(capsys):
+    """Only the length of this page was ever recorded, which is why a wrong
+    user ID and an account still signed in elsewhere look identical."""
+    client, _, _ = build([
+        FetchResult(OK, LOGIN_OK),
+        FetchResult(OK, b"<html><body>Sign on failed for ILA99</body></html>"),
+    ])
+    with pytest.raises(IcosBadCredentials):
+        client.login("ILA99", "dummy")
+    logged = capsys.readouterr().out
+    assert "Sign on failed for" in logged
+    assert "ILA99" not in logged
 
 
 def test_full_size_login_page_is_accepted():


### PR DESCRIPTION
Three things came out of testing on staging this morning, and two of them were real failures staff would have hit.

## A dropped poll threw away a finished run

A 70 case run on a phone showed `Lost contact with Napier. Please run the search again.` at case 8. The server had not failed. Its polls reached Heroku at 10:29:43, :45, :47 and :49, the next one never arrived, and the run carried on and logged `Done. 70 cases written.` at 10:30:15 before releasing the ESA session cleanly. The workbook existed the whole time. The page had already declared the run dead, and the only button it offered logs the browser out, which destroyed the session's claim on the job holding the file.

One missed poll was fatal and permanent, because the page could not tell a phone losing signal from the server saying the job was gone.

Now it can. A 410 carrying an error is the server's own answer and is believed. Anything else, a rejected fetch, a Heroku error page, a response that is not a job, is the connection in the way, so the page keeps asking, backs off to ten seconds, and says the run is still going. Coming back online or returning to the tab retries immediately rather than waiting out the backoff. After about ninety seconds it stops, but it stops by saying the run is very likely finished and offering a button that picks the conversation back up.

The workbook is also no longer reachable from one page only. Any browser that started a finished CRS run nobody has downloaded is offered it again by name for the two hours the job lives, including on the page that says the search is gone.

## Nothing alerted, because nothing raised

Every alert in this app fires from an exception. This run had none, so it was silent. Two signals close that.

A CRS job that built a workbook nobody collected within five minutes emails, carrying the case counts and the progress tail. No defendant name, no date of birth. It is the only trace a run like this leaves.

The progress page also reports its own outage once it can talk again, which is the only way to find out how often staff watch a working run appear to die and never mention it. Gated on owning the job, so it is not an open way to make Napier send mail.

## Sign in refused valid credentials

ESA answered two attempts with a 692 byte page carrying neither the bad credential marker nor the concurrent login marker, and the size backstop told someone with working credentials that their password was wrong.

The user ID is now stripped, since an ESA user ID is `ILA##` or `drakelegalclinic` and never contains a space, so anything around it came from a phone keyboard or autofill. Left alone it passed the `ILA` prefix check, reached ESA as an unknown user, and came back looking exactly like a wrong password. A password with whitespace around it is sent as typed first and only retried trimmed if ESA refuses, so one that legitimately ends in a space is never quietly altered. The refusal page is logged as text with the user ID taken back out, because at that length a wrong user ID and an account still signed in elsewhere are the same number, which is why this could not be diagnosed from the logs.

The message no longer claims to know which credential was wrong. It names the likelier cause, an account still signed in from an earlier search, which ESA clears in about 15 minutes.

## The finish page

`next_url` pointed at the download, so a CRS run had no completion screen. The line naming cases Iowa Courts would not give up was written and destroyed about a second later by the file save, and staff who lost the file to a stray click had to burn another ESA session to get it back. There is now a finish page that names the file, states how many cases are in it, lists any that are missing before you rely on the summary being complete, and keeps working for two hours.

Alongside it: the progress bar measures instead of animating, since the job already knew the counts; the tab title carries the count for a run left in the background; the results list filters when there are more than eight names, and says so when a checked name is hidden by the filter; a favicon drawn inline; and opt in memory for the user ID, which stores the ID and nothing about the client.

## Also

`.actions` sets `display: flex`, which beats the browser's own rule for the `hidden` attribute, so the recovery button was visible on every healthy run until `[hidden]` was given the last word. Caught by looking at the page rather than at the markup.

## Verified

162 passed, 1 xfailed.

The client side is JavaScript and pytest cannot see it, so it was driven against a running app with the poll cut mid run. The amber notice appears and the bar keeps its place; restoring the connection catches up on its own from 21 of 70 to 62 of 70; the give up state lands with the button; the button recovers the page and resumes polling. The lost contact report reached the server on both recoveries.
