### PR TITLE
Pull each client's cases from their own search, and let staff stop a run

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,6 +181,16 @@ def index():
 @app.route('/logout')
 def logout():
     icos_sessions.close(session.pop('icos_token', None))
+    # Starting over has to stop what is running, or the old run keeps the
+    # shared ESA account while the new one queues behind it. This used to drop
+    # the browser's claim on the job and leave the work going, which is the
+    # worst of both: nobody watching and nobody able to collect the result.
+    # The session token is not enough, because a running CRS job has claimed
+    # its session out of the store and owns the logoff itself.
+    for job_id in session.get('job_ids', []):
+        job = jobs.get(job_id)
+        if job is not None and job.status in (jobs.QUEUED, jobs.RUNNING):
+            job.cancel()
     session.pop('job_ids', None)
     return redirect(url_for('index'))
 
@@ -282,8 +292,11 @@ def batch_crs():
             case_ids.extend(entry['cases'].get(key, []))
         # The defendant key is "YYYY-MM-DD NAME", the way the search grouped it.
         def_dob, _, def_name = keys[0].partition(" ")
+        # The search terms come off the search job, never off the browser: the
+        # run repeats this search on ICOS, and a name posted here instead would
+        # be somebody the staffer never saw on the roster page.
         picks.append({'def_name': def_name, 'def_dob': def_dob,
-                      'case_ids': case_ids})
+                      'case_ids': case_ids, 'person': entry.get('person')})
 
     if not picks:
         return jsonify({"error": "Pick a match for at least one client."}), 400
@@ -374,6 +387,25 @@ def job_status(job_id):
                         "error": RESTARTED_MESSAGE,
                         "message": RESTARTED_MESSAGE, "progress": []}), 410
     return jsonify(job.to_dict())
+
+
+@app.route('/job/<job_id>/cancel', methods=['POST'])
+def cancel_job(job_id):
+    """Stop a run a staffer has given up on.
+
+    POST rather than a link because a link gets followed by things that are not
+    the staffer, and the run this ends is holding an ESA account.
+
+    Nothing is killed. The work is asked to stop and stops at its next check,
+    which is what lets it log the session off on the way out. That is the part
+    that matters: the account Iowa Legal Aid shares is locked for a quarter of
+    an hour by a session nobody released.
+    """
+    job = own_job(job_id)
+    if job is None:
+        return jsonify({"error": RESTARTED_MESSAGE}), 410
+    job.cancel()
+    return jsonify({"cancelled": True})
 
 
 @app.route('/job/<job_id>/lost', methods=['POST'])

--- a/icos.py
+++ b/icos.py
@@ -114,6 +114,13 @@ def _timeline(waits):
     return "+".join(str(w) for w in waits) + "s"
 
 
+# Said in one place because the run can stop in three, and a staffer who stops
+# a run wants to know the shared account is free, not that something failed.
+STOPPED_MESSAGE = ("Stopped at your request. Iowa Courts Online has been signed "
+                   "out, so the account is free for the next search straight "
+                   "away.")
+
+
 class IcosError(Exception):
     """Base for failures we surface to staff with a plain-language message."""
 
@@ -134,6 +141,14 @@ class IcosUnavailable(IcosError):
     pass
 
 
+class IcosStopped(IcosError):
+    """A staffer asked for the run to stop and it did.
+
+    Not a failure of anything, but it travels the same way as one so the run
+    unwinds through the same finally that logs the ESA session off.
+    """
+
+
 class IcosClient:
     def __init__(self, log=None, reader=None, budget_seconds=None,
                  concurrent_budget_seconds=None, sleep=time.sleep,
@@ -144,6 +159,10 @@ class IcosClient:
         # testable without a mail path, and so alerts describe the
         # classification below rather than a raw exception.
         self._alert = alert or (lambda failure, **fields: None)
+        # Asked between attempts. A stalled case is waited out for four minutes
+        # and a stalled search for forty-five, which is far too long to make
+        # somebody sit through once they have decided to stop.
+        self._should_stop = lambda: False
         self._sleep = sleep
         self._monotonic = monotonic
         self.budget = budget_seconds if budget_seconds is not None \
@@ -169,6 +188,22 @@ class IcosClient:
         produced the results list.
         """
         self._alert = alert or (lambda failure, **fields: None)
+
+    def set_log(self, log):
+        """Point the progress log at a different job, for the same reason.
+
+        Missing this is worse than missing set_alert, because it is the only
+        thing the person waiting can see. A staffer watching a CRS run whose
+        first case ICOS would not give up sat on "Pulling case 1 of 67" for
+        four minutes with nothing under it: the retry notices that say Iowa
+        Courts is being retried were being written into the search job, which
+        no page is showing by then. It read as a hang, and it was a wait.
+        """
+        self._log = log or (lambda message: None)
+
+    def set_stop_check(self, should_stop):
+        """Give the retry loop a way to be told to give up waiting."""
+        self._should_stop = should_stop or (lambda: False)
 
     # -- retry core --------------------------------------------------------
 
@@ -242,6 +277,10 @@ class IcosClient:
                 raise IcosUnavailable(
                     "Iowa Courts Online did not return this case after %d minutes of "
                     "retrying (last result: %s)." % (round(budget / 60), last))
+            # Checked here rather than only between cases, because the whole
+            # reason somebody reaches for stop is that a wait is in progress.
+            if self._should_stop():
+                raise IcosStopped(STOPPED_MESSAGE)
             self._log(self._attempt_message(what, attempt, elapsed))
             waits.append(wait)
             self._sleep(wait)

--- a/jobs.py
+++ b/jobs.py
@@ -58,7 +58,22 @@ class Job:
         # a staffer has the workbook.
         self.collected = False
         self.reported_uncollected = False
+        # Set when a staffer asks the run to stop. The work checks it between
+        # cases rather than being killed, so the ICOS session is logged off on
+        # the way out and the account is free for the next person.
+        self.cancelled = False
         self._lock = threading.Lock()
+
+    def cancel(self):
+        """Ask the run to stop at its next check.
+
+        A run that is waiting out a court-side stall can sit on one case for
+        four minutes, so there has to be a way to stop it. Without this the
+        only button on the page logged the browser out, which left the work
+        running, held the shared ESA account, and threw away the browser's
+        claim on whatever the run did eventually produce.
+        """
+        self.cancelled = True
 
     def log(self, message, count=None, total=None):
         with self._lock:
@@ -81,6 +96,7 @@ class Job:
                 "count": self.count,
                 "total": self.total,
                 "next_url": self.next_url,
+                "cancelled": self.cancelled,
                 "done": self.status in (DONE, FAILED),
             }
 

--- a/tasks.py
+++ b/tasks.py
@@ -19,7 +19,7 @@ import case_parser
 import crs
 import icos_sessions
 import roster
-from icos import IcosClient, IcosError
+from icos import IcosClient, IcosError, IcosStopped, STOPPED_MESSAGE
 
 # One case ICOS will not hand over is a bad case. Several in a row is the site
 # being down, and there is no point walking the rest of the list to find that
@@ -96,6 +96,7 @@ def report_unknown_dispositions(job, unknown):
 
 def search_task(job, username, password, firstname, middlename, lastname):
     client = IcosClient(log=job.log, alert=alerts.emitter(job))
+    client.set_stop_check(lambda: job.cancelled)
     keep_session = False
     try:
         client.login(username, password)
@@ -124,6 +125,16 @@ def search_task(job, username, password, firstname, middlename, lastname):
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
+def _stop_if_asked(job):
+    """Raise if a staffer has asked this run to stop.
+
+    Called between units of work. The retry loop has its own check, because a
+    run is usually stopped precisely while it is waiting one out.
+    """
+    if getattr(job, 'cancelled', False):
+        raise IcosStopped(STOPPED_MESSAGE)
+
+
 def _pull_cases(job, client, case_ids, offset=0, total=None):
     """Fetch and parse a list of cases. Returns what was read and what was not.
 
@@ -136,6 +147,7 @@ def _pull_cases(job, client, case_ids, offset=0, total=None):
     failures_in_a_row = 0
     not_attempted = []
     for index, case_id in enumerate(case_ids, start=1):
+        _stop_if_asked(job)
         # Counted across the whole run, not this client's slice of it, so the
         # sentence and the bar under it never disagree on a clinic list.
         job.log("Pulling case %d of %d (%s)..." % (offset + index, total, case_id),
@@ -143,6 +155,11 @@ def _pull_cases(job, client, case_ids, offset=0, total=None):
         case = {'id': case_id}
         try:
             summary, charges, financials = client.case_bundle(case_id)
+        except IcosStopped:
+            # A stop is an IcosError so it unwinds like one, which means every
+            # handler that drops a case has to let it past or stopping a run
+            # would read as one bad case and the run would carry on.
+            raise
         except IcosError as e:
             # ICOS never gave up this case inside its retry budget. That
             # costs one row, not the run: the other cases are still worth
@@ -209,6 +226,7 @@ def batch_search_task(job, username, password, people, rejected=()):
     other people use. This lives in the dyno's memory and is gone in two hours.
     """
     client = IcosClient(log=job.log, alert=alerts.emitter(job))
+    client.set_stop_check(lambda: job.cancelled)
     keep_session = False
     try:
         client.login(username, password)
@@ -216,14 +234,21 @@ def batch_search_task(job, username, password, people, rejected=()):
         clients = []
         failures_in_a_row = 0
         for index, person in enumerate(people, start=1):
+            _stop_if_asked(job)
             job.log("Searching Iowa Courts for name %d of %d..."
                     % (index, len(people)), count=index - 1, total=len(people))
+            # The search terms ride along because the CRS run has to repeat
+            # this exact search before it can pull this client's cases. See
+            # batch_crs_task.
             entry = {'name': roster.describe(person), 'keys': [], 'cases': {},
-                     'too_many_results': False, 'error': None}
+                     'too_many_results': False, 'error': None,
+                     'person': person}
             clients.append(entry)
             try:
                 body = client.search(person['first'], person['middle'],
                                      person['last'])
+            except IcosStopped:
+                raise
             except IcosError as e:
                 entry['error'] = e.message
                 failures_in_a_row += 1
@@ -258,12 +283,49 @@ def batch_search_task(job, username, password, people, rejected=()):
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
+def _reselect(job, client, pick):
+    """Put this client's search results back in front of ICOS. True if it took.
+
+    Nothing is read out of the response. The point is the side effect: ICOS
+    decides which case a case request means from whatever it answered last,
+    so the run has to be standing on this client's results before it asks for
+    this client's cases.
+
+    A name that will not answer twice costs that client and not the list, and
+    it is reported as a search failure rather than as sixty-odd unavailable
+    cases, because that is what it is.
+    """
+    person = pick.get('person')
+    if not person:
+        return False
+    try:
+        client.search(person['first'], person['middle'], person['last'])
+    except IcosStopped:
+        raise
+    except IcosError as e:
+        alerts.record(job.id[:8], job.kind, alerts.CASE_UNAVAILABLE,
+                      progress=alerts.recent_progress(job),
+                      case="(re-search before pulling a client's cases)",
+                      note="%s That client was skipped." % e.message)
+        return False
+    return True
+
+
 def batch_crs_task(job, session_token, picks, is_lite):
     """Build a workbook per client, all on the sign in the batch search opened.
 
     picks is what came back off the roster page, already checked against the
     search job by the route: name, date of birth, the defendant keys somebody
     ticked, and that client's own case list.
+
+    Each client's search is repeated here, immediately before their cases are
+    pulled. ICOS keys case selection to the most recent set of search results,
+    not to the case number asked for, so on a clinic list every case belonging
+    to anyone but the last name searched comes back as a stub: right heading,
+    no charges, no money. The validators refuse it and it retries for the full
+    case budget, which reads on the progress page as a hang and costs four
+    minutes a case. Re-searching costs one request and about a third of a
+    second per client.
 
     One client's run failing costs that client's workbook and nothing else. The
     clinic gets the rest and the finish page says which one is missing, because
@@ -274,12 +336,17 @@ def batch_crs_task(job, session_token, picks, is_lite):
         raise IcosError("That clinic list is no longer signed in to Iowa "
                         "Courts Online. Please run it again.")
     client.set_alert(alerts.emitter(job))
+    # Both, or the person waiting watches a job that has stopped being written
+    # to while the run carries on under the search job's name.
+    client.set_log(job.log)
+    client.set_stop_check(lambda: job.cancelled)
 
     total_cases = sum(len(pick['case_ids']) for pick in picks)
     try:
         built = []
         pulled = 0
         for index, pick in enumerate(picks, start=1):
+            _stop_if_asked(job)
             job.log("Client %d of %d: pulling %d case%s..."
                     % (index, len(picks), len(pick['case_ids']),
                        "" if len(pick['case_ids']) == 1 else "s"),
@@ -287,6 +354,14 @@ def batch_crs_task(job, session_token, picks, is_lite):
             record = {'name': pick['def_name'], 'requested': len(pick['case_ids']),
                       'written': 0, 'failed': [], 'file': None, 'error': None}
             built.append(record)
+
+            if not _reselect(job, client, pick):
+                pulled += len(pick['case_ids'])
+                record['failed'] = list(pick['case_ids'])
+                record['error'] = ("Iowa Courts would not answer this client's "
+                                   "name a second time, so their cases could "
+                                   "not be pulled. Search them on their own.")
+                continue
 
             cases, failed = _pull_cases(job, client, pick['case_ids'],
                                         offset=pulled, total=total_cases)
@@ -376,6 +451,11 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         raise IcosError("That search is no longer signed in to Iowa Courts "
                         "Online. Please run the search again.")
     client.set_alert(alerts.emitter(job))
+    # Without this the retry notices go on being written into the search job,
+    # and the progress page the staffer is actually watching sits on one case
+    # with nothing under it while ICOS is being retried.
+    client.set_log(job.log)
+    client.set_stop_check(lambda: job.cancelled)
 
     try:
         case_ids = []

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -121,7 +121,7 @@ summary::marker { color: var(--ink-faint); }
   </details>
 
   <div class="actions" style="margin-top:1.4rem">
-    <a href="/logout" class="btn btn-quiet">Cancel and start over</a>
+    <button type="button" class="btn btn-quiet" id="stop">Cancel and start over</button>
   </div>
 </div>
 
@@ -295,6 +295,20 @@ function poll() {
 }
 
 document.getElementById("recheck-btn").addEventListener("click", resume);
+
+// Ask the run to stop before starting over. It used to go straight to /logout,
+// which left the work running and holding the shared Iowa Courts account while
+// the browser lost its claim on whatever the run went on to produce. The
+// redirect happens either way, because a staffer who has decided to stop
+// should not be held on this page by a failed fetch: /logout cancels too.
+document.getElementById("stop").addEventListener("click", function () {
+  var button = this;
+  button.disabled = true;
+  button.textContent = "Stopping...";
+  fetch("/job/" + encodeURIComponent(jobId) + "/cancel", { method: "POST" })
+    .catch(function () {})
+    .then(function () { window.location = "/logout"; });
+});
 
 // A locked screen or a backgrounded tab suspends the timer above, and the
 // network coming back is the moment worth asking again rather than waiting out

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -471,6 +471,12 @@ def test_a_case_icos_will_not_return_alerts_with_the_case_and_not_the_person(
         def set_alert(self, alert):
             self.alert = alert
 
+        def set_log(self, log):
+            pass
+
+        def set_stop_check(self, should_stop):
+            pass
+
         def case_bundle(self, case_id):
             raise IcosUnavailable("Iowa Courts Online did not return this case "
                                   "after 4 minutes of retrying "
@@ -509,6 +515,12 @@ def test_a_case_that_will_not_parse_alerts_with_the_case_and_not_the_person(
 
         def set_alert(self, alert):
             self.alert = alert
+
+        def set_log(self, log):
+            pass
+
+        def set_stop_check(self, should_stop):
+            pass
 
         def case_bundle(self, case_id):
             return b'<summary>', b'<charges>', b'<financials>'

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -51,24 +51,40 @@ class FakeClient:
     instances = []
     search_error = None
     fail_searches = ()      # 1-based positions in the list that Iowa Courts refuses
+    # A line the real client writes from inside its retry loop. Opt-in, because
+    # only the test that cares where those notices land wants the noise.
+    retry_notice = None
 
     def __init__(self, log=None, alert=None, **kwargs):
         self.log = log or (lambda m, **kw: None)
         self.alert = alert
+        self.should_stop = lambda: False
         self.logged_off = False
         self.searched = []
         self.cases = []
+        # Searches and case pulls in the order they happened. Kept together
+        # because the thing worth asserting is which came before which.
+        self.trace = []
         self.fail_cases = []
         FakeClient.instances.append(self)
 
     def set_alert(self, alert):
         self.alert = alert
 
+    def set_log(self, log):
+        # Recorded rather than ignored: the retry notices going to the job
+        # nobody is watching is exactly the bug this stub has to be able to see.
+        self.log = log or (lambda m, **kw: None)
+
+    def set_stop_check(self, should_stop):
+        self.should_stop = should_stop or (lambda: False)
+
     def login(self, username, password):
         self.log("Signed in to Iowa Courts Online.")
 
     def search(self, first, middle, last):
         self.searched.append((first, middle, last))
+        self.trace.append(('search', last))
         if FakeClient.search_error:
             raise FakeClient.search_error
         if len(self.searched) in FakeClient.fail_searches:
@@ -77,6 +93,9 @@ class FakeClient:
 
     def case_bundle(self, case_id):
         self.cases.append(case_id)
+        self.trace.append(('case', case_id))
+        if FakeClient.retry_notice:
+            self.log(FakeClient.retry_notice)
         if case_id in self.fail_cases:
             raise IcosError("Iowa Courts did not answer for this case.")
         return b"<summary>", b"<charges>", b"<financials>"
@@ -90,6 +109,7 @@ def fake_icos(monkeypatch):
     FakeClient.instances = []
     FakeClient.search_error = None
     FakeClient.fail_searches = ()
+    FakeClient.retry_notice = None
     monkeypatch.setattr(tasks, 'IcosClient', FakeClient)
     monkeypatch.setattr(tasks.case_parser, 'parse_case_summary',
                         lambda html, case: case.update(county='DUBUQUE'))
@@ -441,3 +461,84 @@ class TestNamesStayOffTheBrowser:
         search_job_id, _ = run_batch(client, "Client Name\nDoe, Jane")
         assert 'Client Name' in client.get(
             '/roster/' + search_job_id).get_data(as_text=True)
+
+
+class TestEachClientsCasesComeFromTheirOwnSearch:
+    """The failure that made a real clinic run look hung.
+
+    ICOS decides which case a case request means from whatever it answered
+    last, not from the case number in the request. A two-phase run searches
+    every name and then pulls every case, so by pull time ICOS is standing on
+    the last name searched and every earlier client's cases come back as a
+    stub: right heading, no charges, no money. The validators refuse it, the
+    case retries for its full four minute budget, and the progress page sits on
+    "Pulling case 1 of 67" with nothing under it.
+    """
+
+    def test_a_clients_search_is_repeated_immediately_before_their_cases(self, client):
+        search_job_id, _ = run_batch(client)
+        response = pick_all(client, search_job_id)
+        await_job(client, response.get_json()['job_id'])
+        assert FakeClient.instances[0].trace == [
+            ('search', 'Doe'), ('search', 'Roe'),          # the roster search
+            ('search', 'Doe'), ('case', '00000 FECR000000'),
+            ('case', '00000 SRCR000000'),
+            ('search', 'Roe'), ('case', '00000 SMCR000000'),
+        ]
+
+    def test_the_search_terms_come_off_the_search_job_and_not_the_browser(self, client):
+        """A name posted by the browser would be somebody the staffer never saw
+        on the roster page, and their cases would go in a client's file."""
+        search_job_id, _ = run_batch(client)
+        client.get('/roster/' + search_job_id)
+        result = jobs.get(search_job_id).result
+        picks = [{'client': index, 'keys': entry['keys'], 'person':
+                  {'first': 'Someone', 'middle': '', 'last': 'Else'}}
+                 for index, entry in enumerate(result['clients']) if entry['keys']]
+        response = client.post('/batch-crs', json={'search_job_id': search_job_id,
+                                                   'picks': picks})
+        await_job(client, response.get_json()['job_id'])
+        trace = FakeClient.instances[0].trace
+        assert ('search', 'Else') not in trace
+        # And the re-search did happen, or the line above passes by never
+        # having searched anybody a second time at all.
+        assert trace.count(('search', 'Doe')) == 2
+
+    def test_a_name_that_will_not_answer_twice_costs_that_client_and_not_the_list(
+            self, client):
+        search_job_id, _ = run_batch(client)
+        FakeClient.fail_searches = (3,)    # Doe's re-search, not the roster pass
+        response = pick_all(client, search_job_id)
+        job_id = response.get_json()['job_id']
+        state = await_job(client, job_id)
+        assert state['status'] == 'done'
+        built = jobs.get(job_id).result['clients']
+        assert 'a second time' in built[0]['error']
+        assert built[1]['written'] == 1     # the rest of the clinic still gets theirs
+
+    def test_the_count_still_reaches_the_end_when_a_client_is_skipped(self, client):
+        """The bar measures against every case on the list, so a skipped client
+        has to be counted past or a finished run reads as stalled at 1 of 3."""
+        search_job_id, _ = run_batch(client)
+        FakeClient.fail_searches = (3,)
+        response = pick_all(client, search_job_id)
+        state = await_job(client, response.get_json()['job_id'])
+        assert state['count'] == state['total'] == 3
+
+
+class TestTheProgressPageShowsTheRunItIsWatching:
+    def test_retry_notices_land_in_the_job_the_staffer_is_watching(self, client):
+        """The second half of the hang. The CRS run rebound alerting to itself
+        but not the log, so "Iowa Courts is slow, retrying" was written into
+        the search job, which no page is showing by then. Four minutes of
+        retrying looked like four minutes of nothing."""
+        FakeClient.retry_notice = "Iowa Courts is slow, retrying (attempt 6)..."
+        search_job_id, _ = run_batch(client)
+        response = pick_all(client, search_job_id)
+        crs_job_id = response.get_json()['job_id']
+        await_job(client, crs_job_id)
+
+        crs = " ".join(p["message"] for p in jobs.get(crs_job_id).progress)
+        search = " ".join(p["message"] for p in jobs.get(search_job_id).progress)
+        assert "retrying (attempt 6)" in crs
+        assert "retrying (attempt 6)" not in search

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,207 @@
+"""Stopping a run that is already going.
+
+A clinic list can sit four minutes on one case Iowa Courts will not give up, so
+there has to be a way out. Killing the thread is not it: the ESA account Iowa
+Legal Aid shares stays locked for about a quarter of an hour by a session
+nobody released. So the run is asked to stop, stops at its next check, and
+unwinds through the same finally that logs off.
+
+Every name here is invented and every case number is 00000-shaped. The
+repository is public and a real Iowa case number attached to a real name is a
+person.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
+
+import app as app_module
+import icos_sessions
+import jobs
+import tasks
+from icos import STOPPED_MESSAGE, IcosStopped
+
+JANE = ['00000 FECR000000', '00000 SRCR000000']
+JOHN = ['00000 SMCR000000']
+
+
+def pick(name, case_ids, last):
+    return {'def_name': name, 'def_dob': '01/01/1900', 'case_ids': case_ids,
+            'person': {'first': 'Pat', 'middle': '', 'last': last}}
+
+
+class StubClient:
+    """Cancels the job partway through, standing in for the staffer's button."""
+
+    logged_in = True
+
+    def __init__(self, cancel_on=None):
+        self.cancel_on = cancel_on      # the case id they give up on
+        self.job = None
+        self.pulled = []
+        self.searched = []
+        self.logged_off = False
+        self.should_stop = lambda: False
+
+    def set_alert(self, alert):
+        pass
+
+    def set_log(self, log):
+        pass
+
+    def set_stop_check(self, should_stop):
+        self.should_stop = should_stop
+
+    def search(self, first, middle, last):
+        self.searched.append(last)
+        return b'<html></html>'
+
+    def case_bundle(self, case_id):
+        self.pulled.append(case_id)
+        if case_id == self.cancel_on:
+            self.job.cancel()
+        return b'<summary>', b'<charges>', b'<financials>'
+
+    def logoff(self):
+        self.logged_off = True
+
+
+@pytest.fixture(autouse=True)
+def fake_icos(monkeypatch, tmp_path):
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_summary',
+                        lambda html, case: case.update(county='DUBUQUE'))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_charges',
+                        lambda html, case: case.update(charges=[]))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
+                        lambda html, case: case.update(financials=[],
+                                                       total_due='$0.00'))
+    monkeypatch.setattr(tasks, 'build_workbook',
+                        lambda cases, name, dob, lite: (str(tmp_path / 'w.xlsx'), {}))
+    yield
+
+
+def run_until_cancelled(monkeypatch, picks, cancel_on):
+    job = jobs.Job('batch_crs')
+    stub = StubClient(cancel_on=cancel_on)
+    stub.job = job
+    monkeypatch.setattr(icos_sessions, 'claim', lambda token: stub)
+    with pytest.raises(IcosStopped) as caught:
+        tasks.batch_crs_task(job, 'tok', picks, False)
+    return job, stub, caught.value
+
+
+class TestStoppingTheRun:
+    def test_it_stops_pulling_cases(self, monkeypatch):
+        """The whole point. Before this the only button on the page logged the
+        browser out and left the run going."""
+        _, stub, _ = run_until_cancelled(
+            monkeypatch, [pick('DOE, JANE', JANE, 'Doe')], JANE[0])
+        assert stub.pulled == [JANE[0]]
+
+    def test_it_does_not_carry_on_to_the_next_client(self, monkeypatch):
+        """A stop is an IcosError so it unwinds like one, which means every
+        handler that drops a case or a name has to let it past. Miss one and
+        stopping a run reads as a single bad case and the list carries on."""
+        _, stub, _ = run_until_cancelled(
+            monkeypatch,
+            [pick('DOE, JANE', JANE, 'Doe'), pick('ROE, JOHN', JOHN, 'Roe')],
+            JANE[0])
+        assert stub.pulled == [JANE[0]]
+        assert stub.searched == ['Doe']       # the second client never started
+
+    def test_it_still_logs_the_shared_account_off(self, monkeypatch):
+        """The reason for asking rather than killing. An ESA session nobody
+        released locks the account Iowa Legal Aid shares for about fifteen
+        minutes, so the next person to search cannot."""
+        _, stub, _ = run_until_cancelled(
+            monkeypatch, [pick('DOE, JANE', JANE, 'Doe')], JANE[0])
+        assert stub.logged_off is True
+
+    def test_it_says_the_account_is_free(self, monkeypatch):
+        _, _, stopped = run_until_cancelled(
+            monkeypatch, [pick('DOE, JANE', JANE, 'Doe')], JANE[0])
+        assert stopped.message == STOPPED_MESSAGE
+        assert 'signed out' in stopped.message
+
+    def test_a_stop_does_not_page_anybody(self):
+        """jobs.py emails about anything that raises without a .message,
+        because that is a bug staff cannot act on. A staffer stopping their own
+        run is neither, so it has to arrive carrying its own wording."""
+        def stop_at_once(job):
+            raise IcosStopped(STOPPED_MESSAGE)
+
+        job = jobs.start('batch_crs', stop_at_once)
+        for _ in range(500):
+            if job.status in (jobs.DONE, jobs.FAILED):
+                break
+            import time
+            time.sleep(0.01)
+        assert job.status == jobs.FAILED
+        assert job.error == STOPPED_MESSAGE
+
+
+def a_running_job():
+    """A job the routes can actually find.
+
+    jobs.start is what puts a job in the registry, and it also runs it. These
+    tests want one sitting there, so it goes in by hand. Skipping this makes
+    every route below answer 410 for the wrong reason, and the test that says
+    another browser cannot stop a run would pass without ever reaching the
+    check it is about.
+    """
+    job = jobs.Job('batch_crs')
+    job.status = jobs.RUNNING
+    with jobs._jobs_lock:
+        jobs._jobs[job.id] = job
+    return job
+
+
+class TestTheButton:
+    @pytest.fixture
+    def client(self):
+        app_module.app.config['TESTING'] = True
+        app_module.app.secret_key = 'test'
+        return app_module.app.test_client()
+
+    def test_it_asks_the_run_to_stop(self, client):
+        job = a_running_job()
+        with client.session_transaction() as browser:
+            browser['job_ids'] = [job.id]
+        assert client.post('/job/%s/cancel' % job.id).status_code == 200
+        assert job.cancelled is True
+
+    def test_another_browser_cannot_stop_it(self, client):
+        job = a_running_job()
+        assert client.post('/job/%s/cancel' % job.id).status_code == 410
+        assert job.cancelled is False
+
+    def test_a_link_cannot_stop_it(self, client):
+        """POST because a link gets followed by things that are not the
+        staffer, and the run this ends is holding an ESA account."""
+        job = a_running_job()
+        with client.session_transaction() as browser:
+            browser['job_ids'] = [job.id]
+        assert client.get('/job/%s/cancel' % job.id).status_code == 405
+        assert job.cancelled is False
+
+    def test_starting_over_stops_what_is_running(self, client):
+        """The button redirects here afterwards, and staff reach it on their
+        own. Either way the old run must not keep the shared account while the
+        new one queues behind it."""
+        job = a_running_job()
+        with client.session_transaction() as browser:
+            browser['job_ids'] = [job.id]
+        assert client.get('/logout').status_code == 302
+        assert job.cancelled is True
+
+    def test_starting_over_leaves_a_finished_run_alone(self, client):
+        job = a_running_job()
+        job.status = jobs.DONE
+        with client.session_transaction() as browser:
+            browser['job_ids'] = [job.id]
+        client.get('/logout')
+        assert job.cancelled is False

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -53,6 +53,12 @@ class StubClient:
     def set_alert(self, alert):
         pass
 
+    def set_log(self, log):
+        pass
+
+    def set_stop_check(self, should_stop):
+        pass
+
     def case_bundle(self, case_id):
         self.asked.append(case_id)
         if case_id in self.unavailable:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -41,6 +41,7 @@ class FakeClient:
     def __init__(self, log=None, alert=None, **kwargs):
         self.log = log or (lambda m: None)
         self.alert = alert
+        self.should_stop = lambda: False
         self.logged_in = False
         self.logged_off = False
         self.cases = []
@@ -51,6 +52,15 @@ class FakeClient:
         # The CRS job inherits the search job's session and rebinds alerting
         # to itself; a stub that skipped this would hide a break in that.
         self.alert = alert
+
+    def set_log(self, log):
+        # Same rebinding, and the one staff can actually see. Left unbound, the
+        # retry notices go on being written into the search job while the person
+        # waiting watches the CRS job say nothing.
+        self.log = log or (lambda m: None)
+
+    def set_stop_check(self, should_stop):
+        self.should_stop = should_stop or (lambda: False)
 
     def login(self, username, password):
         if FakeClient.login_error:

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -8,7 +8,8 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import icos
-from icos import IcosAccountLocked, IcosBadCredentials, IcosClient, IcosUnavailable
+from icos import (IcosAccountLocked, IcosBadCredentials, IcosClient,
+                  IcosStopped, IcosUnavailable)
 from reader import EMPTY, OK, TIMEOUT, FetchResult
 
 LOGIN_OK = b"x" * 28000
@@ -413,3 +414,36 @@ def test_no_credentials_are_logged():
     client, _, messages = build([FetchResult(OK, LOGIN_OK), FetchResult(OK, LOGIN_OK)])
     client.login("ILATEST", "hunter2")
     assert not any("hunter2" in m for m in messages)
+# -- stopping ---------------------------------------------------------------
+
+
+def test_a_stop_ends_the_wait_rather_than_riding_out_the_budget():
+    """The reason the check lives in here and not only between cases: the whole
+    reason somebody reaches for stop is that a wait is in progress. A stalled
+    search is waited out for forty-five minutes and a stalled case for four,
+    which is far too long to make a staffer sit through once they have decided
+    to stop."""
+    client, clock, _ = build([FetchResult(TIMEOUT)] * 200)
+    asked = []
+
+    def should_stop():
+        asked.append(1)
+        return len(asked) > 3      # they give up three attempts in
+
+    client.set_stop_check(should_stop)
+    with pytest.raises(IcosStopped):
+        client.search("PAT", "", "TESTER")
+    assert clock.now < 60          # seconds, against a budget of forty-five minutes
+
+
+def test_a_stopped_run_can_still_log_off():
+    """The property the whole design rests on. logoff goes straight at
+    fetch_once instead of through the retry loop, so the stop check can never
+    stand between a cancelled run and releasing the account Iowa Legal Aid
+    shares. Route logoff through _retry and this fails."""
+    client, _, _ = build([FetchResult(OK, LOGIN_OK), FetchResult(OK, LOGIN_OK)])
+    client.login("ILATEST", "secret")
+    client.set_stop_check(lambda: True)
+    client.logoff()
+    assert "EPALogout" in client.reader.calls
+    assert client.logged_in is False


### PR DESCRIPTION
The clinic run that looked hung this morning. Two clients, 67 cases, stuck on
"Pulling case 1 of 67". Nothing had failed. Three things were wrong.

**Every case came back a stub.** ICOS keys case selection to the most recent
search result set, not to the case number asked for. Batch mode searches every
name and then pulls every case, so by pull time ICOS is standing on the last
name searched and everyone else's cases return the problem-report page: right
heading, no charges, no money. The validators refuse it and the case retries
for its full four minute budget. On 67 cases that is four hours to produce
almost nothing.

Each client's search is now repeated immediately before their cases are pulled.
One request, about a third of a second per client. The search terms come off
the search job, never off the browser, so a name the staffer never confirmed on
the roster page cannot put a stranger's convictions in a client's file. A name
Iowa Courts will not answer twice costs that client and not the list.

**The retry notices were going to a job nobody was watching.** The CRS run
rebound alerting to itself but not the progress log, so "Iowa Courts is slow,
retrying (attempt 6)" was written into the search job. Four minutes of retrying
looked like four minutes of nothing. `IcosClient.set_log` now exists and both
places that adopt an existing session call it.

**Cancel did not cancel.** The button was a link to `/logout`, which dropped
the browser's claim on the job while the work carried on holding the shared ESA
account. Runs are now asked to stop and stop at their next check, which is what
lets them unwind through the `finally` that logs the session off. The check is
inside the retry loop as well as between cases, since the reason anybody
reaches for stop is that a wait is in progress. Cancelling is a POST.

`IcosStopped` subclasses `IcosError`, so every handler that drops a case or a
name has to re-raise it or a cancel reads as one bad case and the run carries
on. It carries a message, so a staffer stopping their own run does not page
anyone.

### Tests

Seventeen new, each verified to fail against the code without its fix:

- `TestEachClientsCasesComeFromTheirOwnSearch` - the exact search/pull ordering,
  the terms coming off the search job, a re-search that fails costing one
  client, and the progress count still reaching the end when a client is skipped
- `TestTheProgressPageShowsTheRunItIsWatching` - retry notices in the CRS job's
  progress and not the search job's
- `tests/test_cancel.py` - a cancel stops the run, does not start the next
  client, still logs the shared account off, says the account is free, and does
  not page anybody; plus the route (POST only, other browsers refused, starting
  over cancels a running job and leaves a finished one alone)
- `test_a_stopped_run_can_still_log_off` - `logoff` goes straight at
  `fetch_once` instead of through `_retry`, which is the property that makes
  cooperative cancellation safe. Route it through `_retry` and this fails.
- `test_a_stop_ends_the_wait_rather_than_riding_out_the_budget` - the in-wait
  check, against a 45 minute search budget

512 pass. Every name invented, every case number `00000`-shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t