### PR TITLE
Stop a broken fee category from emptying the columns the analysis sheets read

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -56,6 +56,12 @@ UNHANDLED = 'unhandled exception'
 # because nothing server-side went wrong.
 UNCOLLECTED = 'workbook was built but never collected'
 CLIENT_LOST = 'progress page lost contact with Napier'
+# Napier decides who is a party by listing the roles that are not, so a role
+# nobody has seen before is included by default. That default has been wrong
+# four times, most recently a nonparty filer, and each time it took someone
+# noticing a stranger's convictions in a client's summary. This does not change
+# what is included: it says the list has a gap in it while the run is happening.
+NOVEL_ROLE = 'unrecognised party role on an ICOS search'
 
 # A run that eventually worked but took this many attempts is the early warning
 # that ICOS is degrading, which is worth one email before staff start noticing.

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import platform
 import time
 
 import alerts
+import crs
 import icos_sessions
 import jobs
 import tasks
@@ -299,6 +300,8 @@ def done(job_id):
                            written=result['written_cases'],
                            requested=result['requested_cases'],
                            failed=result['failed_cases'],
+                           limits=crs.workbook_limits(result['written_cases'],
+                                                      result['is_lite']),
                            filename=tasks.download_name(result['def_name'],
                                                         result['is_lite']))
 

--- a/case_parser.py
+++ b/case_parser.py
@@ -44,6 +44,101 @@ def _cell_words(cell):
     return ' '.join(cell.get_text().split())
 
 
+# Roles ICOS gives someone who is on a case without the case being theirs. Every
+# other role is treated as the person searched for, so this list decides whose
+# convictions and whose court debt end up in a client's record summary, and it
+# has been wrong by omission four separate times.
+NON_PARTY_ROLES = frozenset({
+    'NOT ATTORNEY',
+    'NOT JUDGE',
+    'ADMINISTRATOR',
+    'APPLICANT',
+    'ATTORNEY AND GUARDIAN-AD-LITEM',
+    'ATTORNEY FOR APPELLANT',
+    'ATTORNEY FOR APPELLEE',
+    'ATTORNEY FOR CHILD',
+    'ATTORNEY FOR CSRU',
+    'ATTORNEY FOR DEFENDANT',
+    'ATTORNEY FOR FATHER',
+    'ATTORNEY FOR MOTHER',
+    'ATTORNEY FOR PARENT',
+    'ATTORNEY FOR PETITIONER',
+    'ATTORNEY FOR PLAINTIFF',
+    'ATTORNEY FOR PROBATE',
+    'ATTORNEY FOR RESPONDENT',
+    'ATTORNEY - LIMITED APPEARANCE',
+    'ATTORNEY OTHER',
+    'CONSERVATOR',
+    'COUNTER DEFENDANT',
+    'COUNTER PLAINTIFF',
+    'COUNTY ATTORNEY',
+    'CROSS DEFENDANT',
+    'CROSS PLAINTIFF',
+    'CUSTODIAN - LEGAL',
+    'DECEASED INDIVIDUAL',
+    'EXECUTOR',
+    'FILING AGENT FOR PLAINTIFF',
+    'FILING AGENT FOR DEFENDANT',
+    'GUARDIAN',
+    'GUARDIAN-AD-LITEM',
+    'GUARDIAN/CONSERVATOR',
+    'INTERPRETER',
+    'INTERPRETOR',
+    'INTERVENOR',
+    'JUDGE',
+    'LIEN FILER',
+    'NAME OF TRUST',
+    # Someone who filed a document into a case they are not party to,
+    # which is why the charges and the money on that page belong to
+    # somebody else. The charge parser takes every row on the page,
+    # since in the ordinary case the person searched for is the
+    # defendant and there is nothing to separate out, so a case
+    # reaching it under this role puts a stranger's convictions in the
+    # client's record summary. The 'NO ACCESS' half is the filer's
+    # access level to the case file rather than part of the role, so
+    # both spellings are listed.
+    'NO ACCESS NONPARTY FILER',
+    'NONPARTY FILER',
+    'OBLIGOR',
+    'OBLIGEE',
+    'PAYOR',
+    'PAYEE',
+    'TRUSTEE',
+    'WARD',
+    'WITNESS',
+    'WITNESS – PLAINTIFF',
+    'WITNESS - PLAINTIFF',
+    'WITNESS - PLAINTIFF',
+    'WITNESS – DEFENSE',
+    'WITNESS - DEFENSE',
+    'JUVENILE - MOTHER OF',
+    'JUVENILE - FATHER OF',
+    'ATTORNEY',
+    'INTERESTED PARTY'
+})
+
+
+# Roles we have actually seen on the person the search is about. Nothing branches
+# on this: it is only how a run notices that NON_PARTY_ROLES has a gap, by way of
+# the alert in tasks.search_task. Kept deliberately narrow, because a role missing
+# from here costs one email and a role missing from NON_PARTY_ROLES costs a
+# stranger's record in a client's file.
+KNOWN_PARTY_ROLES = frozenset({
+    'DEFENDANT',
+    'PRO SE DEFENDANT',
+    'DEFENDANT - PRO SE',
+    'PLAINTIFF',
+    'PRO SE PLAINTIFF',
+    'PETITIONER',
+    'PRO SE PETITIONER',
+    'RESPONDENT',
+    'PRO SE RESPONDENT',
+    'APPELLANT',
+    'PRO SE APPELLANT',
+    'APPELLEE',
+    'PRO SE APPELLEE',
+})
+
 # The notice ICOS shows when a name matches more cases than it will list. The
 # number is captured rather than assumed, because the only thing worse than not
 # knowing the list is short is telling someone the wrong count.
@@ -114,75 +209,7 @@ def parse_search(html):
         if any([case['id'] == c['id'] for c in cases]):
             print("Supressing duplicate case id", case['id'])
             continue
-        non_party_designations = [
-            'NOT ATTORNEY', 
-            'NOT JUDGE', 
-            'ADMINISTRATOR', 
-            'APPLICANT', 
-            'ATTORNEY AND GUARDIAN-AD-LITEM', 
-            'ATTORNEY FOR APPELLANT', 
-            'ATTORNEY FOR APPELLEE', 
-            'ATTORNEY FOR CHILD', 
-            'ATTORNEY FOR CSRU', 
-            'ATTORNEY FOR DEFENDANT', 
-            'ATTORNEY FOR FATHER', 
-            'ATTORNEY FOR MOTHER', 
-            'ATTORNEY FOR PARENT', 
-            'ATTORNEY FOR PETITIONER', 
-            'ATTORNEY FOR PLAINTIFF', 
-            'ATTORNEY FOR PROBATE', 
-            'ATTORNEY FOR RESPONDENT', 
-            'ATTORNEY - LIMITED APPEARANCE', 
-            'ATTORNEY OTHER', 
-            'CONSERVATOR', 
-            'COUNTER DEFENDANT', 
-            'COUNTER PLAINTIFF', 
-            'COUNTY ATTORNEY', 
-            'CROSS DEFENDANT', 
-            'CROSS PLAINTIFF', 
-            'CUSTODIAN - LEGAL', 
-            'DECEASED INDIVIDUAL', 
-            'EXECUTOR', 
-            'FILING AGENT FOR PLAINTIFF', 
-            'FILING AGENT FOR DEFENDANT', 
-            'GUARDIAN', 
-            'GUARDIAN-AD-LITEM', 
-            'GUARDIAN/CONSERVATOR', 
-            'INTERPRETER', 
-            'INTERPRETOR',
-            'INTERVENOR', 
-            'JUDGE', 
-            'LIEN FILER', 
-            'NAME OF TRUST',
-            # Someone who filed a document into a case they are not party to,
-            # which is why the charges and the money on that page belong to
-            # somebody else. The charge parser takes every row on the page,
-            # since in the ordinary case the person searched for is the
-            # defendant and there is nothing to separate out, so a case
-            # reaching it under this role puts a stranger's convictions in the
-            # client's record summary. The 'NO ACCESS' half is the filer's
-            # access level to the case file rather than part of the role, so
-            # both spellings are listed.
-            'NO ACCESS NONPARTY FILER',
-            'NONPARTY FILER',
-            'OBLIGOR',
-            'OBLIGEE',
-            'PAYOR',
-            'PAYEE',
-            'TRUSTEE',
-            'WARD',
-            'WITNESS', 
-            'WITNESS – PLAINTIFF',
-            'WITNESS - PLAINTIFF',
-            'WITNESS - PLAINTIFF',
-            'WITNESS – DEFENSE',
-            'WITNESS - DEFENSE',
-            'JUVENILE - MOTHER OF', 
-            'JUVENILE - FATHER OF',
-            'ATTORNEY',
-            'INTERESTED PARTY'
-            ]
-        if (case['role'] in non_party_designations):
+        if (case['role'] in NON_PARTY_ROLES):
             print("Supressing non-party case")
             continue
         cases.append(case)

--- a/crs.py
+++ b/crs.py
@@ -246,10 +246,15 @@ def reconcile_financials(case):
     checks each bucket against its summary original, and then subtracts the
     bucket's payment from the specific lines that account for it.
 
-    Returns (columns, note). columns is None when the itemization cannot be
-    reconciled against the summary, which means the caller should fall back.
-    note is None when every payment was resolved, or a string naming the buckets
-    whose payment could not be attributed to particular lines.
+    Reconciling is per category rather than per case: a category that does not
+    add up is reported as a summary total, and the categories that do add up
+    still get their fee breakdown.
+
+    Returns (columns, note). columns is None when nothing on the row could be
+    reconciled, which means the caller should fall back to the summary. note is
+    None when the whole row is fee by fee, and otherwise names the categories
+    that are not, either because they did not add up or because their payment
+    could not be attributed to particular lines.
     """
     categories = case.get('summary_categories')
     rows = case.get('financials')
@@ -294,21 +299,43 @@ def reconcile_financials(case):
                    Decimal(str(paid)) if paid is not None else Decimal(0)]
         buckets[get_summary_bucket(detail)].append(current)
 
-    # Every bucket must add up to what the summary says was assessed. If it
-    # does not, the partition is wrong and any payment we attributed off it
-    # would be wrong too.
-    for name in ICOS_BUCKETS:
-        assessed = sum((entry[1] for entry in buckets[name]), Decimal(0))
-        if abs(assessed - summary[name]['original']) > Decimal('0.01'):
-            return None, None
-
+    # A bucket has to add up to what the summary says was assessed before any
+    # payment is attributed off it. A fee read into the wrong bucket shows up as
+    # a shortfall in one and a matching excess in another, so both fail and
+    # neither is quietly wrong, which is why a bucket that does match to the cent
+    # is good evidence its partition is right.
+    #
+    # A bucket that does not match is reported the way summary_financials would
+    # report it and the rest of the row keeps its fee breakdown. Giving up on the
+    # whole row instead emptied columns J, K and L, and those are where the
+    # statute-of-limitations and Polk room-and-board sheets look for twenty year
+    # old attorney fee and jail debt. Old cases are both the ones that sheet is
+    # for and the ones most likely to have an itemization that will not
+    # reconcile, so the two lined up badly.
     columns = {}
     unresolved = []
+    unreconciled = []
+    carrying = []
     for name in ICOS_BUCKETS:
         entries = buckets[name]
+        category = summary[name]
+        if entries or category['original']:
+            carrying.append(name)
+
+        assessed = sum((entry[1] for entry in entries), Decimal(0))
+        if abs(assessed - category['original']) > Decimal('0.01'):
+            unreconciled.append(name)
+            due = category.get('due')
+            if due is None:
+                due = category['original'] - (category.get('paid') or Decimal(0))
+            if due:
+                column = get_finance_column(category['label'])
+                columns[column] = columns.get(column, Decimal(0)) + due
+            continue
+
         if not entries:
             continue
-        paid = summary[name].get('paid') or Decimal(0)
+        paid = category.get('paid') or Decimal(0)
 
         # The itemization's own Paid column is blank on most fees, but not on
         # all of them: restitution in particular is paid down in instalments
@@ -349,13 +376,37 @@ def reconcile_financials(case):
             column = get_finance_column(detail)
             columns[column] = columns.get(column, Decimal(0)) + owed
 
-    note = None
+    if carrying and not set(carrying) - set(unreconciled):
+        # Nothing on this row reconciled, so what came out is the summary with
+        # extra steps. Hand it back to the caller, which says so in one sentence
+        # rather than five.
+        return None, None
+
+    notes = []
+    if unreconciled:
+        text = ("%s did not add up against the itemization, so %s balance is "
+                "ICOS's category total rather than a per-fee breakdown"
+                % (_and_list(unreconciled),
+                   "those" if len(unreconciled) > 1 else "that"))
+        if any(get_finance_column(summary[name]['label']) == 'O'
+               for name in unreconciled):
+            text += (", and those fees are in MISCELLANEOUS rather than in "
+                     "their own columns")
+        notes.append(text + ". The rest of the row is fee by fee and the ICOS "
+                            "total is still right.")
     if unresolved:
-        note = ("ICOS records payments per category, not per fee. The payment "
-                "in %s could not be tied to a specific line, so that balance "
-                "is reported as a category total rather than per fee."
-                % ", ".join(unresolved))
-    return columns, note
+        notes.append(
+            "ICOS records payments per category, not per fee. The payment "
+            "in %s could not be tied to a specific line, so that balance "
+            "is reported as a category total rather than per fee."
+            % ", ".join(unresolved))
+    return columns, " ".join(notes) or None
+
+
+def _and_list(names):
+    if len(names) == 1:
+        return names[0]
+    return "%s and %s" % (", ".join(names[:-1]), names[-1])
 
 
 def is_excluded_fee(detail):

--- a/crs.py
+++ b/crs.py
@@ -5,6 +5,49 @@ from openpyxl.styles import Font, PatternFill
 MISMATCH_FILL = PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid")
 MISMATCH_FONT = Font(color="9C0006")
 
+# Where the CRS template stops, counted in cases rather than rows. Napier writes
+# CASE DATA from row 4 down and never stops, and Excel accepts every row it is
+# given, so outgrowing the template costs a number rather than raising anything:
+# the analysis sheets carry formulas only so far, and their totals sum a shorter
+# range still. Nobody has hit these on a real client, but the failure is a
+# quietly low figure carried into a hearing, so the run says something.
+#
+# tests/test_workbook_limits.py reads these back out of the two .xlsx files, so
+# a new template that moves them fails the suite instead of going unnoticed.
+FIRST_CASE_ROW = 4
+# CASE DATA row 1 totals =SUM(x4:x300).
+CASE_DATA_TOTAL_LIMIT = 297
+# SOL, BANKRUPTCY and EXEMPTIONS each total =SUM(x4:x100). Full CRS only; the
+# Lite template does not have those sheets.
+ANALYSIS_TOTAL_LIMIT = 97
+# The first sheet to run out of rows altogether: SOL's formulas stop at row 150.
+ANALYSIS_ROW_LIMIT = 147
+# In the Lite template that is EXPUNGEMENT & 910.7, whose rows are offset by one
+# and stop at row 200, so its last case is CASE DATA row 201.
+LITE_ANALYSIS_ROW_LIMIT = 198
+
+
+def workbook_limits(written, is_lite):
+    """What this many cases outgrows in the CRS template, worst first."""
+    warnings = []
+    if written > CASE_DATA_TOTAL_LIMIT:
+        warnings.append(
+            "CASE DATA's totals on row 1 only add up the first %d cases, so "
+            "every total in this workbook is short."
+            % CASE_DATA_TOTAL_LIMIT)
+    row_limit = LITE_ANALYSIS_ROW_LIMIT if is_lite else ANALYSIS_ROW_LIMIT
+    if written > row_limit:
+        warnings.append(
+            "The analysis sheets have rows for the first %d cases only, so the "
+            "cases after that are on CASE DATA and nowhere else."
+            % row_limit)
+    if not is_lite and written > ANALYSIS_TOTAL_LIMIT:
+        warnings.append(
+            "The totals on SOL, BANKRUPTCY and EXEMPTIONS only add up the "
+            "first %d cases. The rows below that are right, the totals are "
+            "low." % ANALYSIS_TOTAL_LIMIT)
+    return warnings
+
 charge_code_map = {
     "GUILTY": {"GTR":1},
     "GUILTY BY COURT": {"GTR":1},

--- a/tasks.py
+++ b/tasks.py
@@ -182,6 +182,16 @@ def build_workbook(cases, def_name, def_dob, is_lite):
         row += 1
 
     sheet = workbook['BASIC INFO']
+    # Every date test in the workbook compares against B3, the clinic date: the
+    # twenty year cut on the SOL sheet, the two year and eight year expungement
+    # waits, whether the client has turned 18. Left blank it reads as zero, so
+    # nothing is ever old enough and the SOL sheet reports every case as having
+    # no argument, which looks exactly like a client with no stale debt. Today
+    # is the right default for a workbook built today, and it is a date value
+    # rather than text so the arithmetic works. Staff can overwrite it for a
+    # clinic on another day.
+    sheet['B3'] = datetime.date.today()
+    sheet['B3'].number_format = 'MM/DD/YYYY'
     sheet['B5'] = def_name.strip()
     sheet['B6'] = def_dob
 

--- a/tasks.py
+++ b/tasks.py
@@ -43,6 +43,27 @@ def group_cases(cases):
     return case_dict, sorted(case_dict)
 
 
+def report_novel_roles(job, cases):
+    """Say when a search included a role nobody has classified yet.
+
+    Napier decides who is a party by listing the roles that are not one, so a
+    role it has never seen is included by default. That has gone wrong four
+    times, and every time the tell was a person reading the workbook and asking
+    why a stranger's convictions were in it. There is nothing to see server side
+    because nothing fails: the case is fetched, parsed and written normally.
+
+    This does not change what goes in the workbook. It reports the role and
+    nothing else, so the same PII rule the rest of alerting keeps holds here:
+    the client's name and date of birth are the privileged part and never leave
+    the machine, and a role string on its own identifies nobody.
+    """
+    novel = sorted({case['role'] for case in cases
+                    if case['role'] not in case_parser.KNOWN_PARTY_ROLES})
+    for role in novel:
+        alerts.record(job.id[:8], job.kind, alerts.NOVEL_ROLE, role=role)
+    return novel
+
+
 def search_task(job, username, password, firstname, middlename, lastname):
     client = IcosClient(log=job.log, alert=alerts.emitter(job))
     keep_session = False
@@ -52,6 +73,7 @@ def search_task(job, username, password, firstname, middlename, lastname):
 
         job.log("Reading results...")
         cases, too_many_results = case_parser.parse_search(body)
+        report_novel_roles(job, cases)
         case_dict, keys = group_cases(cases)
 
         token = icos_sessions.put(client)

--- a/templates/done.html
+++ b/templates/done.html
@@ -97,6 +97,24 @@
     </div>
   {% endif %}
 
+  {% if limits %}
+    <div class="notice" role="alert">
+      <p class="notice-title">
+        This run is bigger than the CRS template counts.
+      </p>
+      <p>
+        Every case is in the workbook and every row is right. The template's own
+        formulas stop before the end of them, and Excel does not say so:
+      </p>
+      <ul>
+        {% for limit in limits %}<li>{{ limit }}</li>{% endfor %}
+      </ul>
+      <p>
+        Splitting the search into two workbooks is the way around it.
+      </p>
+    </div>
+  {% endif %}
+
   <div class="actions">
     <a href="/job/{{ job.id }}/download" class="btn btn-primary" id="again">Download the workbook</a>
     <a href="/logout" class="btn btn-quiet">Search for someone else</a>

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -545,6 +545,73 @@ def test_a_case_that_will_not_parse_alerts_with_the_case_and_not_the_person(
         assert '01/01/1900' not in message['text']
 
 
+# -- a role nobody has classified -----------------------------------------
+
+
+def _hit(role, case_id='00000 FECR000000', name='TESTER, PAT Q'):
+    return {'id': case_id, 'title': 'STATE VS TESTER', 'name': name,
+            'dob': '01/01/1900', 'role': role}
+
+
+def test_a_role_nobody_has_seen_before_reports_itself(mailbox):
+    """The four times this list has been short, a person found it in a workbook.
+
+    Nothing fails when an unclassified role turns up. The case is fetched,
+    parsed and written like any other, so the run is clean by every measure the
+    server has, and the only signal is somebody eventually asking why a stranger
+    is in their client's summary.
+    """
+    job = FakeJob('search')
+    novel = tasks.report_novel_roles(job, [_hit('DEFENDANT'),
+                                           _hit('SUBROGEE', '00000 SCSC000000')])
+    settle()
+    assert novel == ['SUBROGEE']
+    assert len(mailbox) == 1
+    assert alerts.NOVEL_ROLE in mailbox[0]['subject']
+    assert 'SUBROGEE' in mailbox[0]['text']
+
+
+def test_the_role_alert_carries_the_role_and_nothing_else(mailbox):
+    """A role string identifies nobody. A name and a date of birth do.
+
+    This alert exists to say the classification list has a gap in it, which the
+    role alone says completely, so there is no reason for the rest of the row to
+    be anywhere near it.
+    """
+    job = FakeJob('search')
+    tasks.report_novel_roles(job, [_hit('SUBROGEE')])
+    settle()
+    assert 'TESTER' not in mailbox[0]['text']
+    assert '01/01/1900' not in mailbox[0]['text']
+    assert '00000 FECR000000' not in mailbox[0]['text']
+
+
+def test_an_ordinary_search_says_nothing(mailbox):
+    job = FakeJob('search')
+    assert tasks.report_novel_roles(job, [_hit('DEFENDANT'),
+                                          _hit('PRO SE DEFENDANT'),
+                                          _hit('PETITIONER')]) == []
+    settle()
+    assert mailbox == []
+
+
+def test_every_novel_role_reaches_the_digest_even_though_one_email_goes_out(
+        mailbox):
+    """The class floor is per failure kind, so a search that turns up three new
+    roles emails about the first. Losing the other two would leave the list half
+    fixed, which is why record() keeps every call for the digest."""
+    job = FakeJob('search')
+    tasks.report_novel_roles(job, [_hit('SUBROGEE'), _hit('GARNISHEE'),
+                                   _hit('DEFENDANT')])
+    send(alerts.digest(job.id[:8], job.kind))
+    settle()
+    digest = [m for m in mailbox if 'ended with' in m['subject']]
+    assert len(digest) == 1
+    assert 'SUBROGEE' in digest[0]['text']
+    assert 'GARNISHEE' in digest[0]['text']
+    assert 'DEFENDANT' not in digest[0]['text']
+
+
 # -- bookkeeping does not grow forever ------------------------------------
 
 

--- a/tests/test_basic_info.py
+++ b/tests/test_basic_info.py
@@ -1,0 +1,55 @@
+"""What Napier fills in on the BASIC INFO sheet.
+
+B3 is the clinic date, and it is not a label: the twenty year cut on the SOL
+sheet, both expungement waits and the has-the-client-turned-18 test all compare
+against it. A blank B3 is zero to Excel, so every one of those tests fails and
+the workbook reads as a client with nothing stale and nothing expungeable. That
+is a wrong answer with no error attached to it, which is worse than a blank.
+"""
+
+import datetime
+import os
+import sys
+
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tasks
+
+
+def _build(is_lite=False):
+    """A workbook with no cases in it. BASIC INFO does not depend on them."""
+    path = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
+    return load_workbook(path)['BASIC INFO'], path
+
+
+def test_the_clinic_date_is_filled_in_with_a_real_date():
+    sheet, path = _build()
+    try:
+        value = sheet['B3'].value
+        assert value is not None, 'a blank B3 silently zeroes every date test'
+        assert not isinstance(value, str), 'text does not do date arithmetic'
+        if isinstance(value, datetime.datetime):
+            value = value.date()
+        assert value == datetime.date.today()
+        assert 'YY' in sheet['B3'].number_format.upper()
+    finally:
+        os.remove(path)
+
+
+def test_the_lite_template_gets_it_too():
+    sheet, path = _build(is_lite=True)
+    try:
+        assert sheet['B3'].value is not None
+    finally:
+        os.remove(path)
+
+
+def test_the_client_still_lands_in_the_cells_below_it():
+    sheet, path = _build()
+    try:
+        assert sheet['B5'].value == 'TEST CLIENT'
+        assert sheet['B6'].value == '01/01/1980'
+    finally:
+        os.remove(path)

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -109,19 +109,27 @@ def test_the_written_row_keeps_the_fee_detail(felony_case):
     assert sheet.value_of('U4') == Decimal('1219.00')
 
 
-def test_the_summary_path_is_still_there_when_reconciling_fails(felony_case):
-    """A partition that does not add up must fall back, not guess.
+def test_one_broken_category_does_not_cost_the_others(felony_case):
+    """A partition that does not add up must fall back, and no further.
 
     Moving a fee off its assessed amount breaks the bucket check inside
-    `reconcile_financials`, which is the whole safety net: the reconciliation is
-    given up rather than a wrong split being written.
+    `reconcile_financials`, which is the safety net: that bucket's split is
+    given up rather than written wrong. It used to cost the whole row, and the
+    line item moved here is a revolving fund fee, so the sheriff and indigent
+    defense fees in a different bucket were being emptied into MISCELLANEOUS
+    over a discrepancy that had nothing to do with them. J, K and L going empty
+    is what the statute of limitations and Polk sheets read as no debt to chase.
     """
-    felony_case['financials'][0]['amount'] = '31.00'
+    felony_case['financials'][0]['amount'] = '31.00'   # an OTHER line
     sheet = FakeSheet()
     crs.process_financials(felony_case, sheet, 4)
-    assert sheet.value_of('O4') == Decimal('719.00')   # COSTS 629 + OTHER 90
-    assert sheet.value_of('M4') is None                # detail is gone, as before
-    assert 'not a per-fee breakdown' in sheet.value_of('V4')
+    assert sheet.value_of('O4') == Decimal('90.00')    # OTHER, as a total
+    assert sheet.value_of('M4') == Decimal('579.00')   # sheriff fees survive
+    assert sheet.value_of('J4') == Decimal('50.00')    # indigent defense too
+    assert sheet.value_of('S4') == Decimal('500.00')
+    assert sheet.value_of('U4') == Decimal('1219.00')
+    assert 'OTHER' in sheet.value_of('V4')
+    assert 'category total' in sheet.value_of('V4')
 
 
 def test_a_collapsed_row_says_it_is_collapsed(felony_case):
@@ -216,10 +224,30 @@ def test_reconciliation_needs_both_halves(felony_case):
 
 def test_reconciliation_refuses_a_partition_that_does_not_add_up(felony_case):
     # If a fee lands in the wrong bucket the bucket stops matching its summary
-    # original. That must cost us the reconciliation, not produce a wrong split.
+    # original. That must cost us that bucket's split, not produce a wrong one.
     felony_case['financials'][0]['amount'] = '31.00'
     columns, note = crs.reconcile_financials(felony_case)
-    assert columns is None and note is None
+    assert columns == {
+        'M': Decimal('579.00'),
+        'J': Decimal('50.00'),
+        'O': Decimal('90.00'),    # OTHER, off the summary rather than by fee
+        'S': Decimal('500.00'),
+    }
+    assert 'P' not in columns     # no guessed split of the broken bucket
+    assert 'OTHER' in note
+
+
+def test_a_row_where_nothing_reconciles_falls_back_whole(felony_case):
+    # Every bucket broken is a summary row with extra steps, and it reads better
+    # as one sentence than as five.
+    for row in felony_case['financials']:
+        if row['amount'] is not None:
+            row['amount'] = str(Decimal(row['amount']) + 1)
+    assert crs.reconcile_financials(felony_case) == (None, None)
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    assert sheet.value_of('O4') == Decimal('719.00')   # COSTS 629 + OTHER 90
+    assert 'not a per-fee breakdown' in sheet.value_of('V4')
 
 
 def test_ambiguous_payment_is_flagged_not_guessed():
@@ -350,6 +378,36 @@ def test_an_unattributable_payment_keeps_its_category():
     columns, note = crs.reconcile_financials(case)
     assert columns == {'S': Decimal('75.00')}, 'not MISC'
     assert note is not None and 'RESTITUTION' in note
+
+
+def test_old_fee_debt_survives_a_broken_category_elsewhere():
+    """The twenty year old debt Iowa Legal Aid is actually litigating.
+
+    Attorney fees land in J and K and jail and room and board lands in L, and
+    the SOL and Polk sheets read those three columns and nothing else. A stray
+    revolving fund fee in a different summary category used to empty all three
+    into MISCELLANEOUS, and a case sitting in MISCELLANEOUS reads on those
+    sheets as a case with nothing to chase.
+    """
+    case = {
+        'total_due': '$425.00',
+        'summary_categories': _five_buckets(
+            COSTS=(Decimal('400.00'), Decimal('0')),
+            OTHER=(Decimal('50.00'), Decimal('25.00'))),
+        'financials': [
+            {'detail': 'INDIGENT DEFENSE-FELONY-REIMBURSE STATE',
+             'amount': '150.00', 'paid': None},
+            {'detail': 'JAIL FEES-ROOM/BOARD', 'amount': '250.00',
+             'paid': None},
+            {'detail': 'DELINQUENT REVOLVING FUND OBLIGATION',
+             'amount': '30.00', 'paid': None},
+        ],
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert columns['J'] == Decimal('150.00')
+    assert columns['L'] == Decimal('250.00')
+    assert columns['O'] == Decimal('25.00')
+    assert 'OTHER' in note
 
 
 def test_an_unattributable_payment_across_different_fees_still_falls_to_misc():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -139,6 +139,21 @@ def test_a_padded_defendant_is_still_read_as_a_defendant():
     assert cases[0]['role'] == 'DEFENDANT'
 
 
+def test_the_two_role_lists_do_not_overlap():
+    """A role in both would be suppressed and vouched for at the same time."""
+    assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)
+
+
+def test_the_roles_on_the_real_search_page_are_all_classified(search_page):
+    """The suppression list decides what is excluded and this one decides what
+    gets reported as unrecognised, so a role on a page we have should be in
+    exactly one of them or the alert cries wolf on every search."""
+    cases, _ = case_parser.parse_search(search_page)
+    unclassified = {case['role'] for case in cases
+                    if case['role'] not in case_parser.KNOWN_PARTY_ROLES}
+    assert unclassified == set()
+
+
 # -- what gets written to disk --------------------------------------------
 
 def test_parsing_writes_nothing_to_disk_by_default(search_page, tmp_path,

--- a/tests/test_workbook_limits.py
+++ b/tests/test_workbook_limits.py
@@ -1,0 +1,116 @@
+"""The CRS template's own limits, read back out of the template.
+
+Napier writes CASE DATA rows until it runs out of cases. The workbook it writes
+them into stops counting at some point on every sheet, and stops having rows at
+all a little further down, and Excel reports neither. The numbers in crs.py are
+what the finish page warns on, so they are checked against the two .xlsx files
+here rather than trusted: a CRS 3.6 that moves them fails this instead of
+quietly making the warning wrong.
+"""
+
+import os
+import re
+import sys
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
+
+# The three sheets whose row-1 totals are the ones staff read off.
+TOTALLED = ('SOL', 'BANKRUPTCY', 'EXEMPTIONS')
+
+
+def _total_range_end(sheet):
+    """Last row the =SUM() totals on row 1 reach, or None if there are none."""
+    for cell in sheet[1]:
+        if isinstance(cell.value, str) and cell.value.startswith('=SUM('):
+            match = re.search(r':[A-Z]+(\d+)\)', cell.value.replace('\n', ''))
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def _last_case_row_covered(sheet):
+    """Last CASE DATA row this sheet has a row for.
+
+    Each analysis sheet mirrors column A of CASE DATA, some of them offset by a
+    row or two, so the reference inside the formula is the honest answer rather
+    than the sheet's own row number.
+    """
+    last = None
+    for row in range(1, sheet.max_row + 1):
+        value = sheet.cell(row=row, column=1).value
+        if not isinstance(value, str):
+            continue
+        match = re.search(r"'CASE DATA'!A(\d+)", value)
+        if match:
+            last = max(last or 0, int(match.group(1)))
+    return last
+
+
+@pytest.fixture(scope='module')
+def full():
+    return load_workbook(FULL)
+
+
+@pytest.fixture(scope='module')
+def lite():
+    return load_workbook(LITE)
+
+
+def test_case_data_totals_stop_where_we_say_they_do(full, lite):
+    for workbook in (full, lite):
+        end = _total_range_end(workbook['CASE DATA'])
+        cases = end - crs.FIRST_CASE_ROW + 1
+        assert cases == crs.CASE_DATA_TOTAL_LIMIT
+
+
+def test_analysis_totals_stop_where_we_say_they_do(full):
+    ends = {name: _total_range_end(full[name]) for name in TOTALLED}
+    assert None not in ends.values(), ends
+    cases = min(ends.values()) - crs.FIRST_CASE_ROW + 1
+    assert cases == crs.ANALYSIS_TOTAL_LIMIT
+
+
+def test_the_lite_template_has_no_totalled_analysis_sheets(lite):
+    # The Lite warning skips the totals line, which is only right while this is.
+    assert not [name for name in TOTALLED if name in lite.sheetnames]
+
+
+def test_the_analysis_sheets_run_out_of_rows_where_we_say_they_do(full, lite):
+    for workbook, limit in ((full, crs.ANALYSIS_ROW_LIMIT),
+                            (lite, crs.LITE_ANALYSIS_ROW_LIMIT)):
+        covered = {}
+        for name in workbook.sheetnames:
+            if name == 'CASE DATA':
+                continue
+            last = _last_case_row_covered(workbook[name])
+            if last is not None:
+                covered[name] = last - crs.FIRST_CASE_ROW + 1
+        assert covered, 'no sheet mirrors CASE DATA any more'
+        assert min(covered.values()) == limit, covered
+
+
+def test_a_normal_run_says_nothing():
+    assert crs.workbook_limits(70, False) == []
+    assert crs.workbook_limits(70, True) == []
+
+
+def test_the_totals_warning_comes_first_and_only_for_the_full_template():
+    full = crs.workbook_limits(crs.ANALYSIS_TOTAL_LIMIT + 1, False)
+    assert len(full) == 1
+    assert 'SOL, BANKRUPTCY and EXEMPTIONS' in full[0]
+    assert crs.workbook_limits(crs.ANALYSIS_TOTAL_LIMIT + 1, True) == []
+
+
+def test_running_off_the_end_of_everything_says_so():
+    warnings = crs.workbook_limits(crs.CASE_DATA_TOTAL_LIMIT + 1, False)
+    assert len(warnings) == 3
+    assert 'CASE DATA' in warnings[0]


### PR DESCRIPTION
Four fixes that all share a shape: the workbook came out wrong and nothing said so.

## Per-category reconciliation

Reconciling was all or nothing. Napier sorted the itemized fee lines into the five ICOS summary categories, checked each against what the summary said was assessed, and if any one of them was off by a cent it threw away the fee breakdown for the whole case.

That zeroed J, K and L. The statute of limitations sheet looks for 20 year old attorney fees in J and K and 20 year old jail and room and board in L, and the Polk room and board sheet reads L, so a fallback row told both sheets there was nothing to chase. That is indistinguishable from a client with no old debt. Old cases are both what those sheets are for and the ones most likely to have an itemization that will not add up.

A category that reconciles is now reported fee by fee and a category that does not falls back on its own, into whichever J through S column its fees share, or MISCELLANEOUS if they are spread across columns. The rest of the row keeps its breakdown. NOTES names the categories that fell back and says the ICOS total is still right. T still equals U either way. When nothing on the row reconciles the function returns None and the caller writes the summary as before.

The tolerance is unchanged and deliberately tight: a fee read into the wrong category shows up as a shortfall in one and a matching excess in another, so both fail and neither is quietly wrong.

## The clinic date

BASIC INFO B3 was never written, and blank is not neutral in Excel. Every date test in the CRS compares against it and an empty cell reads as zero, so the SOL sheet asked whether the judgment date plus 7300 days was earlier than zero and reported that every case had no argument to make. The expungement clocks and the age 18 test read off the same cell.

Nothing failed and the answer was the plausible one. It is now today's date, as a real date value rather than text, formatted to match the sheet. Staff can type over it.

## Template capacity

CASE DATA totals are `=SUM(x4:x300)`, so case 298 is in the workbook and outside every total. SOL, BANKRUPTCY and EXEMPTIONS total only to row 100, and SOL runs out of formula rows at 147 cases. In Lite the first wall is EXPUNGEMENT & 910.7 at 198.

The finish page now says it, worst first, and says what is still true: every case is in the workbook and every row is right. Splitting the search is the way around it. The constants are read back out of both .xlsx files by `tests/test_workbook_limits.py`, so a new template that moves them fails the suite instead of leaving the warning wrong.

## Unclassified party roles

Napier decides who is a party by listing the roles that are not, so a role it has never seen is a party by default. That has been wrong four times, most recently NO ACCESS NONPARTY FILER, which put the actual defendant's convictions into a client's record summary.

A run now emails once when it sees a role outside `KNOWN_PARTY_ROLES`. Nothing branches on it: what goes in the workbook is unchanged. The alert carries the role string and nothing else, with a test asserting the client name, DOB and case id are all absent from the body. Excluding unrecognised roles instead is the bigger change and is not in this PR.

The suppression list also moved to module level as `NON_PARTY_ROLES`, out of the loop that rebuilt it once per result row. Otherwise unchanged, both WITNESS spellings included, with a test that the two sets do not overlap.

## Testing

212 passing. Each of the four commits was checked out and run on its own (197, 204, 210, 212) so the branch bisects cleanly. Fixtures stay on the `00000  FECR000000` pattern and carry no real case numbers or dates of birth.

The draft reply to Ari about court debt described the old all or nothing behaviour and has been revised locally to match this. It is unsent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t