### PR TITLE
Stop a stranger's convictions landing in the client's record

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -31,6 +31,17 @@ def _dump(name, html):
     with open(os.path.join(tmp_dir, secure_filename(name)), 'w') as text_file:
         text_file.write(html)
 
+def _cell_words(cell):
+    """A table cell's words with ICOS's padding taken out.
+
+    The date of birth two columns to the left of the role arrives wrapped in
+    CRLFs and tabs on the one real search page we have, and the role cell on
+    that same row happens to arrive clean. Matching a role against a list of
+    exact strings works only for as long as that stays true, and the day it
+    stops, every non-party role passes the check at once and nothing says so.
+    """
+    return ' '.join(cell.get_text().split())
+
 def parse_search(html):
     html = html.decode('utf-8', errors='ignore')
     _dump("search_results.html", html)
@@ -50,7 +61,7 @@ def parse_search(html):
             # stripped like 'name' above; ICOS pads every cell with
             # CRLFs and tabs, and a caller comparing to a real date loses.
             'dob': cols[4].string.replace(u'\xa0', u'').strip(),
-            'role': cols[5].string
+            'role': _cell_words(cols[5])
         }
         if case['id'] == 'Case ID':
             continue
@@ -96,8 +107,19 @@ def parse_search(html):
             'INTERVENOR', 
             'JUDGE', 
             'LIEN FILER', 
-            'NAME OF TRUST', 
-            'OBLIGOR', 
+            'NAME OF TRUST',
+            # Someone who filed a document into a case they are not party to,
+            # which is why the charges and the money on that page belong to
+            # somebody else. The charge parser takes every row on the page,
+            # since in the ordinary case the person searched for is the
+            # defendant and there is nothing to separate out, so a case
+            # reaching it under this role puts a stranger's convictions in the
+            # client's record summary. The 'NO ACCESS' half is the filer's
+            # access level to the case file rather than part of the role, so
+            # both spellings are listed.
+            'NO ACCESS NONPARTY FILER',
+            'NONPARTY FILER',
+            'OBLIGOR',
             'OBLIGEE',
             'PAYOR',
             'PAYEE',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -36,10 +36,11 @@ def ids(cases):
 def test_the_search_page_parses_into_one_row_per_party_case(search_page):
     cases, too_many = case_parser.parse_search(search_page)
     assert too_many is False
-    # The INTERESTED PARTY row is dropped; the other four are parties.
+    # The INTERESTED PARTY and NO ACCESS NONPARTY FILER rows are dropped as
+    # people who touched a case without being charged in it. The other four
+    # are parties.
     assert ids(cases) == ['00000  FECR000000', '00000  SMCR000001',
-                          '00000  SCSC000002', '00000  LACV000004',
-                          '00000  SRCR000005']
+                          '00000  SCSC000002', '00000  SRCR000005']
 
 
 def test_a_date_of_birth_arrives_without_the_padding_icos_wraps_it_in(search_page):
@@ -67,8 +68,7 @@ def test_two_people_sharing_a_surname_do_not_become_one_person(search_page):
     sam = [k for k in keys if k.startswith('1901-02-02')]
     unknown = [k for k in keys if k.startswith('DOB-UNKNOWN')]
     assert len(pat) == len(sam) == len(unknown) == 1
-    assert grouped[pat[0]] == ['00000  FECR000000', '00000  LACV000004',
-                               '00000  SRCR000005']
+    assert grouped[pat[0]] == ['00000  FECR000000', '00000  SRCR000005']
     assert grouped[sam[0]] == ['00000  SMCR000001']
     assert grouped[unknown[0]] == ['00000  SCSC000002']
 
@@ -78,16 +78,56 @@ def test_a_pro_se_defendant_is_still_a_defendant(search_page):
     assert '00000  SRCR000005' in ids(cases)
 
 
-@pytest.mark.xfail(reason='NO ACCESS NONPARTY FILER is missing from '
-                          'non_party_designations, so a case where the subject '
-                          'only filed something is scraped as if they were a '
-                          'party. Found on a real search page 2026-07-30; '
-                          'left failing until Ari confirms it should be '
-                          'suppressed.',
-                   strict=True)
 def test_a_nonparty_filer_is_not_a_party(search_page):
+    """Filing one document into a case is not being charged in it.
+
+    This role turned up on a real search page on 2026-07-30 and was not in the
+    suppression list, so the case was pulled as if the client were a party to
+    it. `parse_case_charges` reads every charge row on a case page and does no
+    filtering by person, because in the ordinary case the person searched for
+    is the defendant, so the effect was to write the actual defendant's
+    charges and court debt into this client's record summary.
+    """
     cases, _ = case_parser.parse_search(search_page)
     assert '00000  LACV000004' not in ids(cases)
+
+
+def role_row(role):
+    """One results row carrying the given role, otherwise well formed."""
+    return ("""<html><body><table>
+      <tr><td>00000&nbsp;&nbsp;FECR000000</td><td>Case ID</td>
+          <td>STATE VS TESTER</td><td>TESTER, PAT Q</td>
+          <td>01/01/1900</td><td>%s</td></tr>
+      </table></body></html>""" % role).encode('utf-8')
+
+
+# ICOS pads the date of birth cell with CRLFs and tabs on the real page and
+# leaves the role cell alone, which is the only reason matching roles against
+# exact strings has ever worked. If that ever flips, every one of these roles
+# starts being read as a party at once, and a suppression list that silently
+# stops suppressing looks exactly like a list that had nothing to suppress.
+PADDED_ROLES = [
+    'NO ACCESS NONPARTY FILER',
+    '\r\n\t\tNO ACCESS NONPARTY FILER\r\n\t\t',
+    '&nbsp;NO ACCESS NONPARTY FILER',
+    '  NO ACCESS  NONPARTY  FILER  ',
+    '<font size="2">\r\n\tNO ACCESS NONPARTY FILER\r\n\t</font>',
+    'INTERESTED PARTY',
+    '\r\n\t\tINTERESTED PARTY\t\r\n',
+]
+
+
+@pytest.mark.parametrize('role', PADDED_ROLES)
+def test_padding_around_a_role_does_not_turn_it_into_a_party(role):
+    cases, _ = case_parser.parse_search(role_row(role))
+    assert cases == []
+
+
+def test_a_padded_defendant_is_still_read_as_a_defendant():
+    """The normalizing must not swallow the roles we want to keep."""
+    cases, _ = case_parser.parse_search(role_row('\r\n\tDEFENDANT\r\n\t'))
+    assert ids(cases) == ['00000  FECR000000']
+    assert cases[0]['role'] == 'DEFENDANT'
 
 
 # -- what gets written to disk --------------------------------------------


### PR DESCRIPTION
`NO ACCESS NONPARTY FILER` is a person who filed a document into a case they are not party to. A records custodian answering a subpoena, a lienholder, someone moving to quash. The `NO ACCESS` half is their access level to the case file rather than part of the role. They are not the defendant, they have no charges, and they owe the court nothing on that case.

The role turned up on a real search page on 2026-07-30 and was not in `non_party_designations`, so the case was pulled as if the client were a party to it.

## Why the extra row is not the damage

`parse_case_charges` reads every charge row on a case page and does no filtering by person. It has never needed to, because in the ordinary case the person searched for is the defendant and there is nothing to separate out. Under this role that assumption inverts: the charges and the money on that page belong to somebody else, and they get written into this client's criminal record summary with nothing to tell a staffer that one of those rows describes a different human being.

On the search we captured it landed on a civil case, which carries no charges, so the harm there was limited to a spurious row. Nothing stops the role appearing on a criminal case. Filing a motion to quash a subpoena in someone else's felony would do it, and that is the version that puts a stranger's felony conviction in your client's record.

## The list already agreed

`non_party_designations` suppresses INTERESTED PARTY, WITNESS, LIEN FILER, INTERPRETER, and both FILING AGENT roles. Every one is a person who touched a case without being charged in it. This is the same idea, and its absence reads as an oversight in a hand-maintained list rather than a decision anybody made. Both spellings are listed, with and without the access-level prefix.

## The reason it was fragile in the first place

The role was compared against the list raw, while the date of birth two columns to its left has to have CRLFs and tabs stripped off it before anything can use it. Same row, same page, one cell padded and one not. That means forty-odd exact-string comparisons have only ever worked because of a formatting habit nobody has ever checked.

If ICOS starts padding that cell, every non-party role is read as a party at once. There is no error, no log line, and a suppression list that has silently stopped suppressing looks exactly like a list that had nothing to suppress. The role is now normalized before it is matched, and there are tests covering padded, `&nbsp;`-prefixed, double-spaced, and font-wrapped forms, plus one that a padded DEFENDANT is still read as a defendant so the normalizing cannot quietly swallow the roles we want to keep.

## Verified

171 passed.

Not vacuous: with `case_parser.py` reverted to `main` and the new tests kept, 10 fail.

## Worth telling Iowa Legal Aid

This changes what appears in staff workbooks. Two rows drop out of the captured search rather than one. Worth a line to Ari that the suppression list grew, as a notification rather than a question, since any office relying on seeing non-party cases would want to know they stopped appearing.
