### PR TITLE
Fix the alert check in the cutover runbook

### DIFF
--- a/CUTOVER.md
+++ b/CUTOVER.md
@@ -32,6 +32,18 @@ it is failing is worse than the one before it:
 heroku config -a crs-napier | grep -E 'MAILGUN|ALERT'
 ```
 
+`MAILGUN_DOMAIN`, `MAILGUN_API_KEY` and `ALERT_EMAIL_TO` are the three that are
+read. `ALERT_EMAIL` is also set and nothing reads it, so unset it while you are
+here rather than leaving a variable that looks load-bearing and is not:
+
+```
+heroku config:unset ALERT_EMAIL -a crs-napier
+```
+
+Nothing else needs setting. The retry budgets (`RETRY_BUDGET_MIN`,
+`CASE_RETRY_BUDGET_MIN`, `CONCURRENT_WAIT_MIN`) all have defaults and are meant
+to be absent.
+
 Pick a quiet hour. A deploy restarts the dyno, which ends any search that is
 running at that moment.
 
@@ -63,10 +75,42 @@ instead sits for thirty seconds and ends in `Error R12` and a `SIGKILL`, then
 whatever the app was holding was not handed back, and the shared ICOS account
 will stay locked for about fifteen minutes.
 
-Alert mail has never been exercised on production, because the release before
-this one had no alerting in it. It is worth deliberately provoking one failure
-after the deploy, by signing in with a wrong password, and confirming the mail
-arrives.
+### Checking that alert mail works
+
+Do not test this with a wrong password. Napier alerts on failures staff cannot
+act on, and it decides that by whether the exception carries a message meant for
+them (`jobs.py`, in the `except` around the job body). A bad password carries
+one, so it is shown on screen and deliberately never emailed. Provoking a login
+failure and waiting for mail proves nothing, and the mail that does not arrive
+reads exactly like alerting being broken.
+
+Two checks that do work, cheapest first.
+
+The mail path in the code that is now deployed:
+
+```
+heroku run --no-tty --exit-code -a crs-napier -- python -c "import alerts; alerts._deliver('Napier cutover check', 'Sent by hand after deploying to production.')"
+```
+
+The dyno prints `ALERT sent:` on success and `ALERT delivery failed` otherwise.
+`_deliver` swallows the exception either way, so that line is the only tell.
+
+Then one check that goes through the real trigger rather than the mail helper.
+Sign in, run a CRS for a name known to return cases, and when the finish page
+appears do not download the workbook. Five minutes later a `workbook was built
+but never collected` alert should arrive. That is the alert added because a
+staffer lost a finished run on a phone and nothing server-side noticed, so it is
+the one worth proving end to end.
+
+Run that one once. Each kind of failure is rate limited to one email every ten
+minutes across the whole app, so a second attempt inside that window sends
+nothing, which looks like the first one having been a fluke.
+
+The Mailgun configuration and the egress path out of `crs-napier` were already
+confirmed working on 2026-07-31, by sending a hand-built request from a
+production dyno using production's own config and checking the Mailgun events
+API for `delivered` rather than `accepted`. What has never run on production is
+the code, which is what these two checks are for.
 
 ## Going back
 


### PR DESCRIPTION
Found while auditing whether production is ready for the 46-commit jump from v55.

## The runbook's alert check cannot pass

`CUTOVER.md` said:

> It is worth deliberately provoking one failure after the deploy, by signing in with a wrong password, and confirming the mail arrives.

It will not arrive. `jobs.py` alerts only when the exception carries no `.message`:

```python
message = getattr(e, "message", None)
if message is None:
    ...
    alerts.record(job.id[:8], kind, alerts.JOB_FAILED, ...)
```

`IcosError.__init__` sets `self.message`, and `IcosBadCredentials` inherits it. So a bad password is shown to staff and deliberately never emailed. That is the right design. The problem is a runbook step that reads as broken alerting at the exact moment someone is deciding whether to roll back a release.

## What replaced it

The mail path through the deployed code:

```
heroku run --no-tty --exit-code -a crs-napier -- python -c "import alerts; alerts._deliver(...)"
```

Watching for `ALERT sent:`, because `_deliver` swallows the exception either way and that line is the only tell.

Then the real trigger: run a CRS, leave the workbook undownloaded, and `UNCOLLECTED_AFTER = 5 * 60` fires `workbook was built but never collected`. That is the alert that exists because a staffer lost a finished run on a phone and nothing server-side noticed, so it is worth proving end to end.

With a warning not to repeat it. `CLASS_FLOOR_SECONDS = 10 * 60` is a floor across all jobs per failure class, so a second confirming attempt sends nothing and makes the first look like a fluke.

## Config audit, no changes made

Every variable the code reads, against what production has:

| variable | read by | on crs-napier |
|---|---|---|
| `SECRET_KEY` | `app.py` | set |
| `MAILGUN_DOMAIN`, `MAILGUN_API_KEY`, `ALERT_EMAIL_TO` | `alerts.py` | set |
| `ALERT_EMAIL_FROM` | `alerts.py`, optional | absent, defaults |
| `RETRY_BUDGET_MIN`, `CASE_RETRY_BUDGET_MIN`, `CONCURRENT_WAIT_MIN` | `icos.py` via `_env_seconds` | absent, defaults |
| `NAPIER_DISABLE_BACKGROUND`, `NAPIER_DUMP_HTML` | dev only | absent, correct |
| `ALERT_EMAIL` | nothing | set, inert |

Production's config is complete. `ALERT_EMAIL` is now documented as safe to unset rather than left looking load-bearing.

Also confirmed the two deployment-shape changes prod will take: `soupsieve==2.9.1` pinned in `requirements.txt`, and the `Procfile` moving to `--workers 1 --worker-class gthread --threads 12 --timeout 120`, which the in-memory job store requires.

194 passed. Documentation only, no code change.
