### PR TITLE
Report the fees by name and still land on what ICOS says is owed

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -378,14 +378,43 @@ def itemized_financials(case):
     return financials
 
 
+# What the fee columns on a row are worth, said plainly, for the rows where
+# they are not a straight per-fee breakdown. A reconciled row says nothing,
+# because a note on every row is a note nobody reads.
+SUMMARY_ONLY_NOTE = (
+    "Fee columns are ICOS's five summary categories, not a per-fee breakdown. "
+    "The itemization could not be reconciled against them, so sheriff, "
+    "indigent defense, jail and probation fees are inside MISCELLANEOUS "
+    "rather than in their own columns. The ICOS total is still right."
+)
+
+ITEMIZED_ONLY_NOTE = (
+    "ICOS gave no category summary for this case, so the fee columns come "
+    "from the itemization. ICOS leaves the itemization's paid column blank on "
+    "most fees, so anything already paid may still be counted here. Treat "
+    "these as assessed rather than owed."
+)
+
+
 def process_financials(case, worksheet, row):
-    # Prefer ICOS's own per-category balances; fall back to the itemization for
-    # cases where ICOS doesn't break the summary out by category.
-    financials = summary_financials(case)
-    source = 'summary'
-    if not financials:
-        financials = itemized_financials(case)
-        source = 'itemized'
+    # Reconciling the itemization against the summary is the only path that
+    # keeps the fee breakdown and lands on the balance ICOS reports, so it is
+    # tried first. The summary alone is right about the total and collapses
+    # every fee into five buckets. The itemization alone keeps the fees and
+    # overstates whatever has been paid. Both remain as fallbacks, and a row
+    # that used one says so, because a sheriff fee that is missing because it
+    # was folded into MISCELLANEOUS looks exactly like one that was never
+    # charged.
+    financials, note = reconcile_financials(case)
+    source = 'reconciled'
+    if financials is None:
+        financials = summary_financials(case)
+        source = 'summary'
+        note = SUMMARY_ONLY_NOTE
+        if not financials:
+            financials = itemized_financials(case)
+            source = 'itemized'
+            note = ITEMIZED_ONLY_NOTE
 
     total_due = None
     if 'total_due' in case:
@@ -396,22 +425,31 @@ def process_financials(case, worksheet, row):
     if total_due is not None:
         worksheet['U' + str(row)] = total_due
 
+    notes = [note] if note else []
+
     # If the per-category figures still don't add up to the balance ICOS
     # reports, the ICOS figure (column U) is the one to trust -- flag the row so
     # staff don't take the categories at face value.
+    flagged = False
     if total_due is not None:
         categorized = sum(financials.values(), Decimal(0))
         if abs(categorized - total_due) > Decimal('0.01'):
+            flagged = True
             cell_u = worksheet['U' + str(row)]
             cell_u.fill = MISMATCH_FILL
             cell_u.font = MISMATCH_FONT
-            worksheet['V' + str(row)] = (
+            notes.append(
                 "Category fees total $%s but ICOS shows $%s due (%s figures) - trust "
                 "the ICOS total; the difference is usually payments or third-party "
                 "collection fees ICOS no longer counts"
                 % (categorized, total_due, source)
             )
-            worksheet['V' + str(row)].font = MISMATCH_FONT
+
+    if notes:
+        cell_v = worksheet['V' + str(row)]
+        cell_v.value = " ".join(notes)
+        if flagged:
+            cell_v.font = MISMATCH_FONT
 
 def process_case(case, worksheet, row):
     i = str(row)

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -90,25 +90,62 @@ def test_collection_costs_column_is_zero(felony_case):
     assert sheet.value_of('K4') in (None, Decimal('0'), Decimal('0.00'))
 
 
-def test_summary_path_collapses_fee_detail_into_misc(felony_case):
-    """Documents a real cost of preferring the summary, so it stays visible.
+def test_the_written_row_keeps_the_fee_detail(felony_case):
+    """What the summary path used to cost, and no longer does.
 
-    The summary reconciles against the ICOS balance, which is what the reported
-    bug was about. But its five buckets carry no fee detail, so COSTS and OTHER
-    both fall through to MISC and the columns the CRS workbook exists to fill --
-    sheriff, indigent defense, collection fee, revolving fund -- come back empty.
-    The itemization resolves the same case as M=579.00, J=50.00, K=182.85,
-    P=90.00, S=500.00, but overstates the balance by the 182.85 already paid.
-
-    If the reporting strategy changes, this test should fail and force the call.
+    Preferring the summary reconciled against the ICOS balance, which is what
+    the reported bug was about, but its five buckets carry no fee detail: COSTS
+    and OTHER both fell through to MISC and the columns the CRS workbook exists
+    to fill came back empty. Reconciling gets both, so the row now carries the
+    fees by name and still totals to what ICOS says is owed.
     """
     sheet = FakeSheet()
     crs.process_financials(felony_case, sheet, 4)
+    assert sheet.value_of('M4') == Decimal('579.00')   # sheriff fees
+    assert sheet.value_of('J4') == Decimal('50.00')    # indigent defense
+    assert sheet.value_of('P4') == Decimal('90.00')    # revolving fund
+    assert sheet.value_of('S4') == Decimal('500.00')   # restitution
+    assert sheet.value_of('O4') is None                # nothing left to dump in MISC
+    assert sheet.value_of('U4') == Decimal('1219.00')
+
+
+def test_the_summary_path_is_still_there_when_reconciling_fails(felony_case):
+    """A partition that does not add up must fall back, not guess.
+
+    Moving a fee off its assessed amount breaks the bucket check inside
+    `reconcile_financials`, which is the whole safety net: the reconciliation is
+    given up rather than a wrong split being written.
+    """
+    felony_case['financials'][0]['amount'] = '31.00'
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
     assert sheet.value_of('O4') == Decimal('719.00')   # COSTS 629 + OTHER 90
-    assert sheet.value_of('S4') == Decimal('500.00')
-    assert sheet.value_of('M4') is None                # sheriff fees, itemised only
-    assert sheet.value_of('J4') is None                # indigent defense
-    assert sheet.value_of('P4') is None                # revolving fund
+    assert sheet.value_of('M4') is None                # detail is gone, as before
+    assert 'not a per-fee breakdown' in sheet.value_of('V4')
+
+
+def test_a_collapsed_row_says_it_is_collapsed(felony_case):
+    """An empty sheriff column has two meanings and staff cannot see which.
+
+    Folded into MISCELLANEOUS looks exactly like never charged. The row that
+    cannot be reconciled has to say so on its face, since nothing else about it
+    is different.
+    """
+    felony_case['financials'][0]['amount'] = '31.00'
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    note = sheet.value_of('V4')
+    assert 'MISCELLANEOUS' in note
+    assert 'ICOS total is still right' in note
+
+
+def test_the_itemized_fallback_says_the_figures_are_assessed(felony_case):
+    del felony_case['summary_categories']
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    note = sheet.value_of('V4')
+    assert 'no category summary' in note
+    assert 'assessed rather than owed' in note
 
 
 def test_categories_reconcile_against_icos_total(felony_case):


### PR DESCRIPTION
ICOS reports the same money twice on a case page and the two disagree.

The **summary** rolls every fee into five buckets (COSTS, FINE, SURCHARGE, RESTITUTION, OTHER) and reflects payments. Right balance, no fee detail.

The **itemization** names every fee but leaves the Paid column blank on most of them even when they were paid. Right detail, balance too high.

The workbook was taking the summary. On the real felony page that fills column U correctly at 1219.00 and dumps 719.00 into MISCELLANEOUS, leaving sheriff fees, indigent defense and the revolving fund empty. Those columns are much of why the workbook exists. Taking the itemization instead gives them back and totals 1401.85, overstating by the 182.85 revenue fee that had already been paid.

| path | J indigent | K collection | M sheriff | P revolving | S restitution | O misc | total |
|---|---|---|---|---|---|---|---|
| summary | | | | | 500.00 | 719.00 | 1219.00 |
| itemized | 50.00 | 182.85 | 579.00 | 90.00 | 500.00 | | 1401.85 |
| reconciled | 50.00 | | 579.00 | 90.00 | 500.00 | | **1219.00** |

## The third path already existed

`reconcile_financials` has resolved this since a0431f6 and was never called. It partitions the itemization into the summary's five buckets, checks each bucket against what the summary says was assessed there, and only then subtracts the bucket's payment from the lines that account for it.

That bucket check is what makes it safe. A partition that does not add up costs the reconciliation rather than producing a wrong split, which is the right way for this to fail. The 182.85 drops out on its own because OTHER's 272.85 assessed against 182.85 paid has exactly one subset of lines that explains the payment.

It is now first choice, summary second, itemization last.

## A fallback row says it is one

A sheriff fee folded into MISCELLANEOUS looks exactly like a sheriff fee that was never charged, and nothing else on the row distinguishes them.

The summary path now says its columns are category totals rather than a per-fee breakdown. The itemization path says its figures are assessed rather than owed. A reconciled row says nothing, because a note on every row is a note nobody reads.

That went in the existing NOTES column rather than a new one. The template puts array formulas in W through AH under a merged header reading `DO NOT EDIT THESE!!!`, so a source column would have to sit past them at AI, and the template is Iowa Legal Aid's and versioned separately from this code.

## Verified

Against the real template, not just the test double: all three paths write, the note lands in V, the U mismatch flag fires only on the itemized path, and `T4` and the `W1` header survive a save and reopen.

192 passed.

Not vacuous: with `crs.py` reverted to `main` and the tests kept, 4 fail.

## Open question for Iowa Legal Aid

When reconciling fails, the balance goes to the closest column with a note saying so. The alternative is leaving those cells blank. A number in roughly the right place risks being read as precise, and a blank risks reading as nothing owed. Current behaviour is the former. Sent to Ari separately.

## Caveat

One real financials page exists. The bucket-equality check means a wrong partition costs the reconciliation instead of producing wrong numbers, but how often reconciliation succeeds across a real caseload is unmeasured. One case is not a rate, and the fallback notes are what make that visible in the workbook instead of something taken on trust.
