### PR TITLE
Sentence dates, payment history, a one-page action list, and clinic batch mode

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -1,0 +1,550 @@
+"""The page a clinic actually works from.
+
+The CRS workbook answers seven different questions on seven different sheets,
+one row per case on each, and nobody sitting across from a client reads seven
+sheets. The arguments worth making are scattered: a twenty year old attorney
+fee is on SOL, the case it sits on is on CASE DATA, whether that case is also
+expungeable is on EXPUNGEMENT, and whether the licence is the reason the client
+came in is on LICENSE-REGIS. Finding the three that matter means cross
+referencing all of them by case number, by hand, while somebody waits.
+
+So this collects them into one ranked list. Every line names a case, what to do
+about it, the authority for doing it, and the money at stake, and the list is
+sorted so the biggest number is at the top.
+
+Two rules this module holds to.
+
+It reads the values Napier has already written into CASE DATA rather than
+recomputing them from the ICOS pages. The analysis sheets read those same
+cells, so a list built from them cannot disagree with the workbook it is
+bound into. Recomputing from the source would have been tidier and would have
+drifted the first time either side changed.
+
+And it only mirrors tests the workbook already makes. The twenty year cut is
+the SOL sheet's 7300 days, the dismissal test is the EXPUNGEMENT sheet's list
+of codes, the licence test is LICENSE-REGIS's. Nothing here is a new legal
+opinion. Where the sheet is silent this is silent too.
+"""
+
+from decimal import Decimal
+
+from openpyxl.styles import Alignment, Font, PatternFill
+
+import crs
+
+# Twenty years, counted the way the SOL sheet counts it. That sheet writes
+# 'CASE DATA'!D4+7300, so the arithmetic here is days rather than calendar
+# years on purpose: matching the workbook matters more than being right about
+# leap days, and a list that disagreed with the sheet beside it would be worse
+# than either.
+SOL_DAYS = 7300
+
+# The disposition codes each sheet tests for, taken from the sheets.
+CONVICTION_CODES = frozenset({'GTR', 'GPL', 'DEF'})  # LICENSE-REGIS
+CLEARED_CODES = frozenset({'DISM', 'ACQ', 'NOTF', 'WTHD', 'TNSF'})  # EXPUNGEMENT I
+JUVENILE_CODE = 'JUV'
+
+# Columns, by the letter they carry on CASE DATA.
+FEE_COLUMNS = 'JKLMNOPQRS'         # everything owed, which is what T sums
+REMISSIBLE_COLUMNS = 'JKLMNOP'     # what 910.7 can reach, per EXPUNGEMENT D
+ATTORNEY_AND_COLLECTION = 'JK'     # SOL C
+ROOM_AND_BOARD = 'L'               # SOL D, and the whole of POLK R&B APPEAL
+
+# Ranking. The list is sorted by money first, so these only decide ties, but
+# they also decide what a staffer reads first among the rows carrying no
+# figure at all.
+TIER_TIME_BARRED = 1
+TIER_DISMISSED = 2
+TIER_REMISSION = 3
+TIER_ROOM_AND_BOARD = 4
+TIER_MISDEMEANOUR = 5
+TIER_LICENCE = 6
+TIER_JUVENILE = 7
+
+HEADER_FILL = PatternFill('solid', fgColor='DDDDDD')
+HEADER_FONT = Font(bold=True)
+TITLE_FONT = Font(bold=True, size=14)
+CAVEAT_FONT = Font(italic=True, color='996600')
+
+
+def _decimal(value):
+    """A money cell as a Decimal. Blank, text and None all come back as zero."""
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    return Decimal(0)
+
+
+def _sum(facts, columns):
+    return sum((_decimal(facts['money'].get(column)) for column in columns),
+               Decimal(0))
+
+
+def row_facts(worksheet, row):
+    """What Napier wrote on one CASE DATA row, as the sheets will read it.
+
+    Dates come back as dates. Napier writes them as the strings ICOS uses and
+    Excel coerces those in arithmetic, which is why the SOL sheet works, but
+    nothing in Python coerces them and a string compared against a date is a
+    TypeError rather than a wrong answer.
+    """
+    def cell(column):
+        return worksheet[column + str(row)].value
+
+    return {
+        'row': row,
+        'id': cell('A'),
+        'county': cell('B'),
+        'disposition_date': crs.parse_us_date(cell('D')),
+        'description': cell('E'),
+        'statute': cell('F'),
+        'code': (cell('G') or '').strip().upper(),
+        'vehicular': (cell('H') or '').strip().upper() == 'YES',
+        'supervised': (cell('I') or '').strip().upper() == 'YES',
+        'money': {column: cell(column) for column in FEE_COLUMNS},
+        'icos_total': _decimal(cell('U')),
+        'notes': cell('V') or '',
+    }
+
+
+def is_traffic(facts):
+    """The EXPUNGEMENT sheet's TRAFFIC test, which is a bar to 901C.2.
+
+    A simple misdemeanour under chapter 321, or any case whose number carries
+    ST or NT in positions 8 and 9. Reproduced from the sheet rather than
+    reasoned about, so that a case this calls traffic is exactly the set the
+    sheet calls traffic.
+    """
+    case_id = facts['id'] or ''
+    kind = case_id[7:9].upper()
+    if kind in ('ST', 'NT'):
+        return True
+    return kind == 'SM' and (facts['statute'] or '').startswith('321.')
+
+
+# Eight years, the way the EXPUNGEMENT sheet counts it: C3+2920.
+MISDEMEANOUR_WAIT_DAYS = 2920
+
+# Chapters the sheet rules out by prefix rather than by listing every section.
+INELIGIBLE_CHAPTERS = ('717C', '719', '720', '724', '726', '728', '901A')
+
+
+def code_lists(workbook):
+    """The felony and ineligible-misdemeanour lists, read out of the workbook.
+
+    CODE SECTIONS carries both, and the EXPUNGEMENT sheet's own eligibility
+    formulas match against them by prefix. Reading them here rather than
+    keeping a second copy in Python means a clinic that adds a section to the
+    sheet gets it in the action list too, and the two cannot drift.
+    """
+    sheet = workbook['CODE SECTIONS']
+    felonies = [str(cell.value).strip() for (cell,) in
+                sheet.iter_rows(min_row=2, min_col=22, max_col=22)
+                if cell.value]
+    misdemeanours = [str(cell.value).strip() for (cell,) in
+                     sheet.iter_rows(min_row=2, min_col=24, max_col=24)
+                     if cell.value]
+    return felonies, misdemeanours
+
+
+def statutes(facts):
+    """The statutes on a case, the way the helper columns split them.
+
+    Napier joins a case's adjudicated statutes with semicolons into column F,
+    and W through AH split them back out for the eligibility formulas to match
+    against. This is that split.
+    """
+    return [part.strip() for part in (facts['statute'] or '').split(';')
+            if part.strip()]
+
+
+def _matches(statute, prefixes):
+    return any(statute.upper().startswith(prefix.upper()) for prefix in prefixes)
+
+
+def misdemeanour_expungement(facts, as_of, felonies, ineligible):
+    """The EXPUNGEMENT sheet's 901C.3 test, columns M, N and S.
+
+    Misdemeanour conviction, no section on the felony list, nothing on the
+    ineligible list or in an excluded chapter, and eight years since the
+    disposition. Returns True only when all four hold.
+
+    What it does not check, because the sheet asks a person to: a subsequent
+    conviction, a pending charge, a CDL, and whether the debt is paid off,
+    which 901C.3 requires before anything gets expunged.
+    """
+    if facts['code'] not in ('GTR', 'GPL') or is_traffic(facts):
+        return False
+    found = statutes(facts)
+    if not found:
+        return False
+    if any(_matches(statute, felonies) for statute in found):
+        return False
+    if any(_matches(statute, ineligible) or _matches(statute, INELIGIBLE_CHAPTERS)
+           for statute in found):
+        return False
+    when = facts['disposition_date']
+    return when is not None and (as_of - when).days > MISDEMEANOUR_WAIT_DAYS
+
+
+def time_barred(facts, as_of):
+    """Whether the disposition is more than twenty years behind the clinic."""
+    when = facts['disposition_date']
+    if when is None:
+        return False
+    return (as_of - when).days > SOL_DAYS
+
+
+def case_actions(facts, as_of, sheets, codes=((), ())):
+    """Everything worth doing about one case, as (tier, amount, do, cite, why).
+
+    sheets is the set of sheet names the workbook has, because the Lite
+    workbook ships without SOL, BANKRUPTCY and EXEMPTIONS, and pointing a
+    staffer at a sheet that is not in the file they are holding is worse than
+    saying nothing.
+    """
+    found = []
+    owed = _sum(facts, FEE_COLUMNS)
+
+    # Time barred. The oldest debt is the easiest to argue away and the least
+    # likely to be noticed, because nothing about the row says how old it is
+    # except a date in column D.
+    if time_barred(facts, as_of):
+        stale = _sum(facts, ATTORNEY_AND_COLLECTION) + _sum(facts, ROOM_AND_BOARD)
+        if stale > 0:
+            why = ("Disposed %s, more than 20 years before the clinic date. "
+                   "%s in attorney, collection and room and board charges."
+                   % (facts['disposition_date'].strftime('%m/%d/%Y'),
+                      _dollars(stale)))
+            if 'SOL' in sheets:
+                why += " The SOL sheet counts this row."
+            found.append((
+                TIER_TIME_BARRED, stale,
+                "Object to collection as time barred",
+                "Iowa Code 614.1(6)",
+                why,
+            ))
+
+    # Dismissed or acquitted. All of the debt on the case goes, not a category
+    # of it, which is why this outranks everything except a bigger number.
+    if facts['code'] in CLEARED_CODES and not is_traffic(facts):
+        found.append((
+            TIER_DISMISSED, owed,
+            "Apply to expunge, and to discharge the debt with it",
+            "Iowa Code 901C.2",
+            "Coded %s and not a traffic case, so the whole balance on this "
+            "case is dischargeable, not just part of it." % facts['code'],
+        ))
+
+    # Remission while a term is running. Column I is the gate the EXPUNGEMENT
+    # sheet uses, and Napier only writes it where the sentence table says a
+    # supervision term has not run out yet.
+    if facts['supervised']:
+        remissible = _sum(facts, REMISSIBLE_COLUMNS)
+        if remissible > 0:
+            found.append((
+                TIER_REMISSION, remissible,
+                "Apply to have the court reduce or remit this debt",
+                "Iowa Code 910.7",
+                "Still under supervision on the clinic date, so 910.7 is open. "
+                "Covers everything but surcharges, fines and victim "
+                "restitution. Column V says what term Napier read and what it "
+                "could not see.",
+            ))
+
+    # Room and board. Polk has its own sheet because Polk is where these get
+    # appealed, but the charge itself is a charge anywhere.
+    board = _sum(facts, ROOM_AND_BOARD)
+    if board > 0 and 'POLK' in (facts['county'] or '').upper():
+        found.append((
+            TIER_ROOM_AND_BOARD, board,
+            "Challenge the jail room and board claim",
+            "Iowa Code 356.7",
+            "%s of room and board on a Polk County case. The POLK R&B APPEAL "
+            "sheet lists this row." % _dollars(board),
+        ))
+
+    # The licence. No money comes off for this one, and it is still the reason
+    # most people are in the room. The figure beside it is the balance that has
+    # to be dealt with before the licence comes back, which is why it is not
+    # zero: it is what is at stake, not what can be knocked off.
+    # The registration hold is not here on purpose. It applies to every
+    # conviction carrying a balance, so as a row it fired on most of the case
+    # list and pushed the arguments that are actually worth an hour off the top
+    # of the page. It is one line in the header block instead.
+    if facts['vehicular'] and facts['code'] in CONVICTION_CODES and owed > 0:
+        found.append((
+            TIER_LICENCE, owed,
+            "Ask about an installment agreement to get the licence back",
+            "Iowa Code 321.210A, 321.210B",
+            "Vehicular conviction carrying %s. An installment agreement lifts "
+            "the suspension, needs a financial statement, and a person only "
+            "gets five in a lifetime, so check how many have been used."
+            % _dollars(owed),
+        ))
+
+    # 901C.3. Unlike a dismissal, this one does not wipe the debt out; the debt
+    # has to be gone first. So the figure beside it is what stands between the
+    # client and a clean record, and the row says which way round that is.
+    if misdemeanour_expungement(facts, as_of, codes[0], codes[1]):
+        found.append((
+            TIER_MISDEMEANOUR, owed,
+            "Check 901C.3 expungement, the debt has to be cleared first",
+            "Iowa Code 901C.3",
+            "Misdemeanour conviction disposed %s, more than 8 years ago, and "
+            "not on the sheet's ineligible list. %s still owed, and 901C.3 "
+            "needs it paid before anything is expunged. Napier has not checked "
+            "for a later conviction, a pending charge or a CDL, which the "
+            "EXPUNGEMENT sheet asks you to."
+            % (facts['disposition_date'].strftime('%m/%d/%Y'), _dollars(owed)),
+        ))
+
+    if facts['code'] == JUVENILE_CODE:
+        found.append((
+            TIER_JUVENILE, owed,
+            "Check whether the juvenile record can be sealed",
+            "Iowa Code 232.150",
+            "Juvenile case. The EXPUNGEMENT sheet works out the age and the "
+            "two year wait; this only says the case is one to look at.",
+        ))
+
+    return found
+
+
+def _dollars(amount):
+    return "${:,.2f}".format(amount)
+
+
+def registration_hold(worksheet, written):
+    """Cases where the county treasurer can refuse to renew a registration.
+
+    Every conviction carrying a balance qualifies, which is why this is a
+    count rather than a row per case: as rows it was most of the list, and it
+    is the same sentence every time.
+    """
+    cases, owed = 0, Decimal(0)
+    for row in range(crs.FIRST_CASE_ROW, crs.FIRST_CASE_ROW + written):
+        facts = row_facts(worksheet, row)
+        if not facts['id'] or facts['code'] not in CONVICTION_CODES:
+            continue
+        balance = _sum(facts, FEE_COLUMNS)
+        if balance > 0:
+            cases += 1
+            owed += balance
+    return cases, owed
+
+
+def collect(worksheet, written, as_of, sheets, codes=((), ())):
+    """Every action across every case Napier wrote, best first."""
+    found = []
+    for row in range(crs.FIRST_CASE_ROW, crs.FIRST_CASE_ROW + written):
+        facts = row_facts(worksheet, row)
+        if not facts['id']:
+            continue
+        for action in case_actions(facts, as_of, sheets, codes):
+            found.append((facts, action))
+    # Money first, because a clinic hour spent on the biggest number is the
+    # hour best spent. The tier only settles ties, and the case number after
+    # that, so the same workbook always comes out in the same order.
+    found.sort(key=lambda pair: (-pair[1][1], pair[1][0], pair[0]['id'] or ''))
+    return found
+
+
+# The list is Napier's reading of a court record, not advice, and it goes to a
+# clinic where somebody will act on it inside an hour. It says so on the sheet
+# rather than in a manual nobody has open.
+CAVEAT = ("Napier worked these out from what Iowa Courts Online shows today. "
+          "Check each one against the case before you file anything. Nothing "
+          "here has been read by a lawyer.")
+
+ACTION_HEADERS = [
+    ("#", 5),
+    ("CASE #", 20),
+    ("COUNTY", 14),
+    ("WHAT TO DO", 44),
+    ("AUTHORITY", 26),
+    ("AT STAKE", 13),
+    ("WHY NAPIER SAYS SO", 78),
+]
+
+PAYMENT_HEADERS = [
+    ("CASE #", 20),
+    ("DATE", 12),
+    ("AMOUNT", 12),
+    ("PAID TOWARD", 40),
+    ("RECEIPT", 14),
+    ("HOW PAID", 11),
+]
+
+FIRST_ACTION_ROW = 9
+
+
+def _headers(worksheet, row, spec):
+    for index, (label, width) in enumerate(spec, start=1):
+        cell = worksheet.cell(row, index, label)
+        cell.font = HEADER_FONT
+        cell.fill = HEADER_FILL
+        worksheet.column_dimensions[cell.column_letter].width = width
+
+
+def _money_cell(worksheet, row, column, amount):
+    cell = worksheet.cell(row, column, amount)
+    cell.number_format = '"$"#,##0.00'
+    return cell
+
+
+def client_payments(cases, as_of):
+    """One payment history for the client, across every case.
+
+    A per case figure answers whether this case was being paid. What a court
+    asks is whether the person pays, which is every case at once, and what
+    they are paying now rather than what they paid in 1998.
+    """
+    every = []
+    for case in cases:
+        for payment in crs.payments(case):
+            every.append(dict(payment, case=case['id']))
+    if not every:
+        return None
+    every.sort(key=lambda payment: payment['date'])
+    total = sum((payment['amount'] for payment in every), Decimal(0))
+    cutoff = crs._add_term(as_of, -crs.RECENT_MONTHS, 'Month')
+    recent = sum((payment['amount'] for payment in every
+                  if payment['date'] > cutoff), Decimal(0))
+    return {
+        'payments': every,
+        'count': len(every),
+        'total': total,
+        'first': every[0]['date'],
+        'last': every[-1]['date'],
+        'recent': recent,
+        'recent_monthly': (recent / crs.RECENT_MONTHS).quantize(Decimal('0.01')),
+        'cases': len({payment['case'] for payment in every}),
+    }
+
+
+def build_action_sheet(workbook, cases, written, as_of, def_name):
+    """Add ACTION LIST to a workbook Napier has finished writing.
+
+    Called after CASE DATA is filled in, because it reads CASE DATA back.
+    Returns the number of actions it found.
+    """
+    sheets = set(workbook.sheetnames)
+    found = collect(workbook['CASE DATA'], written, as_of, sheets,
+                    code_lists(workbook))
+    history = client_payments(cases, as_of)
+
+    worksheet = workbook.create_sheet('ACTION LIST', 0)
+    worksheet['A1'] = 'ACTION LIST'
+    worksheet['A1'].font = TITLE_FONT
+    worksheet['D1'] = def_name
+
+    worksheet['A2'] = 'Clinic date'
+    worksheet['B2'] = as_of
+    worksheet['B2'].number_format = 'MM/DD/YYYY'
+
+    worksheet['A3'] = 'Cases read'
+    worksheet['B3'] = written
+
+    worksheet['A4'] = 'Total owed'
+    total_owed = sum(
+        (_sum(row_facts(workbook['CASE DATA'], row), FEE_COLUMNS)
+         for row in range(crs.FIRST_CASE_ROW, crs.FIRST_CASE_ROW + written)),
+        Decimal(0))
+    _money_cell(worksheet, 4, 2, total_owed)
+
+    worksheet['A5'] = 'Payments on record'
+    if history is None:
+        # Not the same as nothing paid, and the difference decides whether an
+        # ability-to-pay argument leans on a payment record or has to be made
+        # without one.
+        worksheet['B5'] = "none in the ICOS itemization"
+    else:
+        worksheet['B5'] = (
+            "%s across %d payment%s on %d case%s, %s to %s. Last 12 months: "
+            "%s, about %s a month."
+            % (_dollars(history['total']), history['count'],
+               "" if history['count'] == 1 else "s",
+               history['cases'], "" if history['cases'] == 1 else "s",
+               history['first'].strftime('%m/%d/%Y'),
+               history['last'].strftime('%m/%d/%Y'),
+               _dollars(history['recent']),
+               _dollars(history['recent_monthly'])))
+
+    worksheet['A6'] = 'Registration hold'
+    held, held_owed = registration_hold(workbook['CASE DATA'], written)
+    if held:
+        worksheet['B6'] = (
+            "%d convicted case%s carrying %s. The county treasurer can refuse "
+            "to renew a registration over any of it (Iowa Code 321.40(6), "
+            "602.8107(7))."
+            % (held, "" if held == 1 else "s", _dollars(held_owed)))
+    else:
+        worksheet['B6'] = "none"
+
+    worksheet['A7'] = CAVEAT
+    worksheet['A7'].font = CAVEAT_FONT
+
+    _headers(worksheet, FIRST_ACTION_ROW - 1, ACTION_HEADERS)
+    row = FIRST_ACTION_ROW
+    for rank, (facts, action) in enumerate(found, start=1):
+        tier, amount, what, cite, why = action
+        worksheet.cell(row, 1, rank)
+        worksheet.cell(row, 2, facts['id'])
+        worksheet.cell(row, 3, facts['county'])
+        worksheet.cell(row, 4, what)
+        worksheet.cell(row, 5, cite)
+        _money_cell(worksheet, row, 6, amount)
+        cell = worksheet.cell(row, 7, why)
+        cell.alignment = Alignment(wrap_text=True, vertical='top')
+        row += 1
+
+    if not found:
+        cell = worksheet.cell(FIRST_ACTION_ROW, 1,
+                              "Nothing on these cases matches an argument "
+                              "Napier knows how to spot. That is not the same "
+                              "as nothing being there.")
+        cell.font = CAVEAT_FONT
+
+    worksheet.freeze_panes = 'A' + str(FIRST_ACTION_ROW)
+    build_payment_sheet(workbook, history)
+    return len(found)
+
+
+def build_payment_sheet(workbook, history):
+    """Add PAYMENTS, the history behind the one line on the action list.
+
+    Every payment ICOS records, newest first, with the receipt number to look
+    it up by. This is the answer to "have you been paying anything?", which is
+    the question that decides an ability to pay hearing, and until now it was
+    downloaded on every run and thrown away.
+    """
+    worksheet = workbook.create_sheet('PAYMENTS')
+    worksheet['A1'] = 'PAYMENT HISTORY'
+    worksheet['A1'].font = TITLE_FONT
+    if history is None:
+        worksheet['A3'] = ("Iowa Courts Online shows no payments in the "
+                           "itemization on any of these cases. That is what "
+                           "the record says, not proof nothing was paid: a "
+                           "case whose itemization ICOS does not publish "
+                           "looks exactly the same.")
+        worksheet['A3'].font = CAVEAT_FONT
+        worksheet.column_dimensions['A'].width = 60
+        return
+
+    worksheet['A2'] = 'Total paid'
+    _money_cell(worksheet, 2, 2, history['total'])
+
+    _headers(worksheet, 4, PAYMENT_HEADERS)
+    row = 5
+    for payment in reversed(history['payments']):
+        worksheet.cell(row, 1, payment['case'])
+        cell = worksheet.cell(row, 2, payment['date'])
+        cell.number_format = 'MM/DD/YYYY'
+        _money_cell(worksheet, row, 3, payment['amount'])
+        worksheet.cell(row, 4, payment['detail'])
+        worksheet.cell(row, 5, payment['receipt'])
+        worksheet.cell(row, 6, payment['tender'])
+        row += 1
+    worksheet.freeze_panes = 'A5'

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import alerts
 import crs
 import icos_sessions
 import jobs
+import roster
 import tasks
 
 app = Flask(__name__)
@@ -151,6 +152,9 @@ def remember_job(job):
     session['job_ids'] = (session.get('job_ids', []) + [job.id])[-20:]
 
 
+app.jinja_env.globals['max_names'] = roster.MAX_NAMES
+
+
 @app.context_processor
 def waiting_workbook():
     """The most recent finished workbook this browser has not picked up yet.
@@ -163,8 +167,8 @@ def waiting_workbook():
     """
     for job_id in reversed(session.get('job_ids', [])):
         job = jobs.get(job_id)
-        if (job is not None and job.kind == 'crs' and job.status == jobs.DONE
-                and not job.collected):
+        if (job is not None and job.kind in jobs.BUILDS_A_WORKBOOK
+                and job.status == jobs.DONE and not job.collected):
             return {"waiting_job": job}
     return {"waiting_job": None}
 
@@ -203,6 +207,155 @@ def search():
                      request.form['lastname'])
     remember_job(job)
     return redirect(url_for('progress', job_id=job.id))
+
+
+@app.route('/batch', methods=['POST'])
+def batch():
+    """A whole clinic list, searched on one sign in."""
+    username = request.form['username'].strip()
+    password = request.form['password']
+    session['isLite'] = 'isLiteBatch' in request.form
+
+    if not username.startswith("ILA") and not username.startswith("drakelegalclinic"):
+        return render_template('start.html', open_batch=True,
+                               error="That user ID is not an Iowa Legal Aid Iowa Courts account.")
+
+    people, rejected = roster.parse(request.form.get('roster', ''))
+    if not people:
+        return render_template('start.html', open_batch=True,
+                               error="There were no names in that list. One "
+                                     "client per line, either \"Last, First\" "
+                                     "or \"First Last\".")
+    if len(people) > roster.MAX_NAMES:
+        return render_template(
+            'start.html', open_batch=True,
+            error="That list has %d names in it. Napier holds the shared Iowa "
+                  "Courts account for the whole run, so it takes %d at a time. "
+                  "Split the list." % (len(people), roster.MAX_NAMES))
+
+    icos_sessions.close(session.pop('icos_token', None))
+
+    # The rejected lines ride on the job, not the session. They can hold part of
+    # a client's name and the session cookie is a store on a shared machine.
+    job = jobs.start('batch_search', tasks.batch_search_task,
+                     username, password, people, rejected)
+    remember_job(job)
+    return redirect(url_for('progress', job_id=job.id))
+
+
+@app.route('/roster/<job_id>')
+def roster_page(job_id):
+    job = own_job(job_id)
+    if job is None or job.status != jobs.DONE or job.kind != 'batch_search':
+        return render_template('start.html', error=RESTARTED_MESSAGE)
+
+    session['icos_token'] = job.result['session_token']
+    return render_template('roster.html', clients=job.result['clients'],
+                           rejected=job.result['rejected'],
+                           search_job_id=job.id)
+
+
+@app.route('/batch-crs', methods=['POST'])
+def batch_crs():
+    data = request.get_json(silent=True) or {}
+    search_job = own_job(data.get('search_job_id', ''))
+    token = session.get('icos_token')
+    if search_job is None or search_job.status != jobs.DONE or not token:
+        return jsonify({"error": RESTARTED_MESSAGE}), 410
+
+    clients = search_job.result['clients']
+    picks = []
+    for chosen in data.get('picks') or []:
+        try:
+            entry = clients[int(chosen.get('client'))]
+        except (TypeError, ValueError, IndexError):
+            return jsonify({"error": "That clinic list does not look like the "
+                                     "one Napier searched. Please run it "
+                                     "again."}), 400
+        # Every key has to be one this search actually returned, so the browser
+        # cannot name a defendant nobody picked off a page.
+        keys = [key for key in (chosen.get('keys') or []) if key in entry['keys']]
+        if not keys:
+            continue
+        case_ids = []
+        for key in keys:
+            case_ids.extend(entry['cases'].get(key, []))
+        # The defendant key is "YYYY-MM-DD NAME", the way the search grouped it.
+        def_dob, _, def_name = keys[0].partition(" ")
+        picks.append({'def_name': def_name, 'def_dob': def_dob,
+                      'case_ids': case_ids})
+
+    if not picks:
+        return jsonify({"error": "Pick a match for at least one client."}), 400
+
+    job = jobs.start('batch_crs', tasks.batch_crs_task, token, picks,
+                     session.get('isLite', False))
+    remember_job(job)
+    session.pop('icos_token', None)  # the batch job owns it now and logs it off
+    return jsonify({"job_id": job.id,
+                    "progress_url": url_for('progress', job_id=job.id)})
+
+
+@app.route('/batch-done/<job_id>')
+def batch_done(job_id):
+    job = own_job(job_id)
+    if job is None or job.status != jobs.DONE or job.kind != 'batch_crs':
+        return render_template('start.html', error=RESTARTED_MESSAGE)
+
+    result = job.result
+    return render_template('batch_done.html', job=job.to_dict(),
+                           clients=result['clients'],
+                           is_lite=result['is_lite'],
+                           built=sum(1 for c in result['clients'] if c['file']),
+                           written=result['written_cases'],
+                           limits=crs.workbook_limits(
+                               max([c['written'] for c in result['clients']]
+                                   or [0]), result['is_lite']))
+
+
+def _served_file(path):
+    """A path is only servable if it is an ordinary file we wrote into tmp_dir.
+
+    Same rule the single download has kept: a tampered session must not be able
+    to point this at anything else on the dyno.
+    """
+    real = os.path.realpath(path)
+    if os.path.dirname(real) != os.path.realpath(tmp_dir).rstrip(os.sep):
+        return None
+    if not (real.endswith('.xlsx') or real.endswith('.zip')):
+        return None
+    return real
+
+
+@app.route('/batch/<job_id>/download')
+@app.route('/batch/<job_id>/download/<int:index>')
+def batch_download(job_id, index=None):
+    job = own_job(job_id)
+    if job is None or job.status != jobs.DONE or job.kind != 'batch_crs':
+        return render_template('start.html', error=RESTARTED_MESSAGE)
+
+    if index is None:
+        path, name = job.result['file'], 'Napier_clinic_list.zip'
+    else:
+        try:
+            record = job.result['clients'][index]
+        except IndexError:
+            return render_template('start.html', error=RESTARTED_MESSAGE)
+        if not record['file']:
+            return render_template('start.html', error=RESTARTED_MESSAGE)
+        path = record['file']
+        name = tasks.download_name(record['name'], job.result['is_lite'])
+
+    path = _served_file(path)
+    if path is None:
+        return "Bad session - invalid file"
+
+    # The zip is the whole errand; one client's workbook is not. Collecting the
+    # list is what stops the uncollected alert, so a staffer who grabs one file
+    # and closes the tab still gets chased about the other nineteen.
+    if index is None:
+        job.collected = True
+    return send_file(path, as_attachment=True, download_name=name)
 
 
 @app.route('/progress/<job_id>')

--- a/case_parser.py
+++ b/case_parser.py
@@ -32,6 +32,20 @@ def _dump(name, html):
     with open(os.path.join(tmp_dir, secure_filename(name)), 'w') as text_file:
         text_file.write(html)
 
+def _text(cell):
+    """A cell's text with ICOS's padding taken out, or None when it is empty.
+
+    `.string` is None whenever a cell holds more than one node, which is why
+    this exists alongside it rather than replacing it: the fields that already
+    use `.string` have been read that way for years and are not being changed
+    underneath the columns that depend on them.
+    """
+    if cell is None:
+        return None
+    text = ' '.join(cell.get_text().split())
+    return text or None
+
+
 def _cell_words(cell):
     """A table cell's words with ICOS's padding taken out.
 
@@ -523,7 +537,16 @@ def parse_case_financials(html, case):
             'detail': cols[1].string,
             'amount': cols[4].string,
             'paid': cols[5].string,
-            'paidDate': cols[6].string
+            'paidDate': cols[6].string,
+            # The receipt number and the tender type sit two cells further
+            # along and have never been read. They are what turns a paid figure
+            # into a payment: a date, a receipt to look it up by, and whether it
+            # came in as cash, a cheque or a garnishment. A client who paid five
+            # dollars a month for three years and still owes twelve hundred is a
+            # different hearing from one who never paid, and until now the
+            # workbook could not tell them apart.
+            'receipt': _text(cols[7]) if len(cols) > 7 else None,
+            'tender': _text(cols[8]) if len(cols) > 8 else None,
         })
     case['financials'] = financials
 

--- a/case_parser.py
+++ b/case_parser.py
@@ -264,10 +264,81 @@ def parse_case_summary(html, case):
     if case['summary_dispo_status'] is None:
         case['summary_dispo_status'] = ""
 
+# The sentence table's own header, in ICOS's order. It is matched exactly
+# rather than by position, because the table sits inside a nested table and the
+# outer row yields the header and the first data row joined together. Matching
+# the header is also how a change to the page announces itself: if ICOS renames
+# or reorders a column, no sentence is read at all rather than the wrong cell
+# being read as a date.
+SENTENCE_HEADER = [
+    'Sentence', 'Sentence Date', 'Duration', 'Fine', 'Appeal', 'Judge',
+    'Facility Type', 'Attorney', 'Restitution', 'Drug', 'Extradition',
+    'Lic. Revoked', 'DDS', 'Batterer',
+]
+
+
+def _row_words(row):
+    """One charges-page row as a list of cleaned cell strings.
+
+    The charges page wraps every value in <font>, and pads it with the CRLFs
+    and tabs that the rest of this module strips the same way.
+    """
+    return [
+        ''.join(col.find_all(string=True))
+        .replace(u'\xa0', u' ')
+        .replace('\r', '')
+        .replace('\n', '')
+        .replace('\t', '')
+        .strip()
+        for col in row.find_all('font')
+    ]
+
+
+def parse_sentences(soup):
+    """Every sentence ICOS lists on a case, as {type, date, duration}.
+
+    Napier has downloaded this table on every case it has ever pulled and read
+    nothing out of it. It is the only place in ICOS that says what happened to
+    somebody after the conviction: the sentence type, the day it was imposed
+    and how long it runs. Column I of CASE DATA wants exactly that, and so does
+    any question about when an expungement wait starts.
+
+    Returns a flat list rather than one per count. A count is not a useful key
+    here: ICOS repeats the same probation term under every count it applies to,
+    and what the workbook asks is whether the person is under supervision on
+    this case, not on which count.
+    """
+    sentences = []
+    # Nothing is read until the header has been seen and matched in full. The
+    # charges page has other wide tables on it, and a row of fourteen cells is
+    # not on its own evidence of a sentence. It is also the whole of Napier's
+    # defence against ICOS reordering the columns: no header, no read, rather
+    # than a confident date taken out of whichever cell is third now.
+    in_table = False
+    for row in soup.find_all('tr'):
+        texts = _row_words(row)
+        if len(texts) < len(SENTENCE_HEADER):
+            continue
+        if texts[:len(SENTENCE_HEADER)] == SENTENCE_HEADER:
+            # The header itself, or, for the row that wraps the nested table,
+            # the header with the first sentence joined onto the end of it.
+            in_table = True
+            continue
+        if not in_table or not texts[0] or texts[0] in SENTENCE_HEADER:
+            continue
+        sentences.append({
+            'type': texts[0],
+            'date': texts[1],
+            'duration': texts[2],
+        })
+    return sentences
+
+
 def parse_case_charges(html, case):
     html = html.decode('utf-8', errors='ignore')
     _dump(case['id'] + "_charges.html", html)
     soup = BeautifulSoup(html, 'html.parser')
+    case['sentences'] = parse_sentences(soup)
     charges = []
     charge_list = list()
     cur_charge = None

--- a/crs.py
+++ b/crs.py
@@ -2,7 +2,7 @@ import re
 
 from calendar import monthrange
 from datetime import date, datetime, timedelta
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from openpyxl.styles import Alignment # Added import
 from openpyxl.styles import Font, PatternFill
 
@@ -143,6 +143,102 @@ def is_vehicular(statutes):
         if any(code.upper().startswith(section) for section in VEHICULAR_SECTIONS):
             return "YES"
     return "NO"
+
+
+# How far back to look when working out what somebody is paying now. A court
+# asking whether a person can pay wants the recent record, not an average that
+# a garnishment in 2003 drags upwards.
+RECENT_MONTHS = 12
+
+
+def _money(text):
+    """A dollar figure off an ICOS page, or None when there is not one."""
+    if text is None:
+        return None
+    text = str(text).replace('$', '').replace(',', '').strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def payments(case):
+    """Every payment ICOS records on a case, oldest first.
+
+    The itemization has carried a date, a receipt number and a tender type
+    against each paid line for as long as Napier has been fetching it, and
+    nothing has ever read them. A fee paid in instalments gets a row per
+    instalment, so this is a payment history rather than a list of fees.
+
+    Third-party collection fees are excluded the same way they are excluded
+    from the fee columns: ICOS lists them and does not count them in the case
+    total, so counting a payment against one as money paid on the case would
+    overstate what the client has actually put in.
+    """
+    history = []
+    last_detail = None
+    for row in case.get('financials') or []:
+        detail = (row.get('detail') or '').strip()
+        if detail:
+            last_detail = detail
+        if is_excluded_fee(detail or last_detail or ''):
+            continue
+        paid = _money(row.get('paid'))
+        when = parse_us_date(row.get('paidDate'))
+        if paid is None or paid <= 0 or when is None:
+            continue
+        history.append({
+            'date': when,
+            'amount': paid,
+            'receipt': row.get('receipt'),
+            'tender': row.get('tender'),
+            'detail': detail or last_detail,
+        })
+    history.sort(key=lambda payment: payment['date'])
+    return history
+
+
+def payment_history(case, as_of):
+    """What a case's payment record says, or None when there is no record.
+
+    None and a record of zero payments are different answers and the sheet
+    should not have to guess which it is looking at. A case ICOS has no
+    itemization for cannot tell us the client never paid.
+    """
+    history = payments(case)
+    if not history:
+        return None
+    total = sum((payment['amount'] for payment in history), Decimal(0))
+    first, last = history[0]['date'], history[-1]['date']
+    recent = sum((payment['amount'] for payment in history
+                  if payment['date'] > _add_term(as_of, -RECENT_MONTHS, 'Month')),
+                 Decimal(0))
+    # Over the window the client was actually paying, not over the age of the
+    # case. Somebody who paid steadily for a year and then lost the job has a
+    # monthly figure of what they paid, and the gap is reported separately.
+    months = max(1, _months_between(first, last) + 1)
+    return {
+        'count': len(history),
+        'total': total,
+        'first': first,
+        'last': last,
+        'monthly': (total / months).quantize(Decimal('0.01')),
+        'recent': recent,
+        'recent_monthly': (recent / RECENT_MONTHS).quantize(Decimal('0.01')),
+        'months_since_last': _months_between(last, as_of),
+        'tenders': sorted({payment['tender'] for payment in history
+                           if payment['tender']}),
+    }
+
+
+def _months_between(start, end):
+    """Whole months from start to end, never negative."""
+    months = (end.year - start.year) * 12 + (end.month - start.month)
+    if end.day < start.day:
+        months -= 1
+    return max(0, months)
 
 
 # Sentence types ICOS uses that put somebody under supervision in the community.

--- a/crs.py
+++ b/crs.py
@@ -1,5 +1,7 @@
 import re
 
+from calendar import monthrange
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from openpyxl.styles import Alignment # Added import
 from openpyxl.styles import Font, PatternFill
@@ -141,6 +143,104 @@ def is_vehicular(statutes):
         if any(code.upper().startswith(section) for section in VEHICULAR_SECTIONS):
             return "YES"
     return "NO"
+
+
+# Sentence types ICOS uses that put somebody under supervision in the community.
+# All three are court-ordered, run for a stated term, and appear in the sentence
+# table with that term, which is what makes them answerable from ICOS at all.
+#
+# PRISON, JAIL and the suspended variants are deliberately not here. Somebody in
+# custody is not what the expungement sheet's 910.7 column is asking about, and
+# the day they get out is not on this page.
+SUPERVISION_SENTENCES = frozenset({
+    'PROBATION',
+    'DRUG COURT',
+    'RESIDENTIAL FACILITY',
+})
+
+# ICOS writes a term as a count and a unit, and has used only two units across
+# every case we have looked at. The others are here so a term Napier has not
+# seen is measured rather than ignored.
+DURATION = re.compile(r'^\s*(\d+)\s*(Year|Month|Week|Day)', re.I)
+
+SUPERVISION_NOTE = (
+    "Column I says YES because ICOS shows a %s term of %s imposed %s, which on "
+    "paper runs to %s. Napier reads the sentence table and cannot see a term "
+    "discharged early, a term extended, or anyone on parole, so confirm this "
+    "before relying on it."
+)
+
+
+def _add_term(start, count, unit):
+    """The day a term of `count` `unit`s beginning on `start` runs out.
+
+    Calendar arithmetic rather than a multiple of 365, because a five year
+    probation term imposed on a leap day is not five times 365 days long and
+    the answer here decides what goes in a column about somebody's debt.
+    """
+    unit = unit.lower()
+    if unit == 'day':
+        return start + timedelta(days=count)
+    if unit == 'week':
+        return start + timedelta(weeks=count)
+    months = count * 12 if unit == 'year' else count
+    month_index = start.month - 1 + months
+    year = start.year + month_index // 12
+    month = month_index % 12 + 1
+    # The 31st of a month landing on a 30 day month, and 29 February landing on
+    # a common year, both fall back to that month's last day.
+    day = min(start.day, monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def parse_us_date(text):
+    """MM/DD/YYYY as ICOS writes it, or None for anything else."""
+    if not text:
+        return None
+    try:
+        return datetime.strptime(str(text).strip(), '%m/%d/%Y').date()
+    except ValueError:
+        return None
+
+
+def supervision_term(sentences):
+    """The supervision term that runs longest, as (type, duration, start, end).
+
+    None when the case has no supervision sentence, or has one with no date or
+    no stated term, because a term nobody can put an end date on cannot answer
+    the question the column is asking.
+    """
+    longest = None
+    for sentence in sentences or []:
+        if (sentence.get('type') or '').strip().upper() not in SUPERVISION_SENTENCES:
+            continue
+        start = parse_us_date(sentence.get('date'))
+        if start is None:
+            continue
+        match = DURATION.match(str(sentence.get('duration') or ''))
+        if not match:
+            continue
+        end = _add_term(start, int(match.group(1)), match.group(2))
+        if longest is None or end > longest[3]:
+            longest = (sentence['type'].strip().upper(),
+                       sentence['duration'].strip(), start, end)
+    return longest
+
+
+def is_under_supervision(sentences, as_of):
+    """("YES", term) when a supervision term is still running, else (None, None).
+
+    Never "NO". A blank and a "NO" read the same to the expungement sheet, so
+    writing "NO" would buy nothing and would claim something Napier cannot know:
+    ICOS records no discharge when probation ends early, records an extension
+    inconsistently, and does not carry parole at all, since parole is corrections
+    rather than the court. So this answers the one direction it can evidence,
+    which is that a term was imposed and has not run out yet.
+    """
+    term = supervision_term(sentences)
+    if term is None or term[3] < as_of:
+        return None, None
+    return "YES", term
 
 
 def get_dominant_charge(charges):
@@ -618,12 +718,19 @@ def append_note(worksheet, row, text):
     cell.value = ("%s %s" % (cell.value, text)).strip() if cell.value else text
 
 
-def process_case(case, worksheet, row):
+def process_case(case, worksheet, row, as_of=None):
     """Write one case into CASE DATA. Returns the dispositions it could not read.
 
     Almost always empty. When it is not, the case is on the sheet under a code
     Napier guessed at, and the return value is how the run gets to say so.
+
+    as_of is the clinic date, the same one build_workbook puts in BASIC INFO B3.
+    Whether a probation term is still running is only answerable against a day,
+    and it has to be that day rather than today, so that reopening a workbook
+    next year does not silently change what column I said.
     """
+    if as_of is None:
+        as_of = date.today()
     i = str(row)
     worksheet['A' + i] = case['id']
     worksheet['B' + i] = case['county']
@@ -663,17 +770,34 @@ def process_case(case, worksheet, row):
         if vehicular is not None:
             worksheet['H' + i] = vehicular
 
+    # Outside the charge branch on purpose. The sentence table is read off the
+    # charges page whatever get_dominant_charge made of the adjudications, and a
+    # case can carry a supervision term that Napier coded as something other
+    # than a plain conviction.
+    supervised, term = is_under_supervision(case.get('sentences'), as_of)
+    if supervised is not None:
+        worksheet['I' + i] = supervised
+        supervision_note = SUPERVISION_NOTE % (
+            term[0].lower(), term[1], term[2].strftime('%m/%d/%Y'),
+            term[3].strftime('%m/%d/%Y'))
+    else:
+        supervision_note = None
+
     cell_E.alignment = Alignment(wrap_text=True) # Apply text wrapping
 
     # If charge was None, we still need to process financials if it wasn't returned early
     if charge is None:
         # process_financials(case, worksheet, i) # Already called above if charge is None
+        if supervision_note:
+            append_note(worksheet, i, supervision_note)
         return [] # Now we can return
 
     process_financials(case, worksheet, i)
 
     # After process_financials, which owns column V, so the note joins whatever
     # it wrote about the money rather than being overwritten by it.
+    if supervision_note:
+        append_note(worksheet, i, supervision_note)
     unknown = charge.get('unknown_dispositions') or []
     if unknown:
         append_note(worksheet, i,

--- a/jobs.py
+++ b/jobs.py
@@ -31,6 +31,11 @@ RETENTION_SECONDS = 2 * 60 * 60
 # run leaves, since every other alert in this app fires from something throwing.
 UNCOLLECTED_AFTER = 5 * 60
 
+# The job kinds that end with a file somebody has to be handed. These are the
+# ones the uncollected alert watches and the ones the start page keeps offering
+# until a staffer has actually taken the file.
+BUILDS_A_WORKBOOK = ('crs', 'batch_crs')
+
 
 class Job:
     def __init__(self, kind):
@@ -151,7 +156,7 @@ def _uncollected_pass(now=None):
     now = now if now is not None else time.time()
     with _jobs_lock:
         orphans = [job for job in _jobs.values()
-                   if job.kind == 'crs' and job.status == DONE
+                   if job.kind in BUILDS_A_WORKBOOK and job.status == DONE
                    and not job.collected and not job.reported_uncollected
                    and now - job.updated_at > UNCOLLECTED_AFTER]
         for job in orphans:

--- a/roster.py
+++ b/roster.py
@@ -1,0 +1,110 @@
+"""A clinic's list of clients, read off whatever staff paste in.
+
+Napier has always been one client per sign in. Iowa Courts allows one session
+per account and Iowa Legal Aid shares a handful of them, so a clinic with
+twenty names on the list is twenty sign ins, twenty locked-account waits when
+two people work the list at once, and twenty runs somebody has to sit and watch.
+The searching is the same work each time; only the name changes.
+
+So this reads a pasted list. It has to survive a paste out of a spreadsheet, a
+Word table, or an email, which means blank lines, a header row, tabs, and a
+date of birth column nobody meant to include. Anything it cannot make a name
+out of comes back as a rejected line rather than being dropped quietly, because
+a client missing from a clinic list is a client nobody sees that day.
+"""
+
+# A clinic list, not a mailing list. Past this the run holds the shared ICOS
+# account for most of an afternoon, and a paste this big is nearly always a
+# whole spreadsheet rather than a day's clients.
+MAX_NAMES = 40
+
+# Words a header row starts with. A pasted table brings its headings along and
+# "Client Name" is not a person. "dob" is here because a table pasted one column
+# per line puts it on a line of its own, where it otherwise reads as a
+# surname-only search, which is a real thing staff do on purpose.
+HEADERS = ('name', 'client', 'first', 'last', 'defendant', 'participant', 'dob')
+
+# Anything after the name in a pasted row: a date of birth, a case number, a
+# phone number, an appointment time.
+SEPARATORS = ('\t', '|', ';')
+
+
+def _clean(line):
+    """One pasted line down to just the name part."""
+    for separator in SEPARATORS:
+        line = line.split(separator)[0]
+    return ' '.join(line.split())
+
+
+def _is_header(name):
+    first = name.split(',')[0].split()
+    return bool(first) and first[0].lower().strip(':') in HEADERS
+
+
+def split_name(name):
+    """A name into first, middle and last, however it was written.
+
+    Two forms, because clinic lists come both ways. With a comma, everything
+    before it is the surname, which is the only form that can carry a surname
+    of more than one word without guessing. Without one, the first word is the
+    first name, the last word is the surname and anything between is the
+    middle, so "Jane Marie Van Dyke" comes out with a surname of "Dyke" and has
+    to be written "Van Dyke, Jane Marie" to search properly.
+    """
+    if ',' in name:
+        surname, _, rest = name.partition(',')
+        # A third column is a date of birth or a case number often enough that
+        # taking it as part of the given names would break the search.
+        rest = rest.split(',')[0]
+        given = rest.split()
+        return (given[0] if given else '',
+                ' '.join(given[1:]),
+                ' '.join(surname.split()))
+
+    words = name.split()
+    if len(words) == 1:
+        # A surname on its own is a real search. Iowa Courts will answer it,
+        # and the roster page is where somebody picks out of the answer.
+        return '', '', words[0]
+    return words[0], ' '.join(words[1:-1]), words[-1]
+
+
+def parse(text):
+    """A pasted list into (people, rejected).
+
+    people are dicts of raw, first, middle and last. rejected are the lines
+    that carried no name, reported back rather than swallowed so that a list of
+    twenty that produced nineteen searches says which one it dropped.
+
+    Duplicates are folded together. A clinic list assembled from two sources
+    has them, and searching the same name twice costs a minute of a shared
+    account for an answer we already have.
+    """
+    people, rejected, seen = [], [], set()
+    for line in (text or '').splitlines():
+        name = _clean(line)
+        if not name:
+            continue
+        if _is_header(name):
+            # Reported rather than dropped. A line Napier decided was a heading
+            # and a line it could not read are both lines it did not search,
+            # and the page has to say so either way.
+            rejected.append(line.strip())
+            continue
+        first, middle, last = split_name(name)
+        if not last:
+            rejected.append(line.strip())
+            continue
+        key = (first.lower(), middle.lower(), last.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        people.append({'raw': name, 'first': first, 'middle': middle,
+                       'last': last})
+    return people, rejected
+
+
+def describe(person):
+    """The name as Napier will search it, for the page that asks staff to check."""
+    return ' '.join(part for part in
+                    (person['first'], person['middle'], person['last']) if part)

--- a/tasks.py
+++ b/tasks.py
@@ -233,10 +233,15 @@ def build_workbook(cases, def_name, def_dob, is_lite):
     """
     workbook = load_workbook('CRS Lite 3.5.5.xlsx' if is_lite else 'CRS 3.5.5.xlsx')
     sheet = workbook['CASE DATA']
+    # One clinic date for the whole workbook, read once. Column I asks whether a
+    # probation term is still running, which is only answerable against a day,
+    # and it has to be the same day BASIC INFO B3 gets below or the workbook
+    # disagrees with itself about when it was built.
+    clinic_date = datetime.date.today()
     row = 4
     unknown = {}
     for case in cases:
-        for disposition in crs.process_case(case, sheet, row) or []:
+        for disposition in crs.process_case(case, sheet, row, clinic_date) or []:
             unknown.setdefault(disposition, []).append(case['id'])
         row += 1
 
@@ -249,7 +254,7 @@ def build_workbook(cases, def_name, def_dob, is_lite):
     # is the right default for a workbook built today, and it is a date value
     # rather than text so the arithmetic works. Staff can overwrite it for a
     # clinic on another day.
-    sheet['B3'] = datetime.date.today()
+    sheet['B3'] = clinic_date
     sheet['B3'].number_format = 'MM/DD/YYYY'
     sheet['B5'] = def_name.strip()
     sheet['B6'] = def_dob

--- a/tasks.py
+++ b/tasks.py
@@ -12,6 +12,7 @@ import platform
 from openpyxl import load_workbook
 from werkzeug.utils import secure_filename
 
+import actions
 import alerts
 import case_parser
 import crs
@@ -258,6 +259,11 @@ def build_workbook(cases, def_name, def_dob, is_lite):
     sheet['B3'].number_format = 'MM/DD/YYYY'
     sheet['B5'] = def_name.strip()
     sheet['B6'] = def_dob
+
+    # Last, and only after BASIC INFO, because the action list reads CASE DATA
+    # back rather than recomputing it and puts the client's name at the top.
+    actions.build_action_sheet(workbook, cases, row - 4, clinic_date,
+                               def_name.strip())
 
     if not os.path.exists(tmp_dir):
         os.mkdir(tmp_dir)

--- a/tasks.py
+++ b/tasks.py
@@ -8,6 +8,7 @@ walks away), and the CRS task logs off when it finishes or fails.
 import datetime
 import os
 import platform
+import zipfile
 
 from openpyxl import load_workbook
 from werkzeug.utils import secure_filename
@@ -17,6 +18,7 @@ import alerts
 import case_parser
 import crs
 import icos_sessions
+import roster
 from icos import IcosClient, IcosError
 
 # One case ICOS will not hand over is a bad case. Several in a row is the site
@@ -122,6 +124,247 @@ def search_task(job, username, password, firstname, middlename, lastname):
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
+def _pull_cases(job, client, case_ids, offset=0, total=None):
+    """Fetch and parse a list of cases. Returns what was read and what was not.
+
+    Shared by the single-client run and the clinic list, so a case that Iowa
+    Courts will not give up costs the same thing either way. offset and total
+    are for the progress bar when this is one client's slice of a longer run.
+    """
+    total = len(case_ids) if total is None else total
+    cases, failed = [], []
+    failures_in_a_row = 0
+    not_attempted = []
+    for index, case_id in enumerate(case_ids, start=1):
+        # Counted across the whole run, not this client's slice of it, so the
+        # sentence and the bar under it never disagree on a clinic list.
+        job.log("Pulling case %d of %d (%s)..." % (offset + index, total, case_id),
+                count=offset + index - 1, total=total)
+        case = {'id': case_id}
+        try:
+            summary, charges, financials = client.case_bundle(case_id)
+        except IcosError as e:
+            # ICOS never gave up this case inside its retry budget. That
+            # costs one row, not the run: the other cases are still worth
+            # pulling and the workbook still gets built without this one.
+            print("Case %s could not be retrieved: %r" % (case_id, e), flush=True)
+            alerts.record(job.id[:8], job.kind, alerts.CASE_UNAVAILABLE,
+                          progress=alerts.recent_progress(job),
+                          case=case_id,
+                          note="%s The run carried on without it." % e.message)
+            failed.append(case_id)
+            failures_in_a_row += 1
+            if failures_in_a_row >= CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
+                not_attempted = case_ids[index:]
+                break
+            continue
+        failures_in_a_row = 0
+        try:
+            case_parser.parse_case_summary(summary, case)
+            case_parser.parse_case_charges(charges, case)
+            case_parser.parse_case_financials(financials, case)
+        except Exception as e:
+            # One unparseable case should not cost staff the whole run --
+            # collect it, report it, and build the CRS from the rest.
+            print("Case %s failed to parse: %r" % (case_id, e), flush=True)
+            # The case id is in the alert on purpose: it is court public
+            # record, and without it nobody can go look at the page that
+            # broke the parser.
+            alerts.record(job.id[:8], job.kind, alerts.PARSE_FAILURE,
+                          progress=alerts.recent_progress(job),
+                          case=case_id,
+                          **{'traceback': alerts.safe_traceback(e)})
+            failed.append(case_id)
+            continue
+        cases.append(case)
+
+    if not_attempted:
+        failed.extend(not_attempted)
+        job.log("Iowa Courts stopped responding, so the last %d case%s could not "
+                "be pulled. The workbook has the rest."
+                % (len(not_attempted), "" if len(not_attempted) == 1 else "s"))
+    return cases, failed
+
+
+def batch_search_task(job, username, password, people, rejected=()):
+    """Search a whole clinic list on one sign in.
+
+    One search per name, all inside the session the first login opened, and the
+    session is handed to the store at the end the same way a single search
+    hands it over. What this saves is not the searching, it is the queueing:
+    Iowa Courts allows one session per account and Iowa Legal Aid shares a few,
+    so twenty clients used to mean twenty sign ins competing for the same
+    account, and any two staff working the list at once locked each other out.
+
+    One name Iowa Courts will not answer for does not end the list. It is
+    recorded against that client and the run carries on, because the other
+    nineteen clients are still in the building.
+
+    No client's name is logged. The progress log is quoted into alert email and
+    those names are privileged; a position in the list is not.
+
+    rejected is the lines Napier could not read a name out of, carried here
+    rather than in the browser's session for the same reason: they can hold a
+    piece of a client's name, and the session cookie is a store on a machine
+    other people use. This lives in the dyno's memory and is gone in two hours.
+    """
+    client = IcosClient(log=job.log, alert=alerts.emitter(job))
+    keep_session = False
+    try:
+        client.login(username, password)
+
+        clients = []
+        failures_in_a_row = 0
+        for index, person in enumerate(people, start=1):
+            job.log("Searching Iowa Courts for name %d of %d..."
+                    % (index, len(people)), count=index - 1, total=len(people))
+            entry = {'name': roster.describe(person), 'keys': [], 'cases': {},
+                     'too_many_results': False, 'error': None}
+            clients.append(entry)
+            try:
+                body = client.search(person['first'], person['middle'],
+                                     person['last'])
+            except IcosError as e:
+                entry['error'] = e.message
+                failures_in_a_row += 1
+                if failures_in_a_row >= CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
+                    for skipped in people[index:]:
+                        clients.append({
+                            'name': roster.describe(skipped), 'keys': [],
+                            'cases': {}, 'too_many_results': False,
+                            'error': "Iowa Courts had stopped responding "
+                                     "before Napier reached this name."})
+                    job.log("Iowa Courts stopped responding, so the rest of the "
+                            "list was not searched.")
+                    break
+                continue
+            failures_in_a_row = 0
+            cases, too_many = case_parser.parse_search(body)
+            report_novel_roles(job, cases)
+            entry['cases'], entry['keys'] = group_cases(cases)
+            entry['too_many_results'] = too_many
+
+        token = icos_sessions.put(client)
+        keep_session = True
+        job.result = {"clients": clients, "session_token": token,
+                      "rejected": list(rejected)}
+        answered = sum(1 for entry in clients if entry['keys'])
+        job.log("Searched %d name%s. %d came back with cases."
+                % (len(clients), "" if len(clients) == 1 else "s", answered))
+        return "/roster/" + job.id
+    finally:
+        if not keep_session:
+            client.logoff()
+        alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
+
+
+def batch_crs_task(job, session_token, picks, is_lite):
+    """Build a workbook per client, all on the sign in the batch search opened.
+
+    picks is what came back off the roster page, already checked against the
+    search job by the route: name, date of birth, the defendant keys somebody
+    ticked, and that client's own case list.
+
+    One client's run failing costs that client's workbook and nothing else. The
+    clinic gets the rest and the finish page says which one is missing, because
+    a list that quietly comes back one short is worse than one that says so.
+    """
+    client = icos_sessions.claim(session_token)
+    if client is None:
+        raise IcosError("That clinic list is no longer signed in to Iowa "
+                        "Courts Online. Please run it again.")
+    client.set_alert(alerts.emitter(job))
+
+    total_cases = sum(len(pick['case_ids']) for pick in picks)
+    try:
+        built = []
+        pulled = 0
+        for index, pick in enumerate(picks, start=1):
+            job.log("Client %d of %d: pulling %d case%s..."
+                    % (index, len(picks), len(pick['case_ids']),
+                       "" if len(pick['case_ids']) == 1 else "s"),
+                    count=pulled, total=total_cases)
+            record = {'name': pick['def_name'], 'requested': len(pick['case_ids']),
+                      'written': 0, 'failed': [], 'file': None, 'error': None}
+            built.append(record)
+
+            cases, failed = _pull_cases(job, client, pick['case_ids'],
+                                        offset=pulled, total=total_cases)
+            pulled += len(pick['case_ids'])
+            record['failed'] = failed
+            if not cases:
+                record['error'] = ("Iowa Courts would not give up any of this "
+                                   "client's cases, so there is no workbook "
+                                   "for them.")
+                continue
+            try:
+                path, unknown = build_workbook(cases, pick['def_name'],
+                                               pick['def_dob'], is_lite)
+            except Exception as e:
+                # The other clients' workbooks are already built or still to
+                # come, and neither should be lost to this one.
+                print("Workbook failed for client %d: %r" % (index, e), flush=True)
+                alerts.record(job.id[:8], job.kind, alerts.JOB_FAILED,
+                              progress=alerts.recent_progress(job),
+                              **{'note': "One client of %d in a clinic list. "
+                                         "The rest of the list carried on."
+                                         % len(picks),
+                                 'traceback': alerts.safe_traceback(e)})
+                record['error'] = ("Napier could not build this client's "
+                                   "workbook. The rest of the list is here.")
+                continue
+            report_unknown_dispositions(job, unknown)
+            record['written'] = len(cases)
+            record['file'] = path
+
+        if not any(record['file'] for record in built):
+            raise ValueError("no workbooks could be built")
+
+        job.log("Packaging %d workbook%s..."
+                % (len(built), "" if len(built) == 1 else "s"),
+                count=total_cases, total=total_cases)
+        bundle = _zip_workbooks(built, is_lite)
+        job.result = {
+            "file": bundle,
+            "is_lite": is_lite,
+            "clients": built,
+            "written_cases": sum(record['written'] for record in built),
+            "requested_cases": total_cases,
+            "def_name": "a clinic list of %d client%s"
+                        % (len(built), "" if len(built) == 1 else "s"),
+            "done_url": "/batch-done/%s" % job.id,
+        }
+        job.log("Done. %d of %d workbook%s built."
+                % (sum(1 for record in built if record['file']), len(built),
+                   "" if len(built) == 1 else "s"))
+        return "/batch-done/%s" % job.id
+    finally:
+        client.logoff()
+        alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
+
+
+def _zip_workbooks(built, is_lite):
+    """One file to download, because a clinic list is one errand.
+
+    Every workbook is also kept on disk under its own name and served on its
+    own from the finish page, for the staffer who only wants the one client
+    they are about to see.
+    """
+    stamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    path = tmp_dir + "Napier_clinic_list_" + stamp + ".zip"
+    with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as bundle:
+        for position, record in enumerate(built, start=1):
+            if not record['file']:
+                continue
+            # Numbered because two clients on one clinic list can share a name
+            # and a zip that quietly holds one of them is the kind of thing
+            # nobody notices until the wrong person is sitting there.
+            name = secure_filename(download_name(record['name'], is_lite))
+            bundle.write(record['file'],
+                         "%02d_%s" % (position, name or "client.xlsx"))
+    return path
+
+
 def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
     client = icos_sessions.claim(session_token)
     if client is None:
@@ -139,57 +382,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         for key in keys:
             case_ids.extend(case_dict.get(key, []))
 
-        cases = []
-        failed = []
-        failures_in_a_row = 0
-        not_attempted = []
-        for index, case_id in enumerate(case_ids, start=1):
-            job.log("Pulling case %d of %d (%s)..." % (index, len(case_ids), case_id),
-                    count=index - 1, total=len(case_ids))
-            case = {'id': case_id}
-            try:
-                summary, charges, financials = client.case_bundle(case_id)
-            except IcosError as e:
-                # ICOS never gave up this case inside its retry budget. That
-                # costs one row, not the run: the other cases are still worth
-                # pulling and the workbook still gets built without this one.
-                print("Case %s could not be retrieved: %r" % (case_id, e), flush=True)
-                alerts.record(job.id[:8], job.kind, alerts.CASE_UNAVAILABLE,
-                              progress=alerts.recent_progress(job),
-                              case=case_id,
-                              note="%s The run carried on without it."
-                                   % e.message)
-                failed.append(case_id)
-                failures_in_a_row += 1
-                if failures_in_a_row >= CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
-                    not_attempted = case_ids[index:]
-                    break
-                continue
-            failures_in_a_row = 0
-            try:
-                case_parser.parse_case_summary(summary, case)
-                case_parser.parse_case_charges(charges, case)
-                case_parser.parse_case_financials(financials, case)
-            except Exception as e:
-                # One unparseable case should not cost staff the whole run --
-                # collect it, report it, and build the CRS from the rest.
-                print("Case %s failed to parse: %r" % (case_id, e), flush=True)
-                # The case id is in the alert on purpose: it is court public
-                # record, and without it nobody can go look at the page that
-                # broke the parser.
-                alerts.record(job.id[:8], job.kind, alerts.PARSE_FAILURE,
-                              progress=alerts.recent_progress(job),
-                              case=case_id,
-                              **{'traceback': alerts.safe_traceback(e)})
-                failed.append(case_id)
-                continue
-            cases.append(case)
-
-        if not_attempted:
-            failed.extend(not_attempted)
-            job.log("Iowa Courts stopped responding, so the last %d case%s could not "
-                    "be pulled. The workbook has the rest."
-                    % (len(not_attempted), "" if len(not_attempted) == 1 else "s"))
+        cases, failed = _pull_cases(job, client, case_ids)
 
         if not cases:
             raise ValueError("no cases could be read")
@@ -204,6 +397,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
             "written_cases": len(cases),
             "requested_cases": len(case_ids),
             "failed_cases": failed,
+            "done_url": "/done/%s" % job.id,
         }
 
         if failed:

--- a/templates/batch_done.html
+++ b/templates/batch_done.html
@@ -1,0 +1,159 @@
+{% extends 'base.html' %}
+{% block title %}Ready: Napier{% endblock %}
+
+{% block head %}
+<style>
+.done-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--brand-bright) 14%, var(--surface));
+  color: var(--brand-bright);
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: .7rem;
+}
+
+.sheet {
+  display: flex;
+  align-items: center;
+  gap: .8rem;
+  padding: .7rem .9rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  margin-bottom: .5rem;
+}
+
+.sheet-main { flex: 1 1 auto; min-width: 0; }
+
+.sheet-name {
+  font-weight: 600;
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.sheet-what {
+  display: block;
+  font-size: .83rem;
+  color: var(--ink-soft);
+}
+
+.sheet-missing {
+  border-color: var(--warn-line);
+  background: var(--line-soft);
+}
+
+.missing {
+  list-style: none;
+  margin: .35rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: .3rem;
+}
+
+.missing li {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .8rem;
+  background: var(--surface);
+  border: 1px solid var(--warn-line);
+  border-radius: 5px;
+  padding: .1rem .4rem;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card">
+  <span class="done-mark" aria-hidden="true">&check;</span>
+  <h1>The clinic list is built</h1>
+  <p class="lede">
+    {{ built }} workbook{{ built | pluralize("","s") }} from
+    {{ clients | length }} client{{ clients | length | pluralize("","s") }},
+    {{ written }} case{{ written | pluralize("","s") }} in all. The zip
+    downloads on its own. Every client is also here on their own, for when you
+    only want the one you are about to see.
+  </p>
+
+  <div class="actions" style="margin-bottom:1.4rem">
+    <a href="/batch/{{ job.id }}/download" class="btn btn-primary" id="again">
+      Download all {{ built }}
+    </a>
+    <a href="/logout" class="btn btn-quiet">Start again</a>
+  </div>
+
+  {% for client in clients %}
+    <div class="sheet {{ 'sheet-missing' if not client['file'] or client['failed'] }}">
+      <span class="sheet-main">
+        <span class="sheet-name">{{ client['name'] }}</span>
+        {% if client['file'] %}
+          <span class="sheet-what">
+            {{ client['written'] }} of {{ client['requested'] }} case{{ client['requested'] | pluralize("","s") }}
+            {{ "written" if client['written'] == client['requested']
+               else "written, the rest would not come off Iowa Courts" }}
+          </span>
+          {% if client['failed'] %}
+            <ul class="missing">
+              {% for case_id in client['failed'] %}<li>{{ case_id }}</li>{% endfor %}
+            </ul>
+          {% endif %}
+        {% else %}
+          <span class="sheet-what">{{ client['error'] }}</span>
+        {% endif %}
+      </span>
+      {% if client['file'] %}
+        <a href="/batch/{{ job.id }}/download/{{ loop.index0 }}" class="btn btn-quiet">
+          Download
+        </a>
+      {% endif %}
+    </div>
+  {% endfor %}
+
+  {% if built != clients | length %}
+    <div class="notice" role="alert" style="margin-top:1.2rem">
+      <p class="notice-title">
+        {{ clients | length - built }} client{{ (clients | length - built) | pluralize("","s") }}
+        {{ "has" if clients | length - built == 1 else "have" }} no workbook.
+      </p>
+      <p>
+        Look {{ "that one" if clients | length - built == 1 else "those" }} up
+        by hand. A list that comes back short without saying so is worse than
+        one that says so.
+      </p>
+    </div>
+  {% endif %}
+
+  {% if limits %}
+    <div class="notice" role="alert" style="margin-top:1.2rem">
+      <p class="notice-title">
+        One of these clients has more cases than the CRS template counts.
+      </p>
+      <p>
+        Every case is in the workbook and every row is right. The template's own
+        formulas stop before the end of them, and Excel does not say so:
+      </p>
+      <ul>
+        {% for limit in limits %}<li>{{ limit }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <p class="lede" style="margin:1.2rem 0 0">
+    This page keeps working for two hours, so you can come back for a file
+    without running the list a second time.
+  </p>
+</div>
+
+<iframe id="grab" title="download" hidden></iframe>
+
+<script>
+// Into a hidden frame so this page stays on screen. What is on it, which
+// client came back short and which has no workbook at all, is the part that
+// matters after the file is saved.
+document.getElementById("grab").src = "/batch/" +
+  encodeURIComponent({{ job.id|tojson }}) + "/download";
+</script>
+{% endblock %}

--- a/templates/roster.html
+++ b/templates/roster.html
@@ -1,0 +1,302 @@
+{% extends 'base.html' %}
+{% block title %}Clinic list: Napier{% endblock %}
+
+{% block head %}
+<style>
+.client {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: .9rem 1rem;
+  margin-bottom: .9rem;
+  background: var(--surface);
+}
+
+.client-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: .8rem;
+  flex-wrap: wrap;
+  margin-bottom: .6rem;
+}
+
+.client-name {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.client-state {
+  font-size: .82rem;
+  color: var(--ink-soft);
+}
+
+.client.picked {
+  border-color: var(--brand-bright);
+  background: color-mix(in srgb, var(--brand-bright) 5%, var(--surface));
+}
+
+.candidates { display: grid; gap: .4rem; }
+
+.candidate {
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  padding: .55rem .7rem;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  cursor: pointer;
+}
+
+.candidate:has(input:checked) { border-color: var(--brand-bright); }
+.candidate input { flex: none; margin: 0; }
+.candidate-main { flex: 1 1 auto; min-width: 0; }
+
+.candidate-name { display: block; overflow-wrap: anywhere; }
+
+.candidate-dob {
+  display: block;
+  font-size: .82rem;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.tally {
+  flex: none;
+  font-size: .78rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+  background: var(--line-soft);
+  border-radius: 999px;
+  padding: .15rem .6rem;
+  white-space: nowrap;
+}
+
+.nobody {
+  font-size: .88rem;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+.bulk {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-size: .85rem;
+  color: var(--brand-bright);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.actions-stuck {
+  position: sticky;
+  bottom: 0;
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  padding: .9rem 0 .2rem;
+}
+
+.skipped {
+  list-style: none;
+  margin: .6rem 0 0;
+  padding: 0;
+}
+
+.skipped li {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: .82rem;
+  overflow-wrap: anywhere;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="card">
+  <h1>Check the list before Napier builds it</h1>
+  <p class="lede">
+    Iowa Courts matched these names. Tick the entry that is your client, and
+    tick more than one where the same person appears under more than one date
+    of birth. A client you leave blank is skipped.
+  </p>
+
+  {% if rejected %}
+    <div class="notice" role="alert">
+      <p class="notice-title">
+        {{ rejected | length }} line{{ rejected | length | pluralize("","s") }}
+        {{ "was" if rejected | length == 1 else "were" }} not searched.
+      </p>
+      <p>
+        Napier could not read a name out of
+        {{ "it" if rejected | length == 1 else "them" }}, or took
+        {{ "it" if rejected | length == 1 else "them" }} for a heading. Search
+        {{ "it" if rejected | length == 1 else "them" }} on their own if
+        {{ "it belongs" if rejected | length == 1 else "they belong" }} on the
+        list.
+      </p>
+      <ul class="skipped">
+        {% for line in rejected %}<li>{{ line }}</li>{% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <form id="batch">
+    <div class="result-head" style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;flex-wrap:wrap;margin-bottom:.6rem">
+      <p class="client-state" id="count">Nothing picked yet</p>
+      {# Ticking the only answer for twenty clients by hand is twenty chances to
+         mis-click. This ticks only where Iowa Courts returned exactly one, and
+         they are all still on screen to be read. #}
+      <button type="button" class="bulk" id="take-singles">
+        Tick every client with only one match
+      </button>
+    </div>
+
+    {% for client in clients %}
+      <div class="client" data-client="{{ loop.index0 }}">
+        <div class="client-head">
+          <span class="client-name">{{ client['name'] }}</span>
+          <span class="client-state">
+            {% if client['error'] %}
+              not searched
+            {% elif client['keys'] %}
+              {{ client['keys'] | length }}
+              match{{ client['keys'] | length | pluralize("","es") }}
+            {% else %}
+              no cases
+            {% endif %}
+          </span>
+        </div>
+
+        {% if client['error'] %}
+          <p class="nobody">{{ client['error'] }}</p>
+        {% elif not client['keys'] %}
+          <p class="nobody">
+            Iowa Courts has no cases under that name. A maiden name or a
+            spelling on the court record will do this, so search it on its own
+            before concluding there is nothing there.
+          </p>
+        {% else %}
+          {% if client['too_many_results'] %}
+            <p class="nobody">
+              Iowa Courts stopped counting at 200 records, so some cases may be
+              missing from these matches.
+            </p>
+          {% endif %}
+          <div class="candidates">
+            {% for key in client['keys'] %}
+              {% set parts = key.split(' ', 1) %}
+              <label class="candidate">
+                <input type="checkbox" value="{{ key }}">
+                <span class="candidate-main">
+                  <span class="candidate-name">{{ parts[1] if parts|length > 1 else key }}</span>
+                  {% if parts|length > 1 %}
+                    <span class="candidate-dob">Born {{ parts[0] }}</span>
+                  {% endif %}
+                </span>
+                {% set n = client['cases'][key] | length %}
+                <span class="tally">{{ n }} case{{ n | pluralize("","s") }}</span>
+              </label>
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+
+    <div class="actions actions-stuck">
+      <button id="batch-submit" type="submit" class="btn btn-primary">
+        Build the workbooks
+      </button>
+      <a href="/logout" class="btn btn-quiet">Start again</a>
+    </div>
+  </form>
+
+  <div id="status" class="notice notice-stop" role="alert" hidden></div>
+</div>
+
+<script>
+var searchJobId = {{ search_job_id|tojson }};
+var form = document.getElementById("batch");
+var button = document.getElementById("batch-submit");
+var statusBox = document.getElementById("status");
+var countLine = document.getElementById("count");
+var singles = document.getElementById("take-singles");
+
+function clientBlocks() {
+  return Array.prototype.slice.call(form.querySelectorAll(".client"));
+}
+
+function picks() {
+  var out = [];
+  clientBlocks().forEach(function (block) {
+    var keys = Array.prototype.slice.call(
+      block.querySelectorAll("input[type=checkbox]"))
+      .filter(function (b) { return b.checked; })
+      .map(function (b) { return b.value; });
+    block.classList.toggle("picked", keys.length > 0);
+    if (keys.length) {
+      out.push({ client: Number(block.dataset.client), keys: keys });
+    }
+  });
+  return out;
+}
+
+function refresh() {
+  var n = picks().length;
+  countLine.textContent = n === 0
+    ? "Nothing picked yet"
+    : n + (n === 1 ? " client picked" : " clients picked");
+}
+
+singles.addEventListener("click", function () {
+  clientBlocks().forEach(function (block) {
+    var boxes = block.querySelectorAll("input[type=checkbox]");
+    if (boxes.length === 1) { boxes[0].checked = true; }
+  });
+  refresh();
+});
+
+function say(message) {
+  statusBox.textContent = message;
+  statusBox.hidden = !message;
+}
+
+form.addEventListener("change", refresh);
+
+// Same shape as the single-client flow: this page hands off the selection and
+// the run itself happens on the server, so a closed laptop does not end it.
+form.addEventListener("submit", function (e) {
+  e.preventDefault();
+  var chosen = picks();
+  if (!chosen.length) {
+    say("Tick a match for at least one client first.");
+    return;
+  }
+  say("");
+  button.disabled = true;
+  button.textContent = "Starting...";
+
+  fetch("/batch-crs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+    body: JSON.stringify({ search_job_id: searchJobId, picks: chosen })
+  }).then(function (response) {
+    return response.json().catch(function () { return null; })
+      .then(function (body) { return { ok: response.ok, body: body }; });
+  }).then(function (result) {
+    if (result.ok && result.body && result.body.progress_url) {
+      window.location = result.body.progress_url;
+      return;
+    }
+    button.disabled = false;
+    button.textContent = "Build the workbooks";
+    say((result.body && result.body.error) ||
+        "Could not start the run. Please try again.");
+  }).catch(function () {
+    button.disabled = false;
+    button.textContent = "Build the workbooks";
+    say("Could not start the run. Please try again.");
+  });
+});
+
+refresh();
+</script>
+{% endblock %}

--- a/templates/start.html
+++ b/templates/start.html
@@ -24,7 +24,7 @@
         {{ waiting_job.result.def_name }} and nothing has downloaded it yet.
         It keeps for two hours.
       </p>
-      <p><a href="/done/{{ waiting_job.id }}">Open that workbook</a></p>
+      <p><a href="{{ waiting_job.result.done_url }}">Open that workbook</a></p>
     </div>
   {% endif %}
 
@@ -85,6 +85,110 @@
     </div>
   </form>
 </div>
+
+{# A clinic day is twenty of the search above, each with its own sign in, each
+   waiting on the shared Iowa Courts account the last one still holds. Same
+   work, one sign in. Folded away because most days it is one client. #}
+<details class="card batch" {% if open_batch %}open{% endif %}>
+  <summary>
+    <span class="batch-title">Doing a whole clinic list?</span>
+    <span class="batch-note">
+      Paste the list and Napier searches every name on one sign in.
+    </span>
+  </summary>
+
+  <form action="/batch" method="post">
+    <fieldset>
+      <legend>Your clients</legend>
+      <label>
+        <span class="field-label">One client per line</span>
+        <textarea name="roster" rows="8" spellcheck="false"
+                  placeholder="Doe, Jane&#10;Roe, John Q&#10;Maria Garcia"></textarea>
+        <span class="check-note">
+          Either "Last, First" or "First Last". A heading row, a date of birth
+          column or a case number after the name are all fine, Napier ignores
+          them. Up to {{ max_names }} names at a time.
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Your Iowa Courts sign in</legend>
+      <div class="row row-two">
+        <label>
+          <span class="field-label">User ID</span>
+          <input type="text" name="username" autocomplete="username"
+                 autocapitalize="none" spellcheck="false" required>
+        </label>
+        <label>
+          <span class="field-label">Password</span>
+          <input type="password" name="password"
+                 autocomplete="current-password" required>
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <label class="check">
+        <input type="checkbox" name="isLiteBatch">
+        <span class="check-text">
+          Build Lite workbooks
+          <span class="check-note">Applies to every client on the list.</span>
+        </span>
+      </label>
+    </fieldset>
+
+    <div class="actions">
+      <button type="submit" class="btn btn-primary">Search the whole list</button>
+    </div>
+  </form>
+</details>
+
+<style>
+.batch summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.batch summary::-webkit-details-marker { display: none; }
+
+.batch summary::before {
+  content: "+";
+  display: inline-block;
+  width: 1.1rem;
+  font-weight: 700;
+  color: var(--brand-bright);
+}
+
+.batch[open] summary::before { content: "\2212"; }
+.batch[open] summary { margin-bottom: 1.1rem; }
+
+.batch-title { font-weight: 600; }
+
+.batch-note {
+  display: block;
+  margin-left: 1.1rem;
+  font-size: .84rem;
+  color: var(--ink-soft);
+}
+
+.batch textarea {
+  width: 100%;
+  padding: .55rem .7rem;
+  font: inherit;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  resize: vertical;
+}
+
+.batch textarea:focus {
+  outline: none;
+  border-color: var(--focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus) 22%, transparent);
+}
+</style>
 
 <script>
 // The shared ICOS user IDs get retyped a dozen times a day. Only the ID is

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,525 @@
+"""The ranked action list, and the promise it makes to the workbook it sits in.
+
+The list is only worth having if it agrees with the sheets behind it, so most
+of what is pinned here is agreement rather than legal opinion: the twenty year
+cut is the SOL sheet's 7300 days, the traffic test is the EXPUNGEMENT sheet's,
+the conviction codes are LICENSE-REGIS's. Where those tests are reproduced in
+Python, these tests hold the reproduction to the sheet.
+
+Every case number is 00000 FECR000000 and every date is in the 1900s, because
+this repository is public.
+"""
+
+import os
+import sys
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from openpyxl import Workbook, load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import actions
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+ALL_SHEETS = {'CASE DATA', 'SOL', 'EXPUNGEMENT & 910.7', 'POLK R&B APPEAL'}
+
+# Twenty years and a day before the clinic, and a day short of it.
+STALE = '01/01/1990'
+FRESH = '01/01/2020'
+
+FEES = 'JKLMNOPQRS'
+
+
+def sheet_with(*rows):
+    """A stand-in CASE DATA holding the columns the action list reads."""
+    worksheet = Workbook().active
+    for offset, values in enumerate(rows):
+        row = crs.FIRST_CASE_ROW + offset
+        cells = dict({'A': '00000  FECR000000', 'B': 'SYNTHETIC',
+                      'D': FRESH, 'G': 'GTR'}, **values)
+        for column, value in cells.items():
+            worksheet[column + str(row)] = value
+    return worksheet
+
+
+def facts_for(**values):
+    return actions.row_facts(sheet_with(values), crs.FIRST_CASE_ROW)
+
+
+def cites(found):
+    return [action[3] for _, action in found]
+
+
+class TestRowFacts:
+    def test_a_date_comes_back_as_a_date(self):
+        # Napier writes dates as the strings ICOS uses. Excel coerces those in
+        # arithmetic; Python does not, and a string against a date raises.
+        assert facts_for(D='07/04/1976')['disposition_date'] == date(1976, 7, 4)
+
+    def test_a_date_iowa_courts_left_blank_is_none_not_an_error(self):
+        assert facts_for(D=None)['disposition_date'] is None
+
+    def test_a_code_is_read_however_it_was_cased(self):
+        assert facts_for(G=' gtr ')['code'] == 'GTR'
+
+    def test_a_missing_code_is_empty_rather_than_none(self):
+        assert facts_for(G=None)['code'] == ''
+
+    def test_yes_columns_are_booleans(self):
+        facts = facts_for(H='YES', I='YES')
+        assert facts['vehicular'] and facts['supervised']
+
+    def test_anything_but_yes_is_no(self):
+        # Column I is blank on most rows and blank has to read as no, or every
+        # case Napier could not answer turns into a 910.7 argument.
+        facts = facts_for(H='', I=None)
+        assert not facts['vehicular'] and not facts['supervised']
+
+    def test_the_fee_columns_all_come_back(self):
+        assert set(facts_for()['money']) == set(FEES)
+
+
+class TestDecimalAndSum:
+    def test_a_blank_fee_cell_is_zero(self):
+        assert actions._decimal(None) == Decimal(0)
+
+    def test_a_text_cell_is_zero_rather_than_an_exception(self):
+        # The workbook is handed back to staff and comes back edited.
+        assert actions._decimal('see notes') == Decimal(0)
+
+    def test_a_float_does_not_pick_up_binary_error(self):
+        assert actions._decimal(0.1) == Decimal('0.1')
+
+    def test_the_fee_columns_add_up(self):
+        facts = facts_for(J=100, K=25.5, R=10)
+        assert actions._sum(facts, FEES) == Decimal('135.5')
+
+    def test_910_7_cannot_reach_fines_surcharges_or_restitution(self):
+        facts = facts_for(J=100, Q=1000, R=1000, S=1000)
+        assert actions._sum(facts, actions.REMISSIBLE_COLUMNS) == Decimal(100)
+
+
+class TestIsTraffic:
+    def test_a_simple_misdemeanour_under_321_is_traffic(self):
+        assert actions.is_traffic(facts_for(A='00000  SMSM000000', F='321.20'))
+
+    def test_a_simple_misdemeanour_under_another_chapter_is_not(self):
+        assert not actions.is_traffic(
+            facts_for(A='00000  SMSM000000', F='123.46'))
+
+    def test_a_scheduled_violation_is_traffic_whatever_the_statute(self):
+        assert actions.is_traffic(facts_for(A='00000  STP0000000', F='123.46'))
+
+    def test_a_non_scheduled_violation_is_traffic_too(self):
+        assert actions.is_traffic(facts_for(A='00000  NTP0000000', F='123.46'))
+
+    def test_a_felony_under_321_is_not_traffic(self):
+        # Chapter 321 carries real felonies, and the sheet only calls the
+        # simple misdemeanours traffic.
+        assert not actions.is_traffic(facts_for(A='00000  FECR000000',
+                                                F='321.261'))
+
+    def test_a_case_with_no_number_does_not_raise(self):
+        assert not actions.is_traffic(facts_for(A=None))
+
+
+class TestTimeBarred:
+    def test_a_day_past_twenty_years_is_barred(self):
+        barred = CLINIC - timedelta(days=actions.SOL_DAYS + 1)
+        assert actions.time_barred(
+            facts_for(D=barred.strftime('%m/%d/%Y')), CLINIC)
+
+    def test_exactly_twenty_years_is_not(self):
+        # The SOL sheet tests D4+7300 < B3, so the day it lands is not barred,
+        # and this has to break the same way round the sheet does.
+        edge = CLINIC - timedelta(days=actions.SOL_DAYS)
+        assert not actions.time_barred(
+            facts_for(D=edge.strftime('%m/%d/%Y')), CLINIC)
+
+    def test_an_undated_disposition_is_not_barred(self):
+        assert not actions.time_barred(facts_for(D=None), CLINIC)
+
+
+class TestMisdemeanourExpungement:
+    def call(self, felonies=('707.2',), ineligible=('123.46',), **values):
+        return actions.misdemeanour_expungement(
+            facts_for(**dict({'D': STALE, 'G': 'GTR', 'F': '714.2'}, **values)),
+            CLINIC, felonies, ineligible)
+
+    def test_an_old_misdemeanour_conviction_qualifies(self):
+        assert self.call()
+
+    def test_a_dismissal_does_not(self):
+        # A dismissal is 901C.2 and wipes the debt with it, which is a
+        # different and better row.
+        assert not self.call(G='DISM')
+
+    def test_a_deferred_judgment_does_not(self):
+        assert not self.call(G='DEF')
+
+    def test_a_felony_on_the_sheet_s_list_does_not(self):
+        assert not self.call(F='707.2')
+
+    def test_one_felony_among_several_counts_disqualifies_the_case(self):
+        # The helper columns split column F and the sheet matches every one of
+        # them, so a clean count does not rescue the case.
+        assert not self.call(F='714.2;707.2')
+
+    def test_the_sheet_s_ineligible_misdemeanour_list_is_honoured(self):
+        assert not self.call(F='123.46')
+
+    def test_an_excluded_chapter_is_ruled_out_by_prefix(self):
+        assert not self.call(F='719.1')
+
+    def test_a_section_that_only_starts_the_same_is_still_matched(self):
+        # 901A.2 is prefix-matched by the sheet, and so is anything under it.
+        assert not self.call(F='901A.2')
+
+    def test_eight_years_has_to_have_run(self):
+        assert not self.call(D=FRESH)
+
+    def test_a_traffic_case_is_not_this_argument(self):
+        assert not self.call(A='00000  SMSM000000', F='321.20')
+
+    def test_a_case_with_no_statute_is_left_alone(self):
+        # Nothing to match against is not the same as matching nothing.
+        assert not self.call(F=None)
+
+
+class TestCaseActions:
+    def find(self, **values):
+        return actions.case_actions(facts_for(**values), CLINIC, ALL_SHEETS)
+
+    def test_old_attorney_fees_are_a_614_1_6_objection(self):
+        found = self.find(D=STALE, J=100, K=50)
+        assert found[0][3] == 'Iowa Code 614.1(6)'
+        assert found[0][1] == Decimal(150)
+
+    def test_room_and_board_counts_toward_the_time_bar(self):
+        assert self.find(D=STALE, L=200)[0][1] == Decimal(200)
+
+    def test_fines_do_not_count_toward_the_time_bar(self):
+        # The SOL sheet only puts attorney, collection and room and board in
+        # its barred columns. A stale fine is a different argument.
+        assert cites(
+            [(None, action) for action in self.find(D=STALE, R=500)]) == []
+
+    def test_an_old_case_with_nothing_owed_is_not_a_row(self):
+        assert self.find(D=STALE) == []
+
+    def test_the_sol_sheet_is_named_only_when_the_workbook_has_one(self):
+        full = actions.case_actions(facts_for(D=STALE, J=100), CLINIC,
+                                    ALL_SHEETS)
+        lite = actions.case_actions(facts_for(D=STALE, J=100), CLINIC,
+                                    {'CASE DATA'})
+        assert 'SOL sheet' in full[0][4]
+        assert 'SOL sheet' not in lite[0][4]
+
+    def test_a_dismissal_discharges_the_whole_balance(self):
+        found = self.find(G='DISM', J=100, R=400, S=500)
+        assert found[0][3] == 'Iowa Code 901C.2'
+        assert found[0][1] == Decimal(1000)
+
+    def test_a_dismissed_traffic_case_is_not_901c_2(self):
+        assert self.find(A='00000  STP0000000', G='DISM', J=100) == []
+
+    def test_supervision_opens_910_7(self):
+        found = self.find(I='YES', J=100, Q=900)
+        assert found[0][3] == 'Iowa Code 910.7'
+        # Surcharges are outside what 910.7 reaches.
+        assert found[0][1] == Decimal(100)
+
+    def test_supervision_with_nothing_remissible_is_not_a_row(self):
+        assert self.find(I='YES', Q=900, R=900) == []
+
+    def test_polk_room_and_board_is_a_356_7_challenge(self):
+        found = self.find(B='Polk', L=300)
+        assert 'Iowa Code 356.7' in cites([(None, a) for a in found])
+
+    def test_room_and_board_outside_polk_is_not_the_polk_argument(self):
+        # The appeal sheet is Polk's. The charge exists elsewhere and the list
+        # says nothing about it rather than pointing at a sheet that will not
+        # have the row.
+        assert 'Iowa Code 356.7' not in cites(
+            [(None, a) for a in self.find(B='SYNTHETIC', L=300)])
+
+    def test_a_vehicular_conviction_with_debt_is_a_licence_row(self):
+        found = self.find(H='YES', G='GTR', R=400)
+        assert found[0][3] == 'Iowa Code 321.210A, 321.210B'
+        assert found[0][1] == Decimal(400)
+
+    def test_a_vehicular_case_that_was_dismissed_is_not(self):
+        assert 'Iowa Code 321.210A, 321.210B' not in cites(
+            [(None, a) for a in self.find(H='YES', G='DISM', R=400)])
+
+    def test_a_vehicular_conviction_with_nothing_owed_is_not(self):
+        assert self.find(H='YES', G='GTR') == []
+
+    def test_a_juvenile_case_is_flagged(self):
+        found = self.find(G='JUV', J=50)
+        assert found[0][3] == 'Iowa Code 232.150'
+
+    def test_one_case_can_carry_several_arguments(self):
+        found = self.find(D=STALE, G='GTR', H='YES', I='YES', J=100, K=50)
+        assert set(cites([(None, action) for action in found])) == {
+            'Iowa Code 614.1(6)', 'Iowa Code 910.7',
+            'Iowa Code 321.210A, 321.210B'}
+
+    def test_the_registration_hold_is_not_a_row(self):
+        # It fires on nearly every convicted case, so as rows it buried the
+        # arguments worth an hour. It is one line in the header block.
+        assert self.find(G='GTR', R=100) == []
+
+
+class TestRegistrationHold:
+    def test_convicted_cases_carrying_a_balance_are_counted(self):
+        worksheet = sheet_with({'G': 'GTR', 'R': 100}, {'G': 'GPL', 'J': 50})
+        assert actions.registration_hold(worksheet, 2) == (2, Decimal(150))
+
+    def test_a_dismissal_is_not_counted(self):
+        worksheet = sheet_with({'G': 'DISM', 'R': 100})
+        assert actions.registration_hold(worksheet, 1) == (0, Decimal(0))
+
+    def test_a_paid_off_conviction_is_not_counted(self):
+        worksheet = sheet_with({'G': 'GTR'})
+        assert actions.registration_hold(worksheet, 1) == (0, Decimal(0))
+
+    def test_rows_past_the_ones_napier_wrote_are_not_read(self):
+        worksheet = sheet_with({'G': 'GTR', 'R': 100}, {'G': 'GTR', 'R': 100})
+        assert actions.registration_hold(worksheet, 1) == (1, Decimal(100))
+
+
+class TestCollect:
+    def test_the_biggest_number_is_first(self):
+        worksheet = sheet_with(
+            {'A': '00000  FECR000001', 'G': 'DISM', 'R': 100},
+            {'A': '00000  FECR000002', 'G': 'DISM', 'R': 900},
+        )
+        found = actions.collect(worksheet, 2, CLINIC, ALL_SHEETS)
+        assert [facts['id'] for facts, _ in found] == [
+            '00000  FECR000002', '00000  FECR000001']
+
+    def test_a_tie_on_money_is_broken_by_tier(self):
+        # Both rows are worth the same; the time barred argument is the easier
+        # one to make, so it reads first.
+        worksheet = sheet_with({'D': STALE, 'G': 'DISM', 'J': 100})
+        found = actions.collect(worksheet, 1, CLINIC, ALL_SHEETS)
+        assert cites(found) == ['Iowa Code 614.1(6)', 'Iowa Code 901C.2']
+
+    def test_the_same_workbook_always_comes_out_in_the_same_order(self):
+        worksheet = sheet_with(
+            {'A': '00000  FECR000002', 'G': 'DISM', 'R': 100},
+            {'A': '00000  FECR000001', 'G': 'DISM', 'R': 100},
+        )
+        found = actions.collect(worksheet, 2, CLINIC, ALL_SHEETS)
+        assert [facts['id'] for facts, _ in found] == [
+            '00000  FECR000001', '00000  FECR000002']
+
+    def test_an_empty_row_is_skipped_rather_than_read(self):
+        worksheet = sheet_with({'G': 'DISM', 'R': 100}, {'A': None})
+        assert len(actions.collect(worksheet, 2, CLINIC, ALL_SHEETS)) == 1
+
+
+# -- the sheets themselves ---------------------------------------------------
+
+def payment_row(detail, paid, when, receipt='000001', tender='CSH'):
+    return {'detail': detail, 'amount': '100.00', 'paid': paid,
+            'paidDate': when, 'receipt': receipt, 'tender': tender}
+
+
+def synthetic_case(case_id='00000  FECR000000', rows=()):
+    return {'id': case_id, 'financials': list(rows)}
+
+
+def written_workbook(path, rows, cases=(), as_of=CLINIC):
+    workbook = load_workbook(path)
+    sheet = workbook['CASE DATA']
+    for offset, values in enumerate(rows):
+        row = crs.FIRST_CASE_ROW + offset
+        cells = dict({'A': '00000  FECR000000', 'B': 'SYNTHETIC',
+                      'D': FRESH, 'G': 'GTR'}, **values)
+        for column, value in cells.items():
+            sheet[column + str(row)] = value
+    actions.build_action_sheet(workbook, list(cases), len(rows), as_of,
+                               'SYNTHETIC CLIENT')
+    return workbook
+
+
+class TestClientPayments:
+    def test_payments_are_pooled_across_every_case(self):
+        history = actions.client_payments([
+            synthetic_case('00000  FECR000001',
+                           [payment_row('FINE', '10.00', '01/01/1900')]),
+            synthetic_case('00000  FECR000002',
+                           [payment_row('FINE', '30.00', '01/01/1901')]),
+        ], CLINIC)
+        assert history['count'] == 2
+        assert history['cases'] == 2
+        assert history['total'] == Decimal('40.00')
+
+    def test_no_payments_anywhere_is_none(self):
+        assert actions.client_payments([synthetic_case()], CLINIC) is None
+
+    def test_the_recent_window_is_what_the_court_asks_about(self):
+        history = actions.client_payments([
+            synthetic_case(rows=[payment_row('FINE', '600.00', '01/01/1900'),
+                                 payment_row('FINE', '120.00', '01/15/2026')]),
+        ], CLINIC)
+        assert history['recent'] == Decimal('120.00')
+        assert history['recent_monthly'] == Decimal('10.00')
+
+    def test_every_payment_carries_the_case_it_was_paid_on(self):
+        history = actions.client_payments([
+            synthetic_case('00000  FECR000007',
+                           [payment_row('FINE', '10.00', '01/01/1900')]),
+        ], CLINIC)
+        assert history['payments'][0]['case'] == '00000  FECR000007'
+
+
+class TestActionSheet:
+    def test_the_action_list_is_the_first_sheet_staff_see(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        assert workbook.sheetnames[0] == 'ACTION LIST'
+
+    def test_the_client_and_the_clinic_date_are_at_the_top(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        sheet = workbook['ACTION LIST']
+        assert sheet['D1'].value == 'SYNTHETIC CLIENT'
+        assert sheet['B2'].value == CLINIC
+        assert sheet['B3'].value == 1
+
+    def test_the_caveat_is_on_the_sheet_not_in_a_manual(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        assert 'has been read by a lawyer' in workbook['ACTION LIST']['A7'].value
+
+    def test_the_total_owed_adds_up_every_fee_column(self):
+        workbook = written_workbook(
+            FULL, [{'J': 100, 'R': 200}, {'S': 300}])
+        assert workbook['ACTION LIST']['B4'].value == Decimal(600)
+
+    def test_a_row_names_the_case_the_authority_and_the_money(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        sheet = workbook['ACTION LIST']
+        row = actions.FIRST_ACTION_ROW
+        assert sheet.cell(row, 1).value == 1
+        assert sheet.cell(row, 2).value == '00000  FECR000000'
+        assert sheet.cell(row, 5).value == 'Iowa Code 901C.2'
+        assert sheet.cell(row, 6).value == Decimal(100)
+
+    def test_a_client_with_no_arguments_is_told_so_plainly(self):
+        workbook = written_workbook(FULL, [{'G': 'GTR'}])
+        cell = workbook['ACTION LIST'].cell(actions.FIRST_ACTION_ROW, 1)
+        assert 'not the same as nothing being there' in cell.value
+
+    def test_the_registration_hold_is_one_line(self):
+        workbook = written_workbook(FULL, [{'G': 'GTR', 'R': 100}])
+        assert '1 convicted case carrying $100.00' in \
+            workbook['ACTION LIST']['B6'].value
+
+    def test_no_hold_says_none_rather_than_nothing(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        assert workbook['ACTION LIST']['B6'].value == 'none'
+
+    def test_a_workbook_with_no_payments_says_which_kind_of_nothing(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        assert workbook['ACTION LIST']['B5'].value == \
+            'none in the ICOS itemization'
+
+    def test_the_payment_line_reports_the_record(self):
+        workbook = written_workbook(
+            FULL, [{'G': 'DISM', 'R': 100}],
+            [synthetic_case(rows=[payment_row('FINE', '25.00', '01/02/1900')])])
+        line = workbook['ACTION LIST']['B5'].value
+        assert '$25.00 across 1 payment on 1 case' in line
+        assert '01/02/1900 to 01/02/1900' in line
+
+    def test_the_helper_columns_are_left_alone(self):
+        # W through AH carry the array formulas the eligibility tests match
+        # against, under a header that says DO NOT EDIT THESE.
+        def formula(sheet, column):
+            value = sheet.cell(crs.FIRST_CASE_ROW, column).value
+            return getattr(value, 'text', value)
+
+        before = load_workbook(FULL)['CASE DATA']
+        after = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])['CASE DATA']
+        for column in range(23, 35):
+            assert formula(after, column) == formula(before, column)
+            assert formula(after, column)
+
+    def test_the_lite_workbook_gets_a_list_too(self):
+        workbook = written_workbook(LITE, [{'D': STALE, 'J': 100}])
+        assert workbook.sheetnames[0] == 'ACTION LIST'
+
+    def test_the_lite_list_does_not_point_at_a_sheet_it_does_not_have(self):
+        # SOL, BANKRUPTCY and EXEMPTIONS are not in the Lite file.
+        workbook = written_workbook(LITE, [{'D': STALE, 'J': 100}])
+        why = workbook['ACTION LIST'].cell(actions.FIRST_ACTION_ROW, 7).value
+        assert 'SOL sheet' not in why
+        assert 'Iowa Code 614.1(6)' == \
+            workbook['ACTION LIST'].cell(actions.FIRST_ACTION_ROW, 5).value
+
+    def test_the_sheet_can_be_saved_and_read_back(self, tmp_path):
+        # openpyxl writes Decimals, and a workbook that will not reopen is not
+        # a work product.
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        path = str(tmp_path / 'synthetic.xlsx')
+        workbook.save(path)
+        assert load_workbook(path)['ACTION LIST'].cell(
+            actions.FIRST_ACTION_ROW, 5).value == 'Iowa Code 901C.2'
+
+
+class TestPaymentSheet:
+    def workbook(self, rows):
+        return written_workbook(FULL, [{'G': 'GTR', 'R': 100}],
+                                [synthetic_case(rows=rows)])
+
+    def test_newest_first_because_that_is_the_question(self):
+        sheet = self.workbook([
+            payment_row('FINE', '10.00', '01/01/1900'),
+            payment_row('FINE', '20.00', '01/01/1901'),
+        ])['PAYMENTS']
+        assert sheet.cell(5, 2).value == date(1901, 1, 1)
+        assert sheet.cell(6, 2).value == date(1900, 1, 1)
+
+    def test_the_receipt_and_the_tender_are_carried_through(self):
+        sheet = self.workbook([
+            payment_row('COURT COSTS', '10.00', '01/01/1900',
+                        receipt='000123', tender='CHK'),
+        ])['PAYMENTS']
+        assert sheet.cell(5, 1).value == '00000  FECR000000'
+        assert sheet.cell(5, 3).value == Decimal('10.00')
+        assert sheet.cell(5, 4).value == 'COURT COSTS'
+        assert sheet.cell(5, 5).value == '000123'
+        assert sheet.cell(5, 6).value == 'CHK'
+
+    def test_the_total_is_on_the_sheet(self):
+        sheet = self.workbook([
+            payment_row('FINE', '10.00', '01/01/1900'),
+            payment_row('FINE', '20.00', '01/01/1901'),
+        ])['PAYMENTS']
+        assert sheet['B2'].value == Decimal('30.00')
+
+    def test_an_empty_record_says_what_it_does_and_does_not_mean(self):
+        sheet = written_workbook(FULL, [{'G': 'GTR', 'R': 100}])['PAYMENTS']
+        assert 'not proof nothing was paid' in sheet['A3'].value
+
+
+def test_the_code_lists_come_out_of_the_workbook():
+    # Keeping a second copy in Python would drift the first time a clinic
+    # added a section to CODE SECTIONS.
+    felonies, ineligible = actions.code_lists(load_workbook(FULL))
+    assert len(felonies) > 100
+    assert ineligible
+    assert all(isinstance(section, str) for section in felonies + ineligible)
+
+
+@pytest.mark.parametrize('statute', ['321.20', ' 321.20 ', '714.2;321.20'])
+def test_statutes_are_split_the_way_the_helper_columns_split_them(statute):
+    assert '321.20' in actions.statutes(facts_for(F=statute))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,443 @@
+"""A clinic list end to end: paste, search, pick, build, download.
+
+Wired through the real routes with a fake court site, because the throughput
+this exists to fix is spread across four of them and one background job, and
+any of them can drop a client on the floor without anything raising.
+
+The names are invented and every case number is 00000-shaped. The repository is
+public and a real Iowa case number attached to a real name is a person.
+"""
+
+import os
+import sys
+import time
+import zipfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
+
+import app as app_module
+import jobs
+import tasks
+from icos import IcosError
+
+ROSTER = "Doe, Jane\nRoe, John"
+
+
+def results_for(surname, given, cases, dob="01/01/1900"):
+    rows = "".join(
+        '<tr><td>%s</td><td></td><td>STATE VS %s</td><td>%s, %s</td>'
+        '<td>%s</td><td>DEFENDANT</td></tr>' % (case, surname, surname, given,
+                                                dob)
+        for case in cases)
+    return ("<html><table>"
+            "<tr><td>Case ID</td><td></td><td>Title</td><td>Name</td>"
+            "<td>DOB</td><td>Role</td></tr>%s</table></html>" % rows).encode()
+
+
+# One client with two cases, one with one, so a wrong slice of the case list
+# shows up as a count rather than passing quietly.
+PEOPLE = {
+    'DOE': results_for('DOE', 'JANE', ['00000 FECR000000', '00000 SRCR000000']),
+    'ROE': results_for('ROE', 'JOHN', ['00000 SMCR000000']),
+}
+
+
+class FakeClient:
+    """Stands in for IcosClient and records the session lifecycle."""
+
+    instances = []
+    search_error = None
+    fail_searches = ()      # 1-based positions in the list that Iowa Courts refuses
+
+    def __init__(self, log=None, alert=None, **kwargs):
+        self.log = log or (lambda m, **kw: None)
+        self.alert = alert
+        self.logged_off = False
+        self.searched = []
+        self.cases = []
+        self.fail_cases = []
+        FakeClient.instances.append(self)
+
+    def set_alert(self, alert):
+        self.alert = alert
+
+    def login(self, username, password):
+        self.log("Signed in to Iowa Courts Online.")
+
+    def search(self, first, middle, last):
+        self.searched.append((first, middle, last))
+        if FakeClient.search_error:
+            raise FakeClient.search_error
+        if len(self.searched) in FakeClient.fail_searches:
+            raise IcosError("Iowa Courts did not answer.")
+        return PEOPLE.get(last.upper(), results_for(last.upper(), 'X', []))
+
+    def case_bundle(self, case_id):
+        self.cases.append(case_id)
+        if case_id in self.fail_cases:
+            raise IcosError("Iowa Courts did not answer for this case.")
+        return b"<summary>", b"<charges>", b"<financials>"
+
+    def logoff(self):
+        self.logged_off = True
+
+
+@pytest.fixture(autouse=True)
+def fake_icos(monkeypatch):
+    FakeClient.instances = []
+    FakeClient.search_error = None
+    FakeClient.fail_searches = ()
+    monkeypatch.setattr(tasks, 'IcosClient', FakeClient)
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_summary',
+                        lambda html, case: case.update(county='DUBUQUE'))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_charges',
+                        lambda html, case: case.update(charges=[]))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
+                        lambda html, case: case.update(financials=[],
+                                                       total_due='$0.00'))
+    monkeypatch.setattr(tasks, 'build_workbook',
+                        lambda cases, name, dob, lite: (_stub_workbook(name), {}))
+    yield
+
+
+def _stub_workbook(name):
+    path = os.path.join(tasks.tmp_dir,
+                        'test_stub_%s.xlsx' % name.split(',')[0].strip())
+    with open(path, 'wb') as f:
+        f.write(b'PK\x03\x04 stub workbook')
+    return path
+
+
+@pytest.fixture
+def client():
+    app_module.app.config['TESTING'] = True
+    app_module.app.secret_key = 'test'
+    return app_module.app.test_client()
+
+
+def await_job(client, job_id, timeout=5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        state = client.get('/job/' + job_id).get_json()
+        if state['done']:
+            return state
+        time.sleep(0.01)
+    raise AssertionError("job never finished")
+
+
+def run_batch(client, roster=ROSTER, username='ILATEST', lite=False):
+    form = {'username': username, 'password': 'secret', 'roster': roster}
+    if lite:
+        form['isLiteBatch'] = 'on'
+    response = client.post('/batch', data=form)
+    if response.status_code != 302:
+        return None, response
+    job_id = response.headers['Location'].rsplit('/', 1)[-1]
+    return job_id, await_job(client, job_id)
+
+
+def pick_all(client, search_job_id, state=None):
+    """Tick every match the search came back with, the way staff would."""
+    client.get('/roster/' + search_job_id)
+    result = jobs.get(search_job_id).result
+    picks = [{'client': index, 'keys': entry['keys']}
+             for index, entry in enumerate(result['clients']) if entry['keys']]
+    return client.post('/batch-crs', json={'search_job_id': search_job_id,
+                                           'picks': picks})
+
+
+def build_a_list(client, roster=ROSTER):
+    search_job_id, _ = run_batch(client, roster)
+    response = pick_all(client, search_job_id)
+    job_id = response.get_json()['job_id']
+    return job_id, await_job(client, job_id)
+
+
+class TestSearchingTheList:
+    def test_the_whole_list_is_searched_on_one_sign_in(self, client):
+        """The point of the feature. Twenty clients used to be twenty sign ins
+        queueing for one shared Iowa Courts account."""
+        search_job_id, state = run_batch(client)
+        assert state['status'] == 'done'
+        assert len(FakeClient.instances) == 1
+        assert FakeClient.instances[0].searched == [
+            ('Jane', '', 'Doe'), ('John', '', 'Roe')]
+
+    def test_it_hands_back_a_page_at_once(self, client):
+        started = time.time()
+        response = client.post('/batch', data={
+            'username': 'ILATEST', 'password': 'secret', 'roster': ROSTER})
+        assert time.time() - started < 1
+        assert '/progress/' in response.headers['Location']
+
+    def test_the_roster_page_lists_every_client_and_their_matches(self, client):
+        search_job_id, _ = run_batch(client)
+        page = client.get('/roster/' + search_job_id).get_data(as_text=True)
+        assert 'DOE, JANE' in page
+        assert 'ROE, JOHN' in page
+        assert '2 cases' in page
+        assert '1 case' in page
+
+    def test_no_client_name_reaches_the_progress_log(self, client):
+        """The log is quoted into alert email and these names are privileged.
+        A position in the list is not."""
+        _, state = run_batch(client)
+        joined = " ".join(state['progress']).upper()
+        assert 'JANE' not in joined
+        assert 'DOE' not in joined
+        assert 'name 1 of 2' in " ".join(state['progress'])
+
+    def test_a_name_iowa_courts_will_not_answer_does_not_end_the_list(self, client):
+        FakeClient.fail_searches = (1,)  # the first name, not the second
+        search_job_id, state = run_batch(client, "Doe, Jane\nRoe, John")
+        assert state['status'] == 'done'
+        entries = jobs.get(search_job_id).result['clients']
+        assert entries[0]['error']
+        assert entries[1]['keys']  # the rest of the clinic is still in the room
+
+    def test_a_client_with_no_cases_says_so_rather_than_showing_blank(self, client):
+        search_job_id, _ = run_batch(client, "Nobody, Sam")
+        page = client.get('/roster/' + search_job_id).get_data(as_text=True)
+        assert 'no cases under that name' in page
+
+    def test_an_unreadable_line_is_reported_on_the_roster_page(self, client):
+        search_job_id, _ = run_batch(client, "Client Name\nDoe, Jane")
+        page = client.get('/roster/' + search_job_id).get_data(as_text=True)
+        assert 'not searched' in page
+        assert 'Client Name' in page
+
+    def test_an_empty_list_is_refused_before_anyone_signs_in(self, client):
+        _, response = run_batch(client, "\n\n")
+        assert response.status_code == 200
+        assert 'no names in that list' in response.get_data(as_text=True)
+        assert FakeClient.instances == []
+
+    def test_a_list_longer_than_the_cap_is_refused_with_the_number(self, client):
+        long_list = "\n".join("Doe%d, Jane" % n for n in range(50))
+        _, response = run_batch(client, long_list)
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        assert '50 names' in body
+        assert 'Split the list' in body
+        assert FakeClient.instances == []
+
+    def test_a_non_legal_aid_user_id_is_refused(self, client):
+        _, response = run_batch(client, username='someoneelse')
+        assert 'not an Iowa Legal Aid' in response.get_data(as_text=True)
+        assert FakeClient.instances == []
+
+    def test_a_failed_search_leaves_no_session_holding_the_account(self, client):
+        FakeClient.search_error = RuntimeError("boom")
+        _, state = run_batch(client)
+        # Every name failed, so the run gave up, and the shared account has to
+        # come back either way.
+        assert FakeClient.instances[0].logged_off is True
+
+
+class TestBuildingTheWorkbooks:
+    def test_every_picked_client_gets_a_workbook(self, client):
+        job_id, state = build_a_list(client)
+        assert state['status'] == 'done'
+        assert state['next_url'] == '/batch-done/%s' % job_id
+        built = jobs.get(job_id).result['clients']
+        assert [record['name'] for record in built] == ['DOE, JANE', 'ROE, JOHN']
+        assert [record['written'] for record in built] == [2, 1]
+
+    def test_the_cases_pulled_are_that_client_s_own(self, client):
+        build_a_list(client)
+        assert FakeClient.instances[0].cases == [
+            '00000 FECR000000', '00000 SRCR000000', '00000 SMCR000000']
+
+    def test_the_bar_counts_cases_across_the_whole_list(self, client):
+        _, state = build_a_list(client)
+        assert state['total'] == 3
+        # The third case belongs to the second client; without the running
+        # offset the bar would slide back to 1 of 3 when that client started.
+        assert any('Pulling case 3 of 3' in line for line in state['progress'])
+
+    def test_one_client_failing_costs_only_that_client(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        FakeClient.instances[0].fail_cases = ['00000 SMCR000000']
+        response = pick_all(client, search_job_id)
+        state = await_job(client, response.get_json()['job_id'])
+
+        assert state['status'] == 'done'
+        built = jobs.get(response.get_json()['job_id']).result['clients']
+        assert built[0]['written'] == 2       # the clinic still gets this one
+        assert built[1]['file'] is None
+        assert built[1]['error']
+
+    def test_a_case_that_would_not_come_off_is_named_on_the_finish_page(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        FakeClient.instances[0].fail_cases = ['00000 SRCR000000']
+        response = pick_all(client, search_job_id)
+        job_id = response.get_json()['job_id']
+        await_job(client, job_id)
+
+        page = client.get('/batch-done/' + job_id).get_data(as_text=True)
+        assert '00000 SRCR000000' in page
+        assert '1 of 2 cases' in page
+
+    def test_a_client_left_unticked_is_skipped(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        entry = jobs.get(search_job_id).result['clients'][0]
+        response = client.post('/batch-crs', json={
+            'search_job_id': search_job_id,
+            'picks': [{'client': 0, 'keys': entry['keys']}]})
+        job_id = response.get_json()['job_id']
+        await_job(client, job_id)
+        assert len(jobs.get(job_id).result['clients']) == 1
+
+    def test_the_run_always_releases_the_shared_account(self, client):
+        build_a_list(client)
+        assert FakeClient.instances[0].logged_off is True
+
+    def test_a_list_where_nothing_could_be_built_fails_plainly(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        FakeClient.instances[0].fail_cases = [
+            '00000 FECR000000', '00000 SRCR000000', '00000 SMCR000000']
+        response = pick_all(client, search_job_id)
+        state = await_job(client, response.get_json()['job_id'])
+        assert state['status'] == 'failed'
+
+
+class TestPickingIsChecked:
+    def test_a_defendant_nobody_picked_off_the_page_is_ignored(self, client):
+        """The browser sends the keys. A key the search never returned would put
+        a stranger's convictions in a client's workbook."""
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        response = client.post('/batch-crs', json={
+            'search_job_id': search_job_id,
+            'picks': [{'client': 0, 'keys': ['1900-01-01 SOMEONE, ELSE']}]})
+        assert response.status_code == 400
+
+    def test_a_client_index_off_the_end_is_refused(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        response = client.post('/batch-crs', json={
+            'search_job_id': search_job_id,
+            'picks': [{'client': 99, 'keys': ['x']}]})
+        assert response.status_code == 400
+
+    def test_nothing_ticked_is_refused(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        response = client.post('/batch-crs', json={
+            'search_job_id': search_job_id, 'picks': []})
+        assert response.status_code == 400
+
+    def test_another_browser_cannot_start_a_run_off_this_list(self, client):
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        other = app_module.app.test_client()
+        assert other.post('/batch-crs', json={
+            'search_job_id': search_job_id, 'picks': []}).status_code == 410
+
+    def test_another_browser_cannot_read_the_roster_page(self, client):
+        search_job_id, _ = run_batch(client)
+        other = app_module.app.test_client()
+        page = other.get('/roster/' + search_job_id).get_data(as_text=True)
+        assert 'DOE, JANE' not in page
+
+
+class TestCollectingTheFiles:
+    def test_the_zip_holds_one_workbook_per_client(self, client):
+        job_id, _ = build_a_list(client)
+        response = client.get('/batch/%s/download' % job_id)
+        assert response.status_code == 200
+
+        path = jobs.get(job_id).result['file']
+        with zipfile.ZipFile(path) as bundle:
+            entries = bundle.namelist()
+        assert len(entries) == 2
+        # Numbered, because two clients on one clinic list can share a name and
+        # a zip that quietly holds one of them is how the wrong person ends up
+        # sitting there.
+        assert entries[0].startswith('01_')
+        assert entries[1].startswith('02_')
+        assert 'DOE' in entries[0]
+
+    def test_one_client_can_be_downloaded_on_their_own(self, client):
+        job_id, _ = build_a_list(client)
+        response = client.get('/batch/%s/download/1' % job_id)
+        assert response.status_code == 200
+        assert 'ROE' in response.headers['Content-Disposition']
+
+    def test_taking_one_file_does_not_end_the_errand(self, client):
+        """The list is the errand. A staffer who grabs one client and closes the
+        tab should still be chased about the other nineteen."""
+        job_id, _ = build_a_list(client)
+        client.get('/batch/%s/download/0' % job_id)
+        assert jobs.get(job_id).collected is False
+        assert 'workbook waiting' in client.get('/').get_data(as_text=True)
+
+    def test_taking_the_zip_ends_it(self, client):
+        job_id, _ = build_a_list(client)
+        client.get('/batch/%s/download' % job_id)
+        assert jobs.get(job_id).collected is True
+        assert 'workbook waiting' not in client.get('/').get_data(as_text=True)
+
+    def test_an_uncollected_clinic_list_is_alerted_on_like_any_workbook(self, client):
+        job_id, _ = build_a_list(client)
+        job = jobs.get(job_id)
+        job.updated_at -= jobs.UNCOLLECTED_AFTER + 1
+        assert jobs._uncollected_pass() == 1
+
+    def test_the_start_page_offers_the_list_back(self, client):
+        job_id, _ = build_a_list(client)
+        page = client.get('/').get_data(as_text=True)
+        assert '/batch-done/%s' % job_id in page
+
+    def test_a_download_path_outside_tmp_is_refused(self, client):
+        job_id, _ = build_a_list(client)
+        jobs.get(job_id).result['file'] = '/etc/passwd'
+        body = client.get('/batch/%s/download' % job_id).get_data(as_text=True)
+        assert 'invalid file' in body
+
+    def test_a_client_download_path_outside_tmp_is_refused(self, client):
+        job_id, _ = build_a_list(client)
+        jobs.get(job_id).result['clients'][0]['file'] = '/etc/passwd'
+        body = client.get('/batch/%s/download/0' % job_id).get_data(as_text=True)
+        assert 'invalid file' in body
+
+    def test_another_browser_cannot_take_the_files(self, client):
+        job_id, _ = build_a_list(client)
+        other = app_module.app.test_client()
+        assert other.get('/batch/%s/download' % job_id).status_code == 200
+        assert 'Napier restarted' in other.get(
+            '/batch/%s/download' % job_id).get_data(as_text=True)
+
+
+class TestLite:
+    def test_the_lite_choice_applies_to_every_client(self, client):
+        search_job_id, _ = run_batch(client, lite=True)
+        response = pick_all(client, search_job_id)
+        job_id = response.get_json()['job_id']
+        await_job(client, job_id)
+        assert jobs.get(job_id).result['is_lite'] is True
+        with zipfile.ZipFile(jobs.get(job_id).result['file']) as bundle:
+            assert all('Lite' in name for name in bundle.namelist())
+
+
+class TestNamesStayOffTheBrowser:
+    def test_a_line_napier_could_not_read_is_not_kept_in_the_session(self, client):
+        """A rejected line can hold part of a client's name. The session cookie
+        is a store on a machine other people use, so it lives on the job."""
+        run_batch(client, ", Jane Q Public\nRoe, John")
+        with client.session_transaction() as browser_session:
+            held = " ".join(str(value) for value in browser_session.values())
+        assert held                      # there is a session, so this is a real look
+        assert 'Public' not in held
+
+    def test_it_still_reaches_the_page(self, client):
+        search_job_id, _ = run_batch(client, "Client Name\nDoe, Jane")
+        assert 'Client Name' in client.get(
+            '/roster/' + search_job_id).get_data(as_text=True)

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,238 @@
+"""The payment history Napier has been downloading and throwing away.
+
+Every case number here is 00000 FECR000000 and every date is in 1900, because
+the repository is public and a real Iowa case number plus a real payment date
+is a person.
+"""
+
+import os
+import sys
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from bs4 import BeautifulSoup
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+
+CLINIC = date(2026, 7, 31)
+
+
+def _row(detail, paid, when, receipt='000001', tender='CSH', amount='100.00'):
+    return {'detail': detail, 'amount': amount, 'paid': paid, 'paidDate': when,
+            'receipt': receipt, 'tender': tender}
+
+
+def _case(rows):
+    return {'id': '00000  FECR000000', 'financials': rows}
+
+
+class TestMoney:
+    def test_reads_a_plain_figure(self):
+        assert crs._money('45.10') == Decimal('45.10')
+
+    def test_strips_dollars_and_commas(self):
+        assert crs._money('$1,234.56') == Decimal('1234.56')
+
+    def test_blank_is_not_zero(self):
+        # A fee with nothing in the paid column has not been paid nothing, it
+        # has not been reported, and the two have to stay distinguishable.
+        assert crs._money('') is None
+        assert crs._money('   ') is None
+        assert crs._money(None) is None
+
+    def test_nonsense_is_none_rather_than_an_exception(self):
+        assert crs._money('see receipt') is None
+
+
+class TestPayments:
+    def test_reads_a_payment(self):
+        history = crs.payments(_case([_row('FINE', '25.00', '01/02/1900')]))
+        assert len(history) == 1
+        assert history[0]['amount'] == Decimal('25.00')
+        assert history[0]['date'] == date(1900, 1, 2)
+        assert history[0]['receipt'] == '000001'
+        assert history[0]['tender'] == 'CSH'
+
+    def test_a_fee_with_no_payment_is_not_a_payment(self):
+        assert crs.payments(_case([_row('FINE', '', '')])) == []
+
+    def test_a_zero_payment_is_not_a_payment(self):
+        assert crs.payments(_case([_row('FINE', '0.00', '01/02/1900')])) == []
+
+    def test_a_payment_with_no_date_is_dropped(self):
+        # Every use of a payment is a use of when it happened, so one without a
+        # date would only ever land in a total and skew the monthly figure.
+        assert crs.payments(_case([_row('FINE', '25.00', '')])) == []
+
+    def test_oldest_first_whatever_order_icos_listed_them(self):
+        history = crs.payments(_case([
+            _row('FINE', '3.00', '03/01/1900'),
+            _row('FINE', '1.00', '01/01/1900'),
+            _row('FINE', '2.00', '02/01/1900'),
+        ]))
+        assert [payment['amount'] for payment in history] == [
+            Decimal('1.00'), Decimal('2.00'), Decimal('3.00')]
+
+    def test_a_continuation_row_is_credited_to_the_fee_above_it(self):
+        # ICOS leaves the detail cell blank when a fee was paid in instalments.
+        history = crs.payments(_case([
+            _row('COURT COSTS', '5.00', '01/01/1900'),
+            _row('', '5.00', '02/01/1900'),
+        ]))
+        assert [payment['detail'] for payment in history] == [
+            'COURT COSTS', 'COURT COSTS']
+
+    def test_third_party_collection_fees_are_left_out(self):
+        # Same rule the fee columns use: ICOS lists them and does not count
+        # them, so a payment against one is not money paid on the case.
+        history = crs.payments(_case([
+            _row('THIRD PARTY COLLECTION FEE', '50.00', '01/01/1900'),
+            _row('FINE', '10.00', '02/01/1900'),
+        ]))
+        assert [payment['detail'] for payment in history] == ['FINE']
+
+    def test_a_continuation_of_an_excluded_fee_is_also_left_out(self):
+        history = crs.payments(_case([
+            _row('THIRD PARTY COLLECTION FEE', '50.00', '01/01/1900'),
+            _row('', '50.00', '02/01/1900'),
+        ]))
+        assert history == []
+
+
+class TestPaymentHistory:
+    def test_no_itemization_is_none_not_zero(self):
+        # A case ICOS publishes no itemization for cannot tell us the client
+        # never paid, and the sheet should not have to guess which it is.
+        assert crs.payment_history(_case([]), CLINIC) is None
+
+    def test_totals_and_dates(self):
+        history = crs.payment_history(_case([
+            _row('FINE', '10.00', '01/01/1900'),
+            _row('FINE', '30.00', '01/01/1901'),
+        ]), CLINIC)
+        assert history['count'] == 2
+        assert history['total'] == Decimal('40.00')
+        assert history['first'] == date(1900, 1, 1)
+        assert history['last'] == date(1901, 1, 1)
+
+    def test_monthly_is_over_the_paying_window_not_the_age_of_the_case(self):
+        # Twelve months of paying, thirteen payment months inclusive. A client
+        # who paid steadily and then stopped should read as somebody who paid
+        # what they paid, with the gap reported separately.
+        rows = [_row('FINE', '13.00', '%02d/01/1900' % month)
+                for month in range(1, 13)]
+        rows.append(_row('FINE', '13.00', '01/01/1901'))
+        history = crs.payment_history(_case(rows), CLINIC)
+        assert history['count'] == 13
+        assert history['total'] == Decimal('169.00')
+        assert history['monthly'] == Decimal('13.00')
+
+    def test_a_single_payment_does_not_divide_by_zero(self):
+        history = crs.payment_history(
+            _case([_row('FINE', '10.00', '01/01/1900')]), CLINIC)
+        assert history['monthly'] == Decimal('10.00')
+
+    def test_recent_counts_only_the_last_twelve_months(self):
+        history = crs.payment_history(_case([
+            _row('FINE', '100.00', '01/01/1900'),
+            _row('FINE', '60.00', '01/15/2026'),
+        ]), CLINIC)
+        assert history['total'] == Decimal('160.00')
+        assert history['recent'] == Decimal('60.00')
+        assert history['recent_monthly'] == Decimal('5.00')
+
+    def test_a_payment_older_than_the_window_is_not_recent(self):
+        history = crs.payment_history(
+            _case([_row('FINE', '100.00', '01/01/1900')]), CLINIC)
+        assert history['recent'] == Decimal('0')
+        assert history['recent_monthly'] == Decimal('0.00')
+
+    def test_months_since_last_payment(self):
+        history = crs.payment_history(
+            _case([_row('FINE', '5.00', '01/31/2026')]), CLINIC)
+        assert history['months_since_last'] == 6
+
+    def test_tenders_are_listed_once_each(self):
+        history = crs.payment_history(_case([
+            _row('FINE', '1.00', '01/01/1900', tender='CSH'),
+            _row('FINE', '1.00', '02/01/1900', tender='CHK'),
+            _row('FINE', '1.00', '03/01/1900', tender='CSH'),
+        ]), CLINIC)
+        assert history['tenders'] == ['CHK', 'CSH']
+
+
+class TestMonthsBetween:
+    def test_same_day_is_zero(self):
+        assert crs._months_between(date(1900, 1, 1), date(1900, 1, 1)) == 0
+
+    def test_a_day_short_of_a_month_does_not_count(self):
+        assert crs._months_between(date(1900, 1, 15), date(1900, 2, 14)) == 0
+
+    def test_the_day_it_lands_counts(self):
+        assert crs._months_between(date(1900, 1, 15), date(1900, 2, 15)) == 1
+
+    def test_across_a_year(self):
+        assert crs._months_between(date(1900, 6, 1), date(1901, 6, 1)) == 12
+
+    def test_backwards_is_zero_rather_than_negative(self):
+        assert crs._months_between(date(1901, 1, 1), date(1900, 1, 1)) == 0
+
+
+HEADER_ROW = ('<tr><td>&nbsp;</td><td>Detail</td><td>Payor</td><td>Obligor</td>'
+              '<td>Original</td><td>Paid</td><td>Date</td><td>Receipt</td>'
+              '<td>Type</td></tr>')
+PAID_ROW = ('<tr><td>&nbsp;</td><td>FINE</td><td>SYNTHETIC PAYOR</td>'
+            '<td>SYNTHETIC OBLIGOR</td><td>100.00</td><td>25.00</td>'
+            '<td>01/02/1900</td><td>\n  000123\t</td><td>CHK</td></tr>')
+SHORT_ROW = ('<tr><td>&nbsp;</td><td>FINE</td><td>SYNTHETIC PAYOR</td>'
+             '<td>SYNTHETIC OBLIGOR</td><td>100.00</td><td>25.00</td>'
+             '<td>01/02/1900</td></tr>')
+
+
+def _page(*rows):
+    return ('<html><body><form><table>%s</table></form></body></html>'
+            % ''.join((HEADER_ROW,) + rows)).encode('utf-8')
+
+
+class TestParser:
+    def test_the_receipt_and_tender_come_off_the_page(self):
+        case = {'id': '00000  FECR000000'}
+        case_parser.parse_case_financials(_page(PAID_ROW), case)
+        row = case['financials'][-1]
+        assert row['detail'] == 'FINE'
+        assert row['paid'] == '25.00'
+        # ICOS wraps this one in whitespace on the real page.
+        assert row['receipt'] == '000123'
+        assert row['tender'] == 'CHK'
+
+    def test_the_header_row_is_not_a_payment(self):
+        case = {'id': '00000  FECR000000'}
+        case_parser.parse_case_financials(_page(PAID_ROW), case)
+        assert len(case['financials']) == 1
+
+    @pytest.mark.parametrize('column', ['receipt', 'tender'])
+    def test_a_short_row_costs_the_column_not_the_run(self, column):
+        # ICOS has published narrower detail tables before now, and a missing
+        # column should cost the receipt number rather than the whole case.
+        case = {'id': '00000  FECR000000'}
+        case_parser.parse_case_financials(_page(SHORT_ROW), case)
+        assert case['financials'][-1][column] is None
+        assert case['financials'][-1]['paid'] == '25.00'
+
+
+class TestCellText:
+    def _cell(self, html):
+        return BeautifulSoup(html, 'html.parser').find('td')
+
+    def test_padding_is_taken_out(self):
+        assert case_parser._text(self._cell('<td>\n  a\tb  </td>')) == 'a b'
+
+    def test_an_empty_cell_is_none_rather_than_blank(self):
+        assert case_parser._text(self._cell('<td>&nbsp; </td>')) is None
+
+    def test_a_missing_cell_is_none(self):
+        assert case_parser._text(None) is None

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,118 @@
+"""Reading a clinic list off whatever staff paste in.
+
+The names here are invented. The shapes they are in are not: a paste out of a
+spreadsheet brings its heading row and its date of birth column with it, and a
+list assembled from two sources has the same client on it twice.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import roster
+
+
+def names(text):
+    people, _ = roster.parse(text)
+    return [roster.describe(person) for person in people]
+
+
+class TestSplitName:
+    def test_comma_form(self):
+        assert roster.split_name("Doe, Jane") == ('Jane', '', 'Doe')
+
+    def test_comma_form_with_a_middle_name(self):
+        assert roster.split_name("Doe, Jane Marie") == ('Jane', 'Marie', 'Doe')
+
+    def test_a_two_word_surname_survives_the_comma_form(self):
+        # The only form that can carry one without guessing, which is why the
+        # placeholder on the page asks for it.
+        assert roster.split_name("Van Dyke, Jane") == ('Jane', '', 'Van Dyke')
+
+    def test_space_form(self):
+        assert roster.split_name("Jane Doe") == ('Jane', '', 'Doe')
+
+    def test_space_form_middle_is_everything_between(self):
+        assert roster.split_name("Jane Marie Ann Doe") == (
+            'Jane', 'Marie Ann', 'Doe')
+
+    def test_a_surname_on_its_own_is_a_surname(self):
+        # Iowa Courts will answer a surname-only search, and the roster page is
+        # where somebody picks their client out of the answer.
+        assert roster.split_name("Doe") == ('', '', 'Doe')
+
+    def test_a_third_comma_column_is_not_part_of_the_given_names(self):
+        assert roster.split_name("Doe, Jane, 01/01/1900") == ('Jane', '', 'Doe')
+
+
+class TestParse:
+    def test_a_plain_list(self):
+        assert names("Doe, Jane\nRoe, John") == ['Jane Doe', 'John Roe']
+
+    def test_blank_lines_are_not_clients(self):
+        assert names("\n\nDoe, Jane\n\n\n") == ['Jane Doe']
+
+    def test_both_forms_on_one_list(self):
+        assert names("Doe, Jane\nJohn Roe") == ['Jane Doe', 'John Roe']
+
+    def test_a_tab_separated_paste_keeps_only_the_name(self):
+        assert names("Doe, Jane\t01/01/1900\t10:30 AM") == ['Jane Doe']
+
+    def test_a_pipe_or_semicolon_column_goes_the_same_way(self):
+        assert names("Doe, Jane | 01/01/1900\nRoe, John; 2pm") == [
+            'Jane Doe', 'John Roe']
+
+    def test_padding_is_squashed(self):
+        assert names("   Doe,    Jane   Marie  ") == ['Jane Marie Doe']
+
+    def test_the_same_client_twice_is_searched_once(self):
+        # A list assembled from two sources has duplicates, and searching one
+        # twice costs a minute of a shared Iowa Courts account for an answer we
+        # already have.
+        assert names("Doe, Jane\nDoe, Jane") == ['Jane Doe']
+
+    def test_the_duplicate_check_ignores_case(self):
+        assert names("Doe, Jane\nDOE, JANE") == ['Jane Doe']
+
+    def test_two_clients_who_differ_by_a_middle_name_are_two_clients(self):
+        assert names("Doe, Jane\nDoe, Jane Marie") == ['Jane Doe',
+                                                       'Jane Marie Doe']
+
+    def test_order_is_the_order_it_was_pasted(self):
+        assert names("Roe, John\nDoe, Jane\nPoe, Alex") == [
+            'John Roe', 'Jane Doe', 'Alex Poe']
+
+
+class TestRejected:
+    def _rejected(self, text):
+        _, rejected = roster.parse(text)
+        return rejected
+
+    def test_a_heading_row_is_reported_not_searched(self):
+        people, rejected = roster.parse("Client Name\tDOB\nDoe, Jane")
+        assert [roster.describe(person) for person in people] == ['Jane Doe']
+        assert rejected == ['Client Name\tDOB']
+
+    def test_the_other_headings_a_paste_brings_along(self):
+        for heading in ("Name", "First Last", "Last, First", "Defendant",
+                        "Participant:", "client"):
+            assert self._rejected(heading) == [heading], heading
+
+    def test_a_line_with_no_name_in_it_is_reported(self):
+        assert self._rejected(", 01/01/1900") == [', 01/01/1900']
+
+    def test_a_rejected_line_does_not_end_the_list(self):
+        # Twenty clients pasted, one unreadable line, nineteen still get seen
+        # that day.
+        assert names("Client Name\nDoe, Jane\n, \nRoe, John") == [
+            'Jane Doe', 'John Roe']
+
+    def test_nothing_readable_is_no_people_and_no_exception(self):
+        people, rejected = roster.parse("Name\nDOB")
+        assert people == []
+        assert rejected == ['Name', 'DOB']
+
+    def test_an_empty_paste(self):
+        assert roster.parse('') == ([], [])
+        assert roster.parse(None) == ([], [])

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -1,0 +1,309 @@
+"""Column I, and the ICOS table Napier downloaded for years and never opened.
+
+CASE DATA column I is "Under supervison?" [sic]. The expungement sheet reads it
+to decide whether to fill in "Amount of debt subject to 910.7?", and reads a
+blank as no, so that column has been "n/a" on every row of every workbook Napier
+has ever produced.
+
+The answer was on a page Napier already fetches. Under each count the charges
+page carries a sentence table: the sentence type, the date it was imposed and
+how long it runs. Across 180 real captures it appears on every case that carries
+a conviction. case_parser marked the section boundary and read nothing out of it.
+
+What Napier can say from that is narrow, and these tests pin the narrowness as
+hard as they pin the answer. A term that ends after the clinic date is a YES. No
+term, an expired term, or a term with no end date is left blank rather than
+called a NO, because ICOS does not record an early discharge, records extensions
+inconsistently, and never carries parole at all.
+"""
+
+import os
+import sys
+from datetime import date
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+
+
+def _sentence(kind, day, duration):
+    return {'type': kind, 'date': day, 'duration': duration}
+
+
+# -- the term arithmetic ----------------------------------------------------
+
+def test_a_year_term_is_a_calendar_year_not_365_days():
+    """A leap year in the middle of the term is the case that separates them."""
+    assert crs._add_term(date(2024, 1, 15), 1, 'Year') == date(2025, 1, 15)
+
+
+def test_a_five_year_term_lands_on_the_same_day_five_years_later():
+    assert crs._add_term(date(2001, 7, 2), 5, 'Year') == date(2006, 7, 2)
+
+
+def test_a_term_starting_on_a_leap_day_falls_back_to_the_28th():
+    assert crs._add_term(date(2024, 2, 29), 1, 'Year') == date(2025, 2, 28)
+
+
+def test_a_term_starting_on_the_31st_falls_back_to_a_short_month():
+    assert crs._add_term(date(2026, 1, 31), 1, 'Month') == date(2026, 2, 28)
+
+
+def test_day_terms_are_counted_in_days():
+    assert crs._add_term(date(1995, 3, 31), 365, 'Day') == date(1996, 3, 30)
+
+
+def test_week_terms_are_counted_in_weeks():
+    assert crs._add_term(date(2026, 1, 1), 2, 'Week') == date(2026, 1, 15)
+
+
+# -- reading a date the way ICOS writes it ----------------------------------
+
+@pytest.mark.parametrize('text', ['07/02/2001', ' 07/02/2001 '])
+def test_an_icos_date_is_read(text):
+    assert crs.parse_us_date(text) == date(2001, 7, 2)
+
+
+@pytest.mark.parametrize('text', ['', None, 'n/a', '2001-07-02', '13/45/2001'])
+def test_anything_else_is_not_guessed_at(text):
+    assert crs.parse_us_date(text) is None
+
+
+# -- which sentences count --------------------------------------------------
+
+def test_probation_still_running_is_a_yes():
+    answer, term = crs.is_under_supervision(
+        [_sentence('PROBATION', '01/01/2025', '3 Year(s)')], CLINIC)
+    assert answer == "YES"
+    assert term[3] == date(2028, 1, 1)
+
+
+def test_probation_that_has_run_out_is_left_blank():
+    answer, _ = crs.is_under_supervision(
+        [_sentence('PROBATION', '01/01/1995', '2 Year(s)')], CLINIC)
+    assert answer is None
+
+
+def test_a_term_ending_on_the_clinic_date_still_counts():
+    """The last day of a term is a day under supervision."""
+    answer, _ = crs.is_under_supervision(
+        [_sentence('PROBATION', '07/31/2024', '2 Year(s)')], CLINIC)
+    assert answer == "YES"
+
+
+def test_prison_is_not_supervision():
+    """Somebody in custody is not what the 910.7 column is asking about, and
+    the day they get out is not on this page."""
+    answer, _ = crs.is_under_supervision(
+        [_sentence('PRISON', '01/01/2025', '5 Year(s)')], CLINIC)
+    assert answer is None
+
+
+@pytest.mark.parametrize('kind', ['FINE', 'JAIL', 'DISMISSED', 'TIME SERVED',
+                                  'SUSPENDED PRISON', 'COMMUNITY SERVICE'])
+def test_the_other_real_sentence_types_are_not_supervision(kind):
+    answer, _ = crs.is_under_supervision(
+        [_sentence(kind, '01/01/2025', '5 Year(s)')], CLINIC)
+    assert answer is None
+
+
+@pytest.mark.parametrize('kind', ['PROBATION', 'DRUG COURT',
+                                  'RESIDENTIAL FACILITY'])
+def test_every_community_supervision_type_counts(kind):
+    answer, _ = crs.is_under_supervision(
+        [_sentence(kind, '01/01/2025', '3 Year(s)')], CLINIC)
+    assert answer == "YES"
+
+
+def test_the_longest_running_term_is_the_one_reported():
+    """ICOS repeats a term under every count, and revocation adds another."""
+    answer, term = crs.is_under_supervision([
+        _sentence('PROBATION', '01/01/2024', '1 Year(s)'),
+        _sentence('PROBATION', '01/01/2025', '5 Year(s)'),
+        _sentence('PROBATION', '01/01/2024', '2 Year(s)'),
+    ], CLINIC)
+    assert answer == "YES"
+    assert term[3] == date(2030, 1, 1)
+
+
+def test_an_expired_term_does_not_hide_a_running_one():
+    answer, _ = crs.is_under_supervision([
+        _sentence('PROBATION', '01/01/1995', '1 Year(s)'),
+        _sentence('PROBATION', '01/01/2025', '5 Year(s)'),
+    ], CLINIC)
+    assert answer == "YES"
+
+
+# -- and where it refuses to answer -----------------------------------------
+
+@pytest.mark.parametrize('sentences', [None, [], [_sentence('FINE', '', '')]])
+def test_nothing_to_go_on_is_left_blank(sentences):
+    assert crs.is_under_supervision(sentences, CLINIC) == (None, None)
+
+
+def test_a_term_with_no_duration_is_left_blank():
+    """An open-ended row has no end date, so it cannot answer the question."""
+    answer, _ = crs.is_under_supervision(
+        [_sentence('PROBATION', '01/01/2025', '')], CLINIC)
+    assert answer is None
+
+
+def test_a_term_with_no_date_is_left_blank():
+    answer, _ = crs.is_under_supervision(
+        [_sentence('PROBATION', '', '3 Year(s)')], CLINIC)
+    assert answer is None
+
+
+def test_no_is_never_written():
+    """The whole point of leaving it blank. A NO would assert that nobody is on
+    parole and no term was extended, neither of which ICOS can tell Napier."""
+    for sentences in ([], [_sentence('PROBATION', '01/01/1990', '1 Year(s)')],
+                      [_sentence('PRISON', '01/01/2025', '5 Year(s)')]):
+        assert crs.is_under_supervision(sentences, CLINIC)[0] != "NO"
+
+
+# -- the parser -------------------------------------------------------------
+
+CHARGES_PAGE = b"""
+<html><body><table>
+<tr><td><font>Sentence</font></td><td><font>Sentence Date</font></td>
+<td><font>Duration</font></td><td><font>Fine</font></td>
+<td><font>Appeal</font></td><td><font>Judge</font></td>
+<td><font>Facility Type</font></td><td><font>Attorney</font></td>
+<td><font>Restitution</font></td><td><font>Drug</font></td>
+<td><font>Extradition</font></td><td><font>Lic. Revoked</font></td>
+<td><font>DDS</font></td><td><font>Batterer</font></td></tr>
+<tr><td><font>PROBATION</font></td><td><font>07/02/2001</font></td>
+<td><font>5 Year(s)</font></td><td><font></font></td>
+<td><font></font></td><td><font>SYNTHETIC, JUDGE</font></td>
+<td><font></font></td><td><font>N</font></td>
+<td><font>N</font></td><td><font>N</font></td>
+<td><font>N</font></td><td><font>N</font></td>
+<td><font>N</font></td><td><font></font></td></tr>
+</table></body></html>
+"""
+
+
+def test_the_sentence_row_is_read_off_the_page():
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(CHARGES_PAGE, case)
+    assert case['sentences'] == [
+        {'type': 'PROBATION', 'date': '07/02/2001', 'duration': '5 Year(s)'}]
+
+
+def test_the_header_row_is_not_mistaken_for_a_sentence():
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(CHARGES_PAGE, case)
+    assert all(s['type'] != 'Sentence' for s in case['sentences'])
+
+
+def test_a_page_with_no_sentence_table_yields_none():
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(
+        b"<html><body><table><tr><td><font>Nothing here</font></td></tr>"
+        b"</table></body></html>", case)
+    assert case['sentences'] == []
+
+
+def test_a_renamed_column_stops_the_read_rather_than_shifting_it():
+    """The header is matched exactly so that a changed page reads as no data.
+
+    Reading the wrong cell as a date is the failure worth designing against:
+    it would put a confident YES in column I off a number that is not a term.
+    """
+    page = CHARGES_PAGE.replace(b'Lic. Revoked', b'License Revoked')
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(page, case)
+    assert case['sentences'] == []
+
+
+# -- end to end into the workbook -------------------------------------------
+
+def _case(sentences, disposition='GUILTY'):
+    return {
+        'id': '00000  FECR000000', 'county': 'SYNTHETIC',
+        'charges': [{'charge': '124.401', 'description': 'SYNTHETIC OFFENSE',
+                     'disposition': [disposition], 'offenseDate': '01/01/1900',
+                     'dispositionDate': '02/02/1901'}],
+        'financials': [], 'summary_categories': [],
+        'sentences': sentences,
+    }
+
+
+def _row(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    crs.process_case(case, sheet, crs.FIRST_CASE_ROW, CLINIC)
+    row = str(crs.FIRST_CASE_ROW)
+    return sheet['I' + row].value, sheet['V' + row].value
+
+
+def test_a_running_term_reaches_column_i():
+    value, _ = _row(_case([_sentence('PROBATION', '01/01/2025', '3 Year(s)')]))
+    assert value == "YES"
+
+
+def test_an_expired_term_leaves_column_i_alone():
+    value, _ = _row(_case([_sentence('PROBATION', '01/01/1995', '1 Year(s)')]))
+    assert value is None
+
+
+def test_the_row_says_what_the_yes_rests_on():
+    """A YES that staff cannot audit is worse than a blank, because this one
+    feeds a dollar figure on the expungement sheet."""
+    _, note = _row(_case([_sentence('PROBATION', '01/01/2025', '3 Year(s)')]))
+    assert 'probation' in note
+    assert '3 Year(s)' in note
+    assert '01/01/2025' in note
+    assert '01/01/2028' in note
+
+
+def test_the_note_admits_what_napier_cannot_see():
+    _, note = _row(_case([_sentence('PROBATION', '01/01/2025', '3 Year(s)')]))
+    assert 'parole' in note
+
+
+def test_the_supervision_note_does_not_displace_the_money_note():
+    _, money_only = _row(_case([]))
+    _, both = _row(_case([_sentence('PROBATION', '01/01/2025', '3 Year(s)')]))
+    assert money_only, 'this case is supposed to carry a fee note'
+    assert money_only in both
+
+
+def test_a_case_with_no_sentences_writes_nothing_in_column_i():
+    """Today's behaviour, which must survive: a blank reads as n/a and that is
+    the honest answer when Napier has nothing."""
+    value, _ = _row(_case([]))
+    assert value is None
+
+
+def test_the_clinic_date_decides_not_today():
+    """Reopening a workbook next year must not change what column I said."""
+    case = _case([_sentence('PROBATION', '01/01/2025', '3 Year(s)')])
+    sheet = load_workbook(FULL)['CASE DATA']
+    crs.process_case(case, sheet, crs.FIRST_CASE_ROW, date(2040, 1, 1))
+    assert sheet['I' + str(crs.FIRST_CASE_ROW)].value is None
+
+
+def test_a_civil_case_can_still_report_supervision():
+    """The sentence table is read whatever get_dominant_charge made of the
+    adjudications, so the write is outside that branch."""
+    case = {
+        'id': '00000  SCSC000000', 'county': 'SYNTHETIC',
+        'charges': [], 'financials': [], 'summary_categories': [],
+        'summary_created_date': '01/01/1900',
+        'summary_disposition_date': '02/02/1901',
+        'summary_dispo_status': 'SYNTHETIC STATUS',
+        'sentences': [_sentence('PROBATION', '01/01/2025', '3 Year(s)')],
+    }
+    value, note = _row(case)
+    assert value == "YES"
+    assert 'probation' in note


### PR DESCRIPTION
Four things, all beyond the contract scope, all aimed at the same thing: making the workbook worth more than the hour it takes to get one.

## Read the sentence table Napier was downloading and discarding

ICOS publishes the sentence on every case and Napier parsed past it. It now fills column I ("Under supervison?"), which the SOL and expungement sheets both read, plus the sentence dates behind it. That column was hand-filled or left blank before, and blank reads as "not on supervision" to every formula downstream.

## Read the payment record

Same story. The financials page carries every receipt and Napier kept only the totals. There's a PAYMENTS sheet now: every payment ICOS records, newest first, with the receipt number to look it up by, and a measured monthly average.

"Have you been paying anything?" is the question that decides an ability-to-pay hearing, and until now the answer was whatever the client remembered.

## One page to work from

A ranked action list per client, each item naming the statute it comes from. Seven tiers. The clinic gets a page instead of nine sheets to cross-reference.

## Clinic batch mode

Iowa Courts allows one session per account and Iowa Legal Aid shares a handful. A twenty-client clinic was twenty sign ins competing for the same account. Now it's one: paste the list, Napier searches every name, staff tick which defendant is their client, and the workbooks come back as a zip.

Staff do the picking on purpose. Matching names automatically would eventually put a stranger's convictions in a client's file, which is the one failure this tool can't make.

## Notes for review

- No client name reaches the progress log, because `alerts.recent_progress` quotes it into alert email and those names are privileged. Positions in the list are not.
- Roster lines Napier couldn't read ride on the job, not the session cookie. They can hold part of a name and the cookie is a store on a shared machine. That test was checked against a deliberate regression, since a Flask cookie is base64 and a naive look at it passes anything.
- The case pull is one function now instead of two copies, so a case Iowa Courts won't give up costs the same on both paths.
- Every fixture is synthetic. Case numbers are `00000 FECR000000`-shaped and dates are in 1900, because this repo is public.

495 tests pass, up from 321 at the branch point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t