### PR TITLE
Capture the 200 record notice instead of inferring it

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -66,11 +66,17 @@ def _flat_text(soup):
 def truncation_limit(soup):
     """The record limit ICOS stopped at, or None if it listed everything.
 
-    This used to be an exact match against one text node, which meant it only
-    fired on a bare unpadded sentence ending in a full stop and never on the
-    page ICOS actually sends. A search that silently comes back short is the
-    same failure as a workbook that is quietly missing two cases: the answer
-    looks complete and is not.
+    A search that silently comes back short is the same failure as a workbook
+    that is quietly missing two cases: the answer looks complete and is not.
+
+    This used to be an exact match against one text node. That was rewritten
+    on the reasoning that ICOS pads every cell with CRLFs and tabs, so an
+    exact match would never fire on the real page. A truncated page has since
+    been captured and that reasoning was wrong: ICOS puts the notice in its
+    own cell with no padding, and the old exact match would have caught it.
+    The rewrite stands on what is left, which is that it survives a change of
+    case, of padding, of the number, or of the markup around the words, and
+    the exact match survived none of those.
     """
     found = _TOO_MANY.search(_flat_text(soup))
     if not found:

--- a/tests/fixtures/search_results_truncated_sample.html
+++ b/tests/fixtures/search_results_truncated_sample.html
@@ -1,0 +1,161 @@
+
+
+
+
+
+
+
+
+
+
+<HTML>
+<head>
+<title>Trial Search Results</title>
+<script language=javascript>
+function mySubmit(id, pin){
+	if (id.substring(7,9) == "JI") {
+		document.JiForm.caseId.value = id;
+		document.JiForm.peopleId.value = pin;
+		document.JiForm.submit();
+	} else {
+		document.TrialForm.caseid.value = id;
+		document.TrialForm.submit();
+	}
+}
+</script>
+<style type="text/css">
+	a:link {
+		COLOR: #0000FF;
+	}
+	a:visited {
+		COLOR: #800080 !important; 
+	}
+	a:hover {
+		COLOR: #FF0000;
+	}
+	a:active {
+		COLOR: #0000FF;
+	}
+</style>
+<script src="js\libs\jquery-3.3.1.min.js"></script>
+</head>
+<body>
+<table border="0" cellspacing="0" cellpadding="7" width="100%">
+
+		<tr>
+			<td bgcolor="#cccccc" colspan=8><font size=3><b>Your query returned more than 200 records.</b></font></td>
+		</tr>
+		<tr>
+			<td bgcolor="#cccccc" colspan=8><font size=3><b>A subset of the results (the first 200 records found) is shown below.</b></font></td>
+		</tr>
+		<tr>
+			<td bgcolor="#cccccc" colspan=8><font size=3><b>To get full results, go back to the search screen and narrow your search.</b></font></td>
+		</tr>
+
+
+		<tr>
+		<td bgcolor=#cccccc><font size=2><b><u>Case ID</u></b></font></td>
+		<td bgcolor=#cccccc><font size=2><b><u>Initiated Date</u></b></font></td>
+		<td bgcolor=#cccccc><font size=2><b><u>Title</u></b></font></td>
+		<td bgcolor="#cccccc"><font size=2><b><u>Name</u></b></font></td>
+
+		<td bgcolor=#cccccc><font size=2><b><u>DOB</u></b></font></td>
+		<td bgcolor=#cccccc><font size=2><b><u>Role</u></b></font></td>
+		</tr>
+
+				<tr>
+				<td bgcolor="#EDEDED" width="15%" valign="top" nowrap><font size="2" face="Courier New"> <a	href="javascript:mySubmit('00000++FECR000000','CR0000000')">00000&nbsp;&nbsp;FECR000000</a></font></td>
+				<td bgcolor="#EDEDED" width="10%" valign="top"><font size="2">01/01/1990</font></td>
+				<td bgcolor="#EDEDED" width="40%" valign="top"><font size="2">STATE OF IOWA VS TESTER, PAT Q</font></td>
+				<td bgcolor="#EDEDED" width="25%" valign="top"><font size="2">TESTER, PAT Q</font></td>
+
+				<td bgcolor="#EDEDED" width="10%" valign="top"><font size="2">
+				
+				01/01/1900
+				
+				</font></td>
+				<td bgcolor="#ededed" width="10%" valign="top"><font size="2">DEFENDANT</font></td>
+				</tr>
+
+				<tr>
+				<td bgcolor="#FFFFFF" width="15%" valign="top" nowrap><font size="2" face="Courier New"> <a	href="javascript:mySubmit('00000++SRCR000000','CR0000001')">00000&nbsp;&nbsp;SRCR000000</a></font></td>
+				<td bgcolor="#FFFFFF" width="10%" valign="top"><font size="2">02/02/1991</font></td>
+				<td bgcolor="#FFFFFF" width="40%" valign="top"><font size="2">STATE OF IOWA VS TESTER, SAM</font></td>
+				<td bgcolor="#FFFFFF" width="25%" valign="top"><font size="2">TESTER, SAM</font></td>
+
+				<td bgcolor="#FFFFFF" width="10%" valign="top"><font size="2">
+				
+				02/02/1901
+				
+				</font></td>
+				<td bgcolor="#ffffff" width="10%" valign="top"><font size="2">DEFENDANT</font></td>
+				</tr>
+
+</table>
+
+
+
+
+ 
+    <script language=javascript>
+        function login(){
+            parent.location.href = "https://www.iowacourts.state.ia.us/ESAWebApp/ESALogin.jsp"
+        }
+        function registration(){
+            parent.location.href = "https://www.iowacourts.state.ia.us/ESAWebApp/Registration"
+        }
+ 
+        function goToPassword() {
+            parent.location.href = "/ESAWebApp/ChangePasswordServlet";
+        }
+ 
+        function goToEditUser() {
+            parent.location.href = "/ESAWebApp/EditUserServlet?getEditPage=true";
+        }
+    </script>
+
+<table width="100%">
+    <tr>
+		<td align=right><font face=Arial size=1>CN=ILATEST,O=JUDICIAL</font></td>
+    </tr>
+</table>
+
+
+
+<div style="text-align: center;">
+	<form name="logoffForm" action="/ESAWebApp/EPALogout" target="_parent" method=POST>
+		<input type=submit name="logoffButton" value="Logoff" style="inline-block"> 
+		<input type=button name="changePassword" value="Change Password" onclick="javaScript:goToPassword()" style="inline-block">
+	</form>
+</div>
+
+
+
+<table width=100%>
+	<tr>
+		<td width=100%>
+
+			<p align=center><font size=2>Please Logoff when you are through accessing case detail information.</font></p>
+			<p align=center><font size=2>For exclusive use by the Iowa Courts<br> State of Iowa,&nbsp; All Rights Reserved</font></p>
+
+		</td>
+	</tr>
+</table>
+
+
+<form name="TrialForm" action="/ESAWebApp/TIndexFrm" method=post target="_parent">
+	<input type="hidden" name="caseid" value=" "> 
+	<input type="hidden" name="screen" value="T">
+</form>
+<form name="JiForm" action="/ESAWebApp/JIndexFrm" method=post target="_parent">
+	<input type="hidden" name="caseId" value=" "> 
+	<input type="hidden" name="peopleId" value=" "> 
+	<input type="hidden" name="screen" value="J">
+</form>
+<script type="text/javascript">
+	$(function()() {
+		$(document).tooltip();
+	});
+</script>
+</body>
+</html>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,10 +22,19 @@ import case_parser
 FIXTURE = os.path.join(os.path.dirname(__file__), 'fixtures',
                        'search_results_sample.html')
 
+TRUNCATED_FIXTURE = os.path.join(os.path.dirname(__file__), 'fixtures',
+                                 'search_results_truncated_sample.html')
+
 
 @pytest.fixture
 def search_page():
     with open(FIXTURE, 'rb') as handle:
+        return handle.read()
+
+
+@pytest.fixture
+def truncated_search_page():
+    with open(TRUNCATED_FIXTURE, 'rb') as handle:
         return handle.read()
 
 
@@ -167,13 +176,12 @@ def test_a_case_id_cannot_write_outside_the_dump_directory(tmp_path,
 
 # -- the 200 record notice -------------------------------------------------
 
-# No capture of the real notice exists. ICOS only shows it for a name that
-# matches more cases than it will list, and the one real search page we have
-# came back with 120 rows. So these cover the shapes ICOS is known to produce
-# rather than one recorded page, and the shapes are not guesses: every cell on
-# the real fixture is a font tag padded with CRLFs and tabs, and the detection
-# this replaced matched one exact unpadded text node and would have missed all
-# of them.
+# These shapes were written before anyone had seen the notice, because ICOS
+# only shows it for a name matching more cases than it will list and the first
+# real search page we had came back under the limit. They are kept now that a
+# truncated page has been captured, since they pin the wording loosely enough
+# to survive ICOS rewording or moving the number, which the captured page on
+# its own does not.
 
 def page_carrying(notice):
     return ("""<html><body>
@@ -232,6 +240,43 @@ def test_a_complete_search_is_not_called_short(search_page):
     cases, too_many = case_parser.parse_search(search_page)
     assert too_many is False
     assert len(cases) > 0
+
+
+def test_the_real_truncated_page_is_recognised(truncated_search_page):
+    """The captured notice, which nothing here had ever actually seen.
+
+    A surname search on a common Iowa name came back at the cap. ICOS words it
+    over three table rows rather than one, each a single cell spanning the
+    table, and the sentence the detection matches is only the first of them:
+
+        Your query returned more than 200 records.
+        A subset of the results (the first 200 records found) is shown below.
+        To get full results, go back to the search screen and narrow your
+        search.
+
+    The 200 result rows were 200 real people and are not in the fixture. Two
+    synthetic rows stand in for them. Everything else is the page as sent.
+    """
+    cases, too_many = case_parser.parse_search(truncated_search_page)
+    assert too_many is True
+    soup = case_parser.BeautifulSoup(truncated_search_page, 'html.parser')
+    assert case_parser.truncation_limit(soup) == 200
+    assert ids(cases) == ['00000  FECR000000', '00000  SRCR000000']
+
+
+def test_the_notices_second_sentence_would_not_carry_the_detection_alone():
+    """Where this is thin, written down rather than left to be discovered.
+
+    ICOS states the count twice and only the first sentence matches. So the
+    detection rests on one of the three lines ICOS sends, and a rewording that
+    kept the count but dropped that line would put us back to a search coming
+    back short in silence. Nothing to fix today: matching the second sentence
+    too would trade a known gap for a guess about wording nobody has seen.
+    """
+    soup = case_parser.BeautifulSoup(
+        page_carrying('<td>A subset of the results (the first 200 records '
+                      'found) is shown below.</td>'), 'html.parser')
+    assert case_parser.truncation_limit(soup) is None
 
 
 def test_the_sentence_inside_a_script_is_not_a_notice():


### PR DESCRIPTION
The >200 truncation notice was the last part of the parser resting on inference. It is now captured.

## The pattern was right

One search on a common Iowa surname came back at the cap. `truncation_limit()` returned 200 against the live page with no change needed. The notice is longer than assumed, three table rows rather than one sentence:

```
Your query returned more than 200 records.
A subset of the results (the first 200 records found) is shown below.
To get full results, go back to the search screen and narrow your search.
```

## The reason for the rewrite was wrong

`truncation_limit`'s docstring said the old exact match against a single text node "would never fire on the page ICOS actually sends" because ICOS pads every cell with CRLFs and tabs.

It does not pad this one. The notice sits alone in its own cell, and the exact-match version would have caught the real page:

```
exact unpadded text-node matches on the REAL page: 1
```

The rewrite still earns its place. It survives a change of case, of padding, of the number, and of the markup around the words, and the exact match survived none of those. The docstring now says that rather than claiming a failure that would not have happened.

## Where it is still thin

Only the first of the three lines is matched. A rewording that keeps the count but drops that line puts us back to a silent short search. Matching the second line too would trade a known gap for another guess about wording nobody has seen, so `test_the_notices_second_sentence_would_not_carry_the_detection_alone` writes it down instead.

## The fixture

`tests/fixtures/search_results_truncated_sample.html` is the page as ICOS sent it, with the 200 result rows removed. Those were 200 real people. Two synthetic rows stand in, using the identifiers already agreed for this repo.

Scrub audit on the committed file:

| check | result |
|---|---|
| dates present | `01/01/1900`, `02/02/1901` and their two initiated dates only |
| case ids | `00000  FECR000000`, `00000  SRCR000000` |
| name-shaped tokens | `TESTER, PAT Q`, `TESTER, SAM` |
| ESA account | `ILATEST` |
| session tokens, cookies, query strings | none |
| captured surname anywhere in file | no |

The unscrubbed capture stays in `~/napier-icos-capture/` at 0600.

## Side benefit: the non-party list met 200 rows

It was built against a nine-row page. The captured search ran 200 real rows through it: 174 kept, 26 dropped. Every drop was an attorney or administrative role. Everything surviving was a genuine party (`DEFENDANT`, `PLAINTIFF`, `RESPONDENT`, `PETITIONER`, `JUVENILE - INVOLVED`, `PRO SE PLAINTIFF`, `RESP/PROTECTED PERSON`, `THIRD PARTY DEFENDANT`). No attorney or filer role slipped through.

Roles are not PII and no row from that check is in the repo.

## Verified

194 passed.

Not vacuous: with `truncation_limit` neutered, `test_the_real_truncated_page_is_recognised` fails. Note that swapping the regex for the naive exact-match shape does **not** fail it, which is the point above about the real page matching either version.
