### PR TITLE
Three columns the analysis sheets read, and one they read wrong

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -62,6 +62,13 @@ CLIENT_LOST = 'progress page lost contact with Napier'
 # noticing a stranger's convictions in a client's summary. This does not change
 # what is included: it says the list has a gap in it while the run is happening.
 NOVEL_ROLE = 'unrecognised party role on an ICOS search'
+# The same shape of gap one column over. charge_code_map turns the words Iowa
+# Courts uses for an outcome into the code the CRS wants, and a word missing
+# from it codes the case OTH, which four analysis sheets read as no conviction.
+# Nothing fails and the workbook is delivered, so the only way this has ever
+# surfaced is somebody noticing a sheet was wrong about a client. The alert
+# carries the ICOS wording and the case number and no defendant.
+UNKNOWN_DISPOSITION = 'unrecognised disposition on an ICOS case'
 
 # A run that eventually worked but took this many attempts is the early warning
 # that ICOS is degrading, which is worth one email before staff start noticing.

--- a/case_parser.py
+++ b/case_parser.py
@@ -182,6 +182,40 @@ def truncation_limit(soup):
         return None
 
 
+# ICOS words a disposition; the CRS wants a code. Hoisted out of
+# parse_case_charges, which rebuilt this literal once per call, so that
+# NOT_ADJUDICATED below can be checked against it by a test.
+charge_code_dict = {
+    "GUILTY": "GTR",
+    "DNU-GUILTY": "GTR",
+    "GUILTY BY COURT": "GTR",
+    "GUILTY - NEGOTIATED/VOLUN PLEA": "GPL",
+    "CONVERT TO SIMPLE MISDEM": "GPL",
+    "ACQUITTED": "ACQ",
+    "DISMISSED": "DISM",
+    "DNU-DISMISSED": "DISM",
+    "DISMISSED BY COURT": "DISM",
+    "DISMISSED BY OTHER": "DISM",
+    "DEFERRED": "DEF",
+    "NOT GUILTY": "ACQ",
+    "WAIVED TO ADULT COURT": "JWV",
+    "ADJUDICATED": "JUV",
+    "WITHDRAWN": "WTHD",
+    "NOT FILED": "NOTF",
+    "CIVIL": "CIV"
+}
+
+# The outcomes that mean no adjudicated charge, so the statutory code is not
+# the client's to carry. Column F feeds the expungement sheet, and a charge
+# listed there is a charge the sheet treats as adjudicated.
+#
+# This was two hardcoded lists that both said WITHD where the map says WTHD,
+# so withdrawn counts were never filtered and their statute rode into column
+# F alongside real convictions. One name, checked against the map by a test,
+# is the reason that cannot drift apart again.
+NOT_ADJUDICATED = frozenset({"WTHD", "DISM", "ACQ", "NOTF"})
+
+
 def parse_search(html):
     html = html.decode('utf-8', errors='ignore')
     _dump("search_results.html", html)
@@ -243,25 +277,6 @@ def parse_case_charges(html, case):
     prior_charge = str()
     prior_description = str()
     #disposition = {}
-    charge_code_dict = {
-        "GUILTY": "GTR",
-        "DNU-GUILTY": "GTR",
-        "GUILTY BY COURT": "GTR",
-        "GUILTY - NEGOTIATED/VOLUN PLEA": "GPL",
-        "CONVERT TO SIMPLE MISDEM": "GPL",
-        "ACQUITTED": "ACQ",
-        "DISMISSED": "DISM",
-        "DNU-DISMISSED": "DISM",
-        "DISMISSED BY COURT": "DISM",
-        "DISMISSED BY OTHER": "DISM",
-        "DEFERRED": "DEF",
-        "NOT GUILTY": "ACQ",
-        "WAIVED TO ADULT COURT": "JWV",
-        "ADJUDICATED": "JUV",
-        "WITHDRAWN": "WTHD",
-        "NOT FILED": "NOTF",
-        "CIVIL": "CIV"
-    }
     rows = soup.find_all('tr')
     for row in rows:
         cols = row.find_all('font')
@@ -330,10 +345,10 @@ def parse_case_charges(html, case):
         
     if cur_charge is not None:
         if ";" not in cur_charge['description']:
-            cur_charge['description'] = cur_charge['description'][:cur_charge['description'].index("[")] 
+            cur_charge['description'] = cur_charge['description'][:cur_charge['description'].index("[")]
             #print("Disposition: " + charge_code_dict.get(cur_charge['disposition'][0], "OTH"))
             disp_code = charge_code_dict.get(cur_charge['disposition'][0], "OTH")
-            if disp_code in ["WITHD", "DISM", "ACQ", "NOTF"]:
+            if disp_code in NOT_ADJUDICATED:
                 cur_charge['charge'] = ""
         else:
             cleaned_list = [] 
@@ -343,7 +358,7 @@ def parse_case_charges(html, case):
             filter_description_list = filter_description_string.split(";")
             combined_list = list(zip(filter_charge_list, filter_description_list))
             for index, charge_tuple in enumerate(combined_list):
-                if any(x in charge_tuple[1] for x in ["WITHD", "DISM", "ACQ", "NOTF"]):
+                if any("[" + x + "]" in charge_tuple[1] for x in NOT_ADJUDICATED):
                     #print("Excluding: " + charge_tuple[0] + " " + charge_tuple[1])
                     pass
                 else: 

--- a/crs.py
+++ b/crs.py
@@ -1,3 +1,5 @@
+import re
+
 from decimal import Decimal
 from openpyxl.styles import Alignment # Added import
 from openpyxl.styles import Font, PatternFill
@@ -65,6 +67,52 @@ charge_code_map = {
     "NOT FILED": {"NOTF":0},
     "CIVIL": {"CIV":0}
 }
+
+
+# Column H of CASE DATA, headed "Vehicular?". LICENSE-REGIS reads it in 299
+# formulas and it is the whole of the difference between the two answers that
+# sheet can give: convicted with debt and H="YES" is "License & registration",
+# anything else is "Registration only". Napier never wrote the column, so the
+# sheet has never once said "License & registration" about anybody. Blank is not
+# neutral there, it is a quiet "no".
+#
+# Iowa suspends a driver's licence for unpaid debt on a chapter 321 conviction
+# and holds vehicle registration for delinquent court debt of any kind, which is
+# the distinction the sheet is drawing. So the test is the chapter the statute
+# sits in, which Napier already has: it is the adjudicated statutory code in
+# column F.
+VEHICULAR_CHAPTER = re.compile(r'^\s*321[A-Z]?\.', re.I)
+# Homicide and serious injury by vehicle live in chapter 707 rather than 321 and
+# revoke a licence on conviction, so they are vehicular for this purpose even
+# though the chapter does not say so.
+VEHICULAR_SECTIONS = ('707.6A',)
+
+
+def is_vehicular(statutes):
+    """"YES", "NO", or None when there is nothing to judge from.
+
+    None matters. A civil case writes "n/a" into column F and a case whose only
+    counts were dismissed writes nothing at all, and in neither is there a
+    conviction for a licence to hang off. Saying "NO" there would be asserting
+    something Napier does not know, and the sheet reads a blank and a "NO"
+    identically anyway, so the honest answer costs nothing.
+
+    Any vehicular count carries the case. A client who pleaded to OWI and a
+    drugs count has a licence problem regardless of which count the CRS picked
+    to speak for the case in column G.
+    """
+    if not statutes:
+        return None
+    codes = [code.strip() for code in str(statutes).split(';')]
+    codes = [code for code in codes if code and code.lower() != 'n/a']
+    if not codes:
+        return None
+    for code in codes:
+        if VEHICULAR_CHAPTER.match(code):
+            return "YES"
+        if any(code.upper().startswith(section) for section in VEHICULAR_SECTIONS):
+            return "YES"
+    return "NO"
 
 
 def get_dominant_charge(charges):
@@ -579,6 +627,11 @@ def process_case(case, worksheet, row):
         cell_E.value = charge['description']
         worksheet['F' + i] = charge['charge']
         worksheet['G' + i] = charge['disposition']
+        # Only when we can tell. is_vehicular returns None for a case with no
+        # adjudicated statute, and the cell is left alone rather than told "NO".
+        vehicular = is_vehicular(charge['charge'])
+        if vehicular is not None:
+            worksheet['H' + i] = vehicular
 
     cell_E.alignment = Alignment(wrap_text=True) # Apply text wrapping
 

--- a/crs.py
+++ b/crs.py
@@ -180,27 +180,6 @@ def get_dominant_charge(charges):
     return delisted
 
 
-def get_primary_charge(charges):
-    if len(charges) == 0:
-        return None
-
-    charge = charges[0]
-    #creates list for [?]
-    charge['code'] = None
-    date = None
-    for c in charges:
-        disposition = c['disposition'].replace("DNU-", "")
-        charge = c
-        #print c
-        if not disposition:
-            charge['code'] = "NOTF"
-        elif disposition not in charge_code_map:
-            charge['code'] = "OTH"
-        else:
-            charge['code'] = charge_code_map[disposition]
-        
-    return charge
-
 def get_finance_column(detail):
     if "COLLECTION BY CO ATTY" in detail:
         return "P" # UNKNOWN

--- a/crs.py
+++ b/crs.py
@@ -68,6 +68,34 @@ charge_code_map = {
     "CIVIL": {"CIV":0}
 }
 
+# The rank for a disposition string charge_code_map has never seen. It sits
+# between a dismissal and a conviction on purpose.
+#
+# It used to be 3, above everything else here. So one unrecognised word on one
+# count of a case demoted the whole case to OTH, and OTH is not GTR, GPL or DEF,
+# which is the test four analysis sheets run before they say anything:
+# LICENSE-REGIS in 897 formulas, BANKRUPTCY in 396, EXEMPTIONS in 394, SOL in
+# 294. A client with a conviction and one stray code came out of all four
+# looking like a client with no conviction at all, and the workbook gave no sign
+# of it.
+#
+# Below a conviction now, so an unknown code cannot talk over one Napier
+# understands. Still above a dismissal, so a case whose counts are all
+# unrecognised reads as OTH rather than passing itself off as dismissed. Both
+# are guesses, which is why an unrecognised code is also named on its own row
+# and mailed out while the run is happening instead of being absorbed quietly.
+OTH_RANK = 0.5
+
+# What column V says about that row. The workbook outlives the alert and gets
+# read by whoever has the client in front of them, so the guess has to be
+# visible in the file itself and not only in Alex's inbox.
+UNKNOWN_DISPOSITION_NOTE = (
+    "Iowa Courts recorded a disposition Napier does not recognise (%s), so this "
+    "case is coded OTH. The expungement, bankruptcy, exemption and licence "
+    "sheets treat OTH as no conviction. Check this case in ICOS before relying "
+    "on what they say about it."
+)
+
 
 # Column H of CASE DATA, headed "Vehicular?". LICENSE-REGIS reads it in 299
 # formulas and it is the whole of the difference between the two answers that
@@ -124,24 +152,31 @@ def get_dominant_charge(charges):
 
     Returns a copy. The caller's charge keeps its list of dispositions, so
     calling this twice on the same case gives the same answer both times.
+
+    The copy carries 'unknown_dispositions', the ICOS wordings that produced an
+    OTH. Empty on almost every case. When it is not, the case is coded on a
+    guess and the caller is the one that has to say so.
     """
     if len(charges) == 0:
         return None
     delisted = dict(charges[0])
     raw_charge = delisted['disposition']
     charge_dict = {}
+    unknown = set()
     for disposition in raw_charge:
         disposition = disposition.replace("DNU-", "")
         if not disposition:
             charge_dict["NOTF"] = 0
         elif disposition not in charge_code_map:
-            charge_dict["OTH"] = 3
+            charge_dict["OTH"] = OTH_RANK
+            unknown.add(disposition)
         else:
             charge_key, rank = next(iter(charge_code_map[disposition].items()))
             charge_dict[charge_key] = rank
     sorted_tuples = sorted(charge_dict.items(), reverse=True,
                            key=lambda item: item[1] if item[1] is not None else float('inf'))
     delisted['disposition'] = sorted_tuples[0][0]
+    delisted['unknown_dispositions'] = sorted(unknown)
     return delisted
 
 
@@ -593,7 +628,23 @@ def process_financials(case, worksheet, row):
         if flagged:
             cell_v.font = MISMATCH_FONT
 
+def append_note(worksheet, row, text):
+    """Add to column V without displacing what process_financials put there.
+
+    A row can be both reconciled from the summary and coded on a guess, and the
+    two notes are about different things. Whichever is written second joins the
+    first rather than replacing it.
+    """
+    cell = worksheet['V' + str(row)]
+    cell.value = ("%s %s" % (cell.value, text)).strip() if cell.value else text
+
+
 def process_case(case, worksheet, row):
+    """Write one case into CASE DATA. Returns the dispositions it could not read.
+
+    Almost always empty. When it is not, the case is on the sheet under a code
+    Napier guessed at, and the return value is how the run gets to say so.
+    """
     i = str(row)
     worksheet['A' + i] = case['id']
     worksheet['B' + i] = case['county']
@@ -638,6 +689,14 @@ def process_case(case, worksheet, row):
     # If charge was None, we still need to process financials if it wasn't returned early
     if charge is None:
         # process_financials(case, worksheet, i) # Already called above if charge is None
-        return # Now we can return
+        return [] # Now we can return
 
     process_financials(case, worksheet, i)
+
+    # After process_financials, which owns column V, so the note joins whatever
+    # it wrote about the money rather than being overwritten by it.
+    unknown = charge.get('unknown_dispositions') or []
+    if unknown:
+        append_note(worksheet, i,
+                    UNKNOWN_DISPOSITION_NOTE % ", ".join(unknown))
+    return unknown

--- a/opener.py
+++ b/opener.py
@@ -1,7 +1,6 @@
 #import cookielib 
 import http.cookiejar
 import os
-import pickle
 import urllib, urllib.request, urllib.parse
 
 user_agent = u"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
@@ -38,13 +37,6 @@ class Opener:
         cookie_processor = urllib.request.HTTPCookieProcessor(self.cookieJar)
         self.opener = urllib.request.build_opener(cookie_processor)
         self.opener.addheaders = list(browser_headers)
-
-    def get_cookies(self):
-        return pickle.dumps(list(self.cookieJar))
-    
-    def load_cookies(self, encoded_cookies):
-        for cookie in pickle.loads(encoded_cookies):
-            self.cookieJar.set_cookie(cookie)
 
     def open(self, url, data=None, timeout=None):
         kw = {} if timeout is None else {"timeout": timeout}

--- a/tasks.py
+++ b/tasks.py
@@ -64,6 +64,33 @@ def report_novel_roles(job, cases):
     return novel
 
 
+def report_unknown_dispositions(job, unknown):
+    """Say when a case was coded on a guess, on the page and by email.
+
+    charge_code_map has a word for every outcome anyone has seen ICOS use.
+    Anything else codes the case OTH, and OTH is what the expungement,
+    bankruptcy, exemption and licence sheets read as no conviction, so a client
+    with a real conviction can come out of four sheets looking clean. The row
+    itself says so in column V, but the workbook goes to whoever runs the
+    clinic and the map only gets the missing word added if it reaches Alex.
+
+    The wording and the case number go out. Both are court public record and
+    neither is any use without the other: the word is what the map is missing
+    and the case is the page to read it off. The client is not in it.
+    """
+    for disposition, case_ids in sorted(unknown.items()):
+        job.log("Iowa Courts recorded \"%s\" on %d case%s, which Napier does not "
+                "recognise. Those rows are coded OTH and say so in the notes "
+                "column: %s."
+                % (disposition, len(case_ids), "" if len(case_ids) == 1 else "s",
+                   ", ".join(case_ids)))
+        alerts.record(job.id[:8], job.kind, alerts.UNKNOWN_DISPOSITION,
+                      progress=alerts.recent_progress(job),
+                      disposition=disposition,
+                      cases=", ".join(case_ids))
+    return sorted(unknown)
+
+
 def search_task(job, username, password, firstname, middlename, lastname):
     client = IcosClient(log=job.log, alert=alerts.emitter(job))
     keep_session = False
@@ -167,7 +194,8 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
             raise ValueError("no cases could be read")
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
-        path = build_workbook(cases, def_name, def_dob, is_lite)
+        path, unknown_dispositions = build_workbook(cases, def_name, def_dob, is_lite)
+        report_unknown_dispositions(job, unknown_dispositions)
         job.result = {
             "file": path,
             "def_name": def_name,
@@ -196,11 +224,20 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
 
 
 def build_workbook(cases, def_name, def_dob, is_lite):
+    """Returns the path written, and the dispositions Napier could not read.
+
+    The second value is a map of the ICOS wording to the case numbers it turned
+    up on. Empty on almost every run. When it is not, those cases are on the
+    sheet under a guessed code and somebody needs to know before the workbook is
+    used, so the caller reports it rather than the file quietly carrying it.
+    """
     workbook = load_workbook('CRS Lite 3.5.5.xlsx' if is_lite else 'CRS 3.5.5.xlsx')
     sheet = workbook['CASE DATA']
     row = 4
+    unknown = {}
     for case in cases:
-        crs.process_case(case, sheet, row)
+        for disposition in crs.process_case(case, sheet, row) or []:
+            unknown.setdefault(disposition, []).append(case['id'])
         row += 1
 
     sheet = workbook['BASIC INFO']
@@ -226,7 +263,7 @@ def build_workbook(cases, def_name, def_dob, is_lite):
     suffix = "_Lite_CRS_" if is_lite else "_CRS_"
     path = tmp_dir + safe_name + suffix + stamp + ".xlsx"
     workbook.save(path)
-    return path
+    return path, unknown
 
 
 def download_name(def_name, is_lite):

--- a/tests/test_basic_info.py
+++ b/tests/test_basic_info.py
@@ -20,7 +20,7 @@ import tasks
 
 def _build(is_lite=False):
     """A workbook with no cases in it. BASIC INFO does not depend on them."""
-    path = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
+    path, _ = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
     return load_workbook(path)['BASIC INFO'], path
 
 

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -82,7 +82,7 @@ def run(monkeypatch, case_ids, unavailable=()):
 
     def fake_build(cases, name, dob, lite):
         written.extend(case['id'] for case in cases)
-        return os.path.join(tasks.tmp_dir, 'stub.xlsx')
+        return os.path.join(tasks.tmp_dir, 'stub.xlsx'), {}
 
     monkeypatch.setattr(tasks, 'build_workbook', fake_build)
 

--- a/tests/test_charge_pages.py
+++ b/tests/test_charge_pages.py
@@ -1,0 +1,123 @@
+"""What comes off an ICOS charges page, and what column F is allowed to say.
+
+Column F is the adjudicated statutory code. The expungement sheet reads it in
+792 formulas, so a code sitting there is a charge that sheet treats as
+adjudicated against the client. A count that was dismissed, acquitted, never
+filed or withdrawn was not adjudicated and its statute does not belong there.
+
+Three of those four were filtered. Withdrawn was not, because the filter
+spelled it WITHD in two places and the map spells it WTHD, so the test at the
+bottom of this file is the one that matters most: it checks the filter against
+the map rather than against another copy of the filter.
+
+The pages here are synthetic. This repo is public and a real charges page is
+one person's unredacted criminal record.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+
+
+def _row(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page(*counts):
+    """An ICOS charges page. Each count is (statute, description, outcome)."""
+    html = ['<html><body><table>']
+    for number, (statute, description, outcome) in enumerate(counts, start=1):
+        html.append(_row('Count %d' % number))
+        html.append(_row('Offense Date:', '01/01/1900', ''))
+        html.append(_row('Adjudication'))
+        html.append(_row('Charge:', statute, '', description))
+        html.append(_row('Adjudication:', outcome, '', '02/02/1901'))
+    html.append('</table></body></html>')
+    return ''.join(html).encode('utf-8')
+
+
+def parse(*counts):
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(charges_page(*counts), case)
+    return case['charges'][0]
+
+
+GUILTY = ('124.401', 'SYNTHETIC FELONY', 'GUILTY')
+
+
+# -- what column F may carry ----------------------------------------------
+
+# Every outcome that means the count was not adjudicated, paired with the ICOS
+# wording that produces it. Parametrized rather than written out once, because
+# the bug was one member of this set behaving differently from the other three
+# and a test covering only DISMISSED passed the whole time.
+NOT_ADJUDICATED_WORDINGS = [
+    ('WITHDRAWN', 'WTHD'),
+    ('DISMISSED', 'DISM'),
+    ('DISMISSED BY COURT', 'DISM'),
+    ('ACQUITTED', 'ACQ'),
+    ('NOT GUILTY', 'ACQ'),
+    ('NOT FILED', 'NOTF'),
+]
+
+
+@pytest.mark.parametrize('outcome,code', NOT_ADJUDICATED_WORDINGS)
+def test_a_count_that_was_not_adjudicated_leaves_column_f_empty(outcome, code):
+    assert parse(('321.218', 'SYNTHETIC OFFENSE', outcome))['charge'] == ''
+
+
+@pytest.mark.parametrize('outcome,code', NOT_ADJUDICATED_WORDINGS)
+def test_it_is_dropped_from_a_case_that_also_has_a_conviction(outcome, code):
+    """The plea deal shape: plead to one count, the rest go away.
+
+    The surviving count's statute is the client's. The others are not, and on
+    this path they were being joined onto it with a semicolon.
+    """
+    charge = parse(GUILTY, ('321.218', 'SYNTHETIC OFFENSE', outcome))
+    assert charge['charge'] == '124.401'
+    assert '321.218' not in charge['charge']
+    # The count is still described, so nothing is hidden from a reader. It is
+    # only the statutory code the analysis sheets read that it stays out of.
+    assert code in charge['description']
+
+
+def test_a_conviction_keeps_its_statute():
+    """Guard against a filter that passes the tests above by dropping all of them."""
+    assert parse(GUILTY)['charge'] == '124.401'
+
+
+def test_two_convictions_both_survive():
+    charge = parse(GUILTY, ('321J.2', 'SYNTHETIC OWI', 'GUILTY BY COURT'))
+    assert charge['charge'] == '124.401;321J.2'
+
+
+def test_a_deferred_judgment_is_adjudicated():
+    """A deferred judgment is still an adjudication and still carries debt."""
+    assert parse(('321J.2', 'SYNTHETIC OWI', 'DEFERRED'))['charge'] == '321J.2'
+
+
+# -- the invariant the typo broke ------------------------------------------
+
+def test_every_not_adjudicated_code_is_one_the_map_can_produce():
+    """The check the old code could not do, because it compared two copies.
+
+    NOT_ADJUDICATED held WITHD and the map produced WTHD, so withdrawn counts
+    were never filtered and no test noticed for as long as the filter was only
+    ever compared against itself. Anchoring it to the map means a rename on
+    either side fails here instead of quietly widening column F.
+    """
+    produced = set(case_parser.charge_code_dict.values())
+    assert case_parser.NOT_ADJUDICATED <= produced, (
+        case_parser.NOT_ADJUDICATED - produced)
+
+
+def test_the_outcomes_that_are_convictions_are_not_in_it():
+    """The other direction: filtering a guilty code would empty column F."""
+    convictions = {'GTR', 'GPL', 'DEF', 'JUV'}
+    assert not (case_parser.NOT_ADJUDICATED & convictions)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -92,7 +92,7 @@ def fake_icos(monkeypatch):
     monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
                         lambda html, case: case.update(financials=[], total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: _write_stub_workbook())
+                        lambda cases, name, dob, lite: (_write_stub_workbook(), {}))
     yield
 
 

--- a/tests/test_unknown_disposition.py
+++ b/tests/test_unknown_disposition.py
@@ -1,0 +1,248 @@
+"""What happens to a case ICOS words in a way Napier has never seen.
+
+charge_code_map holds every outcome anyone has watched ICOS produce. Anything
+else becomes OTH, and OTH is not GTR, GPL or DEF, which is the test the
+expungement, bankruptcy, exemption and licence sheets run before they say
+anything about a case. So an unrecognised word does not fail. It codes a client
+with a real conviction as somebody with none, on four sheets at once, in a file
+that is about to be used to advise them.
+
+The old rank made that worse than it had to be: OTH was 3, above a conviction,
+so a single stray count on a nine count case took the whole case with it.
+
+Nothing here can make Napier understand a word it has not been taught. What it
+can do is stop the guess from overruling what Napier does know, and make the
+guess impossible to miss. Three ways, because a workbook and an inbox are read
+by different people at different times: the rank, the note on the row, and the
+email.
+"""
+
+import os
+import sys
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import alerts
+import crs
+import tasks
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+# Not a real ICOS wording, which is the point: it stands for whatever Iowa
+# Courts starts writing next.
+NOVEL = 'SYNTHETIC OUTCOME NOBODY HAS TAUGHT NAPIER'
+
+
+def _charge(*dispositions):
+    return [{'description': 'SYNTHETIC OFFENSE', 'charge': '124.401',
+             'disposition': list(dispositions),
+             'offenseDate': '01/01/1900', 'dispositionDate': '02/02/1901'}]
+
+
+# -- the rank ---------------------------------------------------------------
+
+def test_a_stray_code_no_longer_takes_the_conviction_with_it():
+    """The bug. One unreadable count on a case that also has a guilty plea.
+
+    This is the whole of it: the case is a conviction, ICOS said so on one of
+    the counts, and Napier used to throw that away because it could not read a
+    different count.
+    """
+    charge = _charge('GUILTY - NEGOTIATED/VOLUN PLEA', NOVEL)
+    assert crs.get_dominant_charge(charge)['disposition'] == 'GPL'
+
+
+def test_it_does_not_take_a_deferred_judgment_either():
+    """DEF outranks a plain guilty, so it is the one furthest from OTH."""
+    assert crs.get_dominant_charge(
+        _charge('DEFERRED', NOVEL))['disposition'] == 'DEF'
+
+
+def test_a_case_that_is_only_unreadable_still_reads_as_unreadable():
+    """The other direction, and the reason OTH is not ranked below everything.
+
+    A case Napier cannot read at all must not pass itself off as dismissed.
+    Staff seeing OTH go and look; staff seeing DISM do not.
+    """
+    assert crs.get_dominant_charge(_charge(NOVEL))['disposition'] == 'OTH'
+    assert crs.get_dominant_charge(
+        _charge('DISMISSED BY COURT', NOVEL))['disposition'] == 'OTH'
+
+
+def test_the_rank_sits_between_a_dismissal_and_a_conviction():
+    """Pinning the two tests above to the constant they both depend on."""
+    dismissals = [rank for entry in crs.charge_code_map.values()
+                  for rank in entry.values() if rank == 0]
+    convictions = [rank for entry in crs.charge_code_map.values()
+                   for rank in entry.values() if rank >= 1]
+    assert max(dismissals) < crs.OTH_RANK < min(convictions)
+
+
+def test_the_unreadable_wording_comes_back_out():
+    charge = _charge('GUILTY', NOVEL)
+    assert crs.get_dominant_charge(charge)['unknown_dispositions'] == [NOVEL]
+
+
+def test_a_case_napier_can_read_reports_nothing():
+    charge = _charge('GUILTY', 'DISMISSED BY COURT')
+    assert crs.get_dominant_charge(charge)['unknown_dispositions'] == []
+
+
+def test_the_dnu_prefix_is_stripped_before_the_map_is_asked():
+    """Otherwise every DNU- case reports itself as unreadable and the alert is noise."""
+    assert crs.get_dominant_charge(
+        _charge('DNU-GUILTY'))['unknown_dispositions'] == []
+
+
+# -- the note on the row ----------------------------------------------------
+
+def _case(*dispositions):
+    return {
+        'id': '00000  FECR000000',
+        'county': 'SYNTHETIC',
+        'charges': _charge(*dispositions),
+        'financials': [],
+        'summary_categories': [],
+    }
+
+
+def _row(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    unknown = crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
+    row = str(crs.FIRST_CASE_ROW)
+    return unknown, sheet['G' + row].value, sheet['V' + row].value
+
+
+def test_the_row_says_it_was_coded_on_a_guess():
+    """The workbook outlives the alert and goes to whoever runs the clinic."""
+    unknown, code, note = _row(_case(NOVEL))
+    assert unknown == [NOVEL]
+    assert code == 'OTH'
+    assert NOVEL in note
+    assert 'OTH' in note
+
+
+def test_the_note_names_every_wording_it_could_not_read():
+    other = 'SECOND SYNTHETIC OUTCOME'
+    _, _, note = _row(_case(NOVEL, other))
+    assert NOVEL in note and other in note
+
+
+def test_a_case_napier_can_read_gets_no_note():
+    """Column V is not empty here. process_financials has its own say about
+    where the fee figures came from, and that is not this note's business."""
+    unknown, code, note = _row(_case('GUILTY'))
+    assert unknown == []
+    assert code == 'GTR'
+    assert NOVEL not in (note or '')
+    assert 'OTH' not in (note or '')
+
+
+def test_the_note_does_not_displace_what_the_money_put_there():
+    """process_financials owns column V and writes it first. Both notes matter.
+
+    A row can be coded on a guess and have its fee figures come from a fallback
+    at the same time, and the fee note is the one staff have been trained to
+    look for. Appending rather than assigning is why both survive.
+    """
+    _, _, money_only = _row(_case('GUILTY'))
+    _, _, both = _row(_case(NOVEL))
+    assert money_only, 'this case is supposed to carry a fee note'
+    assert money_only in both
+    assert NOVEL in both
+
+
+# -- the email --------------------------------------------------------------
+
+class FakeJob(object):
+    id = 'synthetic-job-id'
+    kind = 'crs'
+
+    def __init__(self):
+        self.progress = []
+        self.messages = []
+
+    def log(self, message, **kwargs):
+        self.messages.append(message)
+
+
+@pytest.fixture(autouse=True)
+def clean_alerts():
+    alerts.reset()
+    yield
+    alerts.reset()
+
+
+def _recorded(monkeypatch):
+    sent = []
+    monkeypatch.setattr(alerts, 'record',
+                        lambda *a, **kw: sent.append((a, kw)))
+    return sent
+
+
+def test_an_unreadable_disposition_is_mailed_out(monkeypatch):
+    """The map only gets the missing word added if it reaches Alex.
+
+    Every other signal here lives in a file on somebody else's desk.
+    """
+    sent = _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, {NOVEL: ['00000  FECR000000']})
+    assert len(sent) == 1
+    args, kwargs = sent[0]
+    assert args[2] == alerts.UNKNOWN_DISPOSITION
+    assert kwargs['disposition'] == NOVEL
+    assert '00000  FECR000000' in kwargs['cases']
+
+
+def test_the_alert_carries_no_defendant(monkeypatch):
+    """Article 5. The wording and the case number are public record; a client is not.
+
+    Both of those are needed to fix the map: the word is what is missing from
+    it and the case is the ICOS page to read the wording off. Nothing else is.
+    """
+    sent = _recorded(monkeypatch)
+    tasks.report_unknown_dispositions(
+        FakeJob(), {NOVEL: ['00000  FECR000000']})
+    _, kwargs = sent[0]
+    assert set(kwargs) <= {'progress', 'disposition', 'cases'}
+
+
+def test_the_run_says_so_on_the_progress_page_too(monkeypatch):
+    """Staff read the finish page. Alex reads the mail. Both need to know."""
+    _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, {NOVEL: ['00000  FECR000000']})
+    assert any(NOVEL in message for message in job.messages)
+    assert any('OTH' in message for message in job.messages)
+
+
+def test_a_clean_run_says_nothing_anywhere(monkeypatch):
+    sent = _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, {})
+    assert sent == [] and job.messages == []
+
+
+def test_one_alert_per_wording_not_per_case(monkeypatch):
+    """A clinic pulling seventy cases through one new ICOS wording is one email."""
+    sent = _recorded(monkeypatch)
+    tasks.report_unknown_dispositions(
+        FakeJob(), {NOVEL: ['00000  FECR000000', '00000  FECR000001',
+                            '00000  FECR000002']})
+    assert len(sent) == 1
+    assert sent[0][1]['cases'].count(',') == 2
+
+
+# -- and that a real run carries it through --------------------------------
+
+def test_the_workbook_build_hands_the_wordings_back(tmp_path, monkeypatch):
+    """process_case can report all it likes if build_workbook drops it."""
+    monkeypatch.setattr(tasks, 'tmp_dir', str(tmp_path) + os.sep)
+    _, unknown = tasks.build_workbook(
+        [_case(NOVEL), _case('GUILTY')], 'TEST CLIENT', '01/01/1980', False)
+    assert unknown == {NOVEL: ['00000  FECR000000']}

--- a/tests/test_vehicular.py
+++ b/tests/test_vehicular.py
@@ -1,0 +1,210 @@
+"""Column H, "Vehicular?", and the sheet that has been reading it empty.
+
+LICENSE-REGIS asks one question per case: does unpaid debt on this case cost the
+client a driver's licence, or only a vehicle registration. It answers it from
+CASE DATA column H, and Napier has never written column H, so the answer has
+been "Registration only" on every case of every workbook the app has produced.
+That is not a formatting problem. A client is told their licence is safe when
+it is not.
+
+The first half of this file pins what Napier now writes there. The second half
+pins why "YES" is the string, by reading the formula back out of the template
+rather than trusting a comment: if CRS 3.6 renames the sentinel or moves the
+column, the sheet goes quietly wrong again and these fail instead.
+"""
+
+import os
+import re
+import sys
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
+
+
+# -- what Napier writes -----------------------------------------------------
+
+VEHICULAR = [
+    ('321J.2', 'OWI, the reason most of these clients lose a licence'),
+    ('321.218', 'driving while barred'),
+    ('321.174', 'no valid licence'),
+    ('321.560', 'habitual offender'),
+    ('321A.32', 'financial responsibility'),
+    ('321.20A', 'a subsection, so the chapter test cannot key on length'),
+    ('707.6A', 'homicide by vehicle, chapter 707 but revokes a licence'),
+    ('707.6A(1)', 'the same with a subsection'),
+]
+
+
+@pytest.mark.parametrize('statute,why', VEHICULAR)
+def test_a_vehicular_statute_says_yes(statute, why):
+    assert crs.is_vehicular(statute) == "YES", why
+
+
+NOT_VEHICULAR = [
+    ('124.401', 'controlled substances'),
+    ('714.1', 'theft'),
+    ('708.2', 'assault'),
+    ('707.6', 'not 707.6A. The vehicular section is the one with the A'),
+    ('32.1', 'chapter 32, which is not 321 and must not match on a prefix'),
+    ('3210.1', 'no such chapter, but a prefix test would call it vehicular'),
+]
+
+
+@pytest.mark.parametrize('statute,why', NOT_VEHICULAR)
+def test_a_statute_that_is_not_vehicular_says_no(statute, why):
+    assert crs.is_vehicular(statute) == "NO", why
+
+
+NOTHING_TO_JUDGE = [
+    ('', 'every count was dismissed, so column F is empty'),
+    (None, 'no charge at all'),
+    ('n/a', 'a civil case, which is what the civil branch writes into F'),
+    ('  ', 'whitespace'),
+]
+
+
+@pytest.mark.parametrize('statutes,why', NOTHING_TO_JUDGE)
+def test_it_says_nothing_when_there_is_nothing_to_say(statutes, why):
+    """Blank, not "NO".
+
+    A blank and a "NO" read the same to the sheet, so this costs nothing there
+    and it stops the workbook asserting to a reader that Napier checked and
+    found no vehicular charge when it had nothing to check.
+    """
+    assert crs.is_vehicular(statutes) is None, why
+
+
+def test_one_vehicular_count_carries_the_case():
+    """Column F is semicolon-joined and the licence follows any count in it.
+
+    Plead to possession and OWI together and column G says GPL once for the
+    whole case, but the licence consequence attaches to the OWI whichever count
+    the ranking picked to speak for it.
+    """
+    assert crs.is_vehicular('124.401;321J.2') == "YES"
+    assert crs.is_vehicular('321J.2;124.401') == "YES"
+
+
+def test_several_counts_none_of_them_vehicular():
+    assert crs.is_vehicular('124.401;714.1;708.2') == "NO"
+
+
+def test_spacing_around_the_semicolon_does_not_matter():
+    assert crs.is_vehicular('124.401; 321J.2') == "YES"
+
+
+# -- and that it reaches the cell -------------------------------------------
+
+# The tests above would all have passed against a version of Napier that never
+# wrote column H, because they call is_vehicular directly. These are the ones
+# that would not: they write a case into a worksheet the way a real run does.
+
+def _case(statutes, disposition='GUILTY BY PLEA'):
+    return {
+        'id': '00000  FECR000000',
+        'county': 'SYNTHETIC',
+        'charges': [{
+            'charge': statutes,
+            'description': 'SYNTHETIC OFFENSE',
+            'disposition': [disposition],
+            'offenseDate': '01/01/1900',
+            'dispositionDate': '02/02/1901',
+        }],
+        # No money on the case. The financial columns have their own tests.
+        'financials': [],
+        'summary_categories': [],
+    }
+
+
+def _written(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
+    row = str(crs.FIRST_CASE_ROW)
+    return sheet['F' + row].value, sheet['H' + row].value
+
+
+def test_a_vehicular_case_reaches_column_h():
+    assert _written(_case('321J.2')) == ('321J.2', 'YES')
+
+
+def test_a_non_vehicular_case_reaches_column_h():
+    assert _written(_case('124.401')) == ('124.401', 'NO')
+
+
+def test_a_case_with_no_adjudicated_statute_leaves_column_h_alone():
+    """Every count dismissed. Column F is empty and so is H."""
+    assert _written(_case('', disposition='DISMISSED')) == ('', None)
+
+
+def test_a_civil_case_leaves_column_h_alone():
+    """The civil branch writes "n/a" into F, which is not a statute."""
+    civil = {
+        'id': '00000  SCSC000000',
+        'county': 'SYNTHETIC',
+        'charges': [],
+        'summary_created_date': '01/01/1900',
+        'summary_disposition_date': '02/02/1901',
+        'summary_dispo_status': 'SYNTHETIC STATUS',
+        'financials': [],
+        'summary_categories': [],
+    }
+    assert _written(civil) == ('n/a', None)
+
+
+# -- what the sheet does with it --------------------------------------------
+
+def _license_regis_formula(path):
+    """The first LICENSE-REGIS formula that reads CASE DATA column H."""
+    sheet = load_workbook(path)['LICENSE-REGIS']
+    for row in sheet.iter_rows():
+        for cell in row:
+            if isinstance(cell.value, str) and "'CASE DATA'!H" in cell.value:
+                return cell.value.replace('\n', '')
+    return None
+
+
+def test_the_full_template_asks_column_h_about_the_licence():
+    formula = _license_regis_formula(FULL)
+    assert formula is not None, "LICENSE-REGIS stopped reading column H"
+    assert 'License & registration' in formula
+    assert 'Registration only' in formula
+
+
+def test_yes_is_the_string_the_sheet_is_testing_for():
+    """The reason is_vehicular returns "YES" and not True or "Y".
+
+    The sheet compares column H against a literal. Anything else Napier could
+    write there is indistinguishable from an empty cell, which is exactly the
+    state this whole change is fixing.
+    """
+    formula = _license_regis_formula(FULL)
+    match = re.search(r"'CASE DATA'!H\d+\s*=\s*\"([^\"]*)\"", formula)
+    assert match, formula
+    assert match.group(1) == "YES"
+
+
+def test_the_lite_template_asks_the_same_question():
+    """Lite drops three sheets but keeps this one, and staff use it far more."""
+    formula = _license_regis_formula(LITE)
+    assert formula is not None
+    match = re.search(r"'CASE DATA'!H\d+\s*=\s*\"([^\"]*)\"", formula)
+    assert match and match.group(1) == "YES", formula
+
+
+def test_the_sheet_only_asks_once_the_case_is_a_conviction_with_debt():
+    """Context for the blank-when-unknown choice above.
+
+    Column H is only reached when the case has debt and a conviction code, so a
+    civil case or an all-dismissed case never gets asked. Writing "NO" into
+    those rows would have been noise that changed no answer.
+    """
+    formula = _license_regis_formula(FULL)
+    assert 'GTR' in formula and 'GPL' in formula and 'DEF' in formula


### PR DESCRIPTION
Four fixes to what Napier writes into CASE DATA. All of them change what the analysis sheets say about a client, and none of them failed loudly enough for anyone to have noticed from the app.

**Withdrawn charges were riding into column F.** The filter that keeps unadjudicated counts out of the adjudicated statutory code column spelled withdrawn `WITHD` in two places where the map spells it `WTHD`. Dismissed, acquitted and not-filed were filtered; withdrawn never was. The expungement sheet reads column F in 792 formulas and treats a code sitting there as adjudicated, so a charge the client had withdrawn was being counted against them. The two lists are now one name checked against the map's own values by a test, so a rename on either side fails instead of quietly widening the column.

**Column H was never written at all.** LICENSE-REGIS decides between "License & registration" and "Registration only" from CASE DATA column H, "Vehicular?", and Napier has never written it. A blank reads as no, so that sheet has never once said "License & registration" about anybody. Napier now derives it from the statutory codes it already puts in column F: the chapter 321 family, plus homicide and serious injury by vehicle, which sit in chapter 707 but revoke a licence on conviction. Any count carries the case. Where there is no adjudicated statute the cell is left alone rather than told "NO", because the sheet reads a blank the same way and a "NO" would claim Napier checked when it had nothing to check.

**One unreadable word could erase a conviction.** A disposition `charge_code_map` has never seen codes the case OTH, and OTH was ranked above every real outcome, so a single stray count took the whole case with it. OTH is not GTR, GPL or DEF, which is the test four sheets run before they say anything: 1,981 formulas across LICENSE-REGIS, BANKRUPTCY, EXEMPTIONS and SOL. A client with a guilty plea came out of all of them looking unconvicted. The rank is now 0.5, below a conviction so it cannot talk over one Napier understands, still above a dismissal so an all-unreadable case does not pass itself off as dismissed. It is still a guess, so it stops being a silent one: the row names the wording in column V, the progress page says it during the run, and it emails, carrying the ICOS wording and the case number and no defendant.

**Two dead things deleted.** `Opener.get_cookies`/`load_cookies` pickle a cookie jar and nothing calls them, which leaves a `pickle.loads` in a web app for somebody to wire up later. `crs.get_primary_charge` has no callers and does not work: its loop reassigns on every iteration, so it returns whichever count ICOS listed last.

## Verification

275 tests, up from 212 on `main`. Three new files, and each fix was checked by putting the old behaviour back:

- revert the `WITHD` spelling: 3 fail, 14 pass
- take the column H write back out: 2 fail, 27 pass
- put `OTH_RANK` back to 3: 3 fail, 14 pass
- take the column V note back out: 3 more fail

The template tests read the sentinel back out of both `CRS 3.5.5.xlsx` and `CRS Lite 3.5.5.xlsx` rather than trusting a comment, so a CRS 3.6 that renames `"YES"` or moves the column fails here instead of going quietly wrong again.

`build_workbook` now returns `(path, unknown_dispositions)`. Three test call sites updated.

## Still open

Column I, "Under supervison?", is also never written, and the expungement sheet's "Amount of debt subject to 910.7?" reads `n/a` on every row of every workbook because of it. Napier cannot derive it from the ICOS case pages. That one is a question for Iowa Legal Aid rather than a fix, and it is drafted.

Every fixture here is synthetic. This repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t