### PR TITLE
Retry the cases that failed, and say which run is holding the account

### DIFF
--- a/accounts.py
+++ b/accounts.py
@@ -1,0 +1,110 @@
+"""Which shared Iowa Courts accounts Napier is holding right now.
+
+ICOS allows one session per account and offers no force-logoff, so a second
+staffer signing in on the same ILA account waits the lock out. Until this they
+waited it out blind: the page said an account was signed in somewhere else and
+could not say where, so the honest guess was fifteen minutes of nothing.
+
+Most of the time the answer is Napier. Somebody else on the same account
+started a run in this process a few minutes ago, and Napier has known which
+account that run holds since it signed in. It just never said so.
+
+State is this process's memory, which here is the whole application: the
+Procfile pins gunicorn to one worker, and a restart that loses this registry
+loses the sessions it describes at the same moment, so an entry cannot outlive
+the session behind it.
+
+The account id is staff-facing and the alerting is not. Somebody told their own
+sign in collided already typed the user id, so naming it back tells them
+nothing they did not bring with them, while alert mail keeps to the account
+family the way everything else in Napier does.
+"""
+
+import threading
+import time
+import uuid
+
+_held = {}
+_lock = threading.Lock()
+
+
+def _key(username):
+    return (username or "").strip().upper()
+
+
+def hold(username, now=None):
+    """Record that Napier has an ICOS session open on this account.
+
+    Returns a handle to give back to release(). Handles rather than usernames
+    because two runs can briefly overlap on one account while the first is
+    logging off, and the second must not release the first one's entry.
+    """
+    handle = uuid.uuid4().hex
+    with _lock:
+        _held[handle] = {"account": _key(username),
+                         "since": time.time() if now is None else now}
+    return handle
+
+
+def release(handle):
+    """Forget a session. Safe to call twice, and safe with an unknown handle."""
+    if not handle:
+        return
+    with _lock:
+        _held.pop(handle, None)
+
+
+def holder(username, now=None):
+    """The oldest live Napier session on this account, or None.
+
+    The oldest because that is the one actually holding the lock: anything
+    newer is either the caller or a session ICOS refused.
+    """
+    account = _key(username)
+    if not account:
+        return None
+    with _lock:
+        entries = [entry for entry in _held.values()
+                   if entry["account"] == account]
+    if not entries:
+        return None
+    entry = min(entries, key=lambda e: e["since"])
+    now = time.time() if now is None else now
+    return {"account": account, "since": entry["since"],
+            "seconds": max(0.0, now - entry["since"])}
+
+
+def describe_wait(seconds):
+    """How long the run holding the account has been going, in plain words."""
+    minutes = int(seconds // 60)
+    if minutes < 1:
+        return "less than a minute ago"
+    if minutes == 1:
+        return "a minute ago"
+    if minutes < 60:
+        return "%d minutes ago" % minutes
+    hours = int(minutes // 60)
+    return "%d hour%s ago" % (hours, "" if hours == 1 else "s")
+
+
+def describe(username, now=None):
+    """What to tell a staffer whose sign in collided, or None if we cannot say.
+
+    None is the honest answer when Napier is not holding the account: the lock
+    belongs to somebody signed in to Iowa Courts outside Napier, or to a run
+    lost with a restarted dyno, and neither is something to guess about.
+    """
+    entry = holder(username, now=now)
+    if entry is None:
+        return None
+    return ("Napier is already signed in to Iowa Courts as %s. That run "
+            "started %s and Iowa Courts allows one session per account, so "
+            "this search will start as soon as it finishes or somebody stops "
+            "it."
+            % (entry["account"], describe_wait(entry["seconds"])))
+
+
+def _reset():
+    """For tests. Nothing in the app has any business emptying this."""
+    with _lock:
+        _held.clear()

--- a/app.py
+++ b/app.py
@@ -309,21 +309,84 @@ def batch_crs():
                     "progress_url": url_for('progress', job_id=job.id)})
 
 
+def _finish_page(job, error=None):
+    """The page a finished workbook run lands on, whichever kind of run it was.
+
+    Split out because the retry it offers has to be able to come back to this
+    same page with something to say, and a retry of a clinic list and a retry
+    of one client end up in different templates.
+    """
+    result = job.result
+    # Whether there is anything left worth trying, not the payload itself. The
+    # payload holds whole parsed cases and a browser has no business with them.
+    can_retry = bool(result.get('retry'))
+    if job.kind == 'batch_crs':
+        return render_template('batch_done.html', job=job.to_dict(),
+                               clients=result['clients'],
+                               is_lite=result['is_lite'],
+                               built=sum(1 for c in result['clients'] if c['file']),
+                               written=result['written_cases'],
+                               can_retry=can_retry, error=error,
+                               missing=sum(len(c['failed'])
+                                           for c in result['clients']),
+                               limits=crs.workbook_limits(
+                                   max([c['written'] for c in result['clients']]
+                                       or [0]), result['is_lite']))
+    return render_template('done.html', job=job.to_dict(),
+                           def_name=result['def_name'],
+                           is_lite=result['is_lite'],
+                           written=result['written_cases'],
+                           requested=result['requested_cases'],
+                           failed=result['failed_cases'],
+                           can_retry=can_retry, error=error,
+                           missing=len(result['failed_cases']),
+                           limits=crs.workbook_limits(result['written_cases'],
+                                                      result['is_lite']),
+                           filename=tasks.download_name(result['def_name'],
+                                                        result['is_lite']))
+
+
 @app.route('/batch-done/<job_id>')
 def batch_done(job_id):
     job = own_job(job_id)
     if job is None or job.status != jobs.DONE or job.kind != 'batch_crs':
         return render_template('start.html', error=RESTARTED_MESSAGE)
 
-    result = job.result
-    return render_template('batch_done.html', job=job.to_dict(),
-                           clients=result['clients'],
-                           is_lite=result['is_lite'],
-                           built=sum(1 for c in result['clients'] if c['file']),
-                           written=result['written_cases'],
-                           limits=crs.workbook_limits(
-                               max([c['written'] for c in result['clients']]
-                                   or [0]), result['is_lite']))
+    return _finish_page(job)
+
+
+@app.route('/retry/<job_id>', methods=['POST'])
+def retry(job_id):
+    """Another go at only the cases Iowa Courts would not give up.
+
+    A fresh sign in, because the run this is started from logged its ICOS
+    session off on the way out and that is the behaviour keeping the shared
+    account usable. It is the same sign in staff would do anyway, and it buys
+    them not re-pulling the sixty cases that already worked.
+    """
+    job = own_job(job_id)
+    if (job is None or job.status != jobs.DONE
+            or job.kind not in jobs.BUILDS_A_WORKBOOK):
+        return render_template('start.html', error=RESTARTED_MESSAGE)
+
+    payload = job.result.get('retry')
+    if not payload:
+        # The run came back complete, or it has no way to put the search back in
+        # front of ICOS. Either way there is nothing here to do.
+        return _finish_page(job, error="There is nothing on this run left to "
+                                       "try again.")
+
+    username = request.form.get('username', '').strip()
+    password = request.form.get('password', '')
+    if not username.startswith("ILA") and not username.startswith("drakelegalclinic"):
+        return _finish_page(job, error="That user ID is not an Iowa Legal Aid "
+                                       "Iowa Courts account.")
+
+    icos_sessions.close(session.pop('icos_token', None))
+    retry_job = jobs.start(payload['kind'], tasks.retry_task,
+                           username, password, payload)
+    remember_job(retry_job)
+    return redirect(url_for('progress', job_id=retry_job.id))
 
 
 def _served_file(path):
@@ -465,8 +528,12 @@ def crs_job():
     primary = keys[0]
     def_dob, _, def_name = primary.partition(" ")
 
+    # The search terms travel with the run so a short workbook can be finished
+    # off later. They come off the search job and never off the browser, the
+    # same rule the clinic list keeps.
     job = jobs.start('crs', tasks.crs_task, token, keys, search_job.result['cases'],
-                     def_name, def_dob, session.get('isLite', False))
+                     def_name, def_dob, session.get('isLite', False),
+                     search_job.result.get('person'))
     remember_job(job)
     session.pop('icos_token', None)  # the CRS job owns it now and logs it off
     return jsonify({"job_id": job.id, "progress_url": url_for('progress', job_id=job.id)})
@@ -478,17 +545,7 @@ def done(job_id):
     if job is None or job.status != jobs.DONE or job.kind != 'crs':
         return render_template('start.html', error=RESTARTED_MESSAGE)
 
-    result = job.result
-    return render_template('done.html', job=job.to_dict(),
-                           def_name=result['def_name'],
-                           is_lite=result['is_lite'],
-                           written=result['written_cases'],
-                           requested=result['requested_cases'],
-                           failed=result['failed_cases'],
-                           limits=crs.workbook_limits(result['written_cases'],
-                                                      result['is_lite']),
-                           filename=tasks.download_name(result['def_name'],
-                                                        result['is_lite']))
+    return _finish_page(job)
 
 
 @app.route('/job/<job_id>/download')

--- a/icos.py
+++ b/icos.py
@@ -18,6 +18,7 @@ import os
 import re
 import time
 
+import accounts
 import alerts
 from opener import Opener
 from reader import Reader
@@ -179,6 +180,9 @@ class IcosClient:
             else _env_seconds("CONCURRENT_WAIT_MIN", 16)
         self.logged_in = False
         self.username = None
+        # The registry entry for the ESA account this client holds, so the next
+        # staffer to collide with it can be told what is holding it.
+        self._account_handle = None
 
     def set_alert(self, alert):
         """Point alerts at a different job.
@@ -295,6 +299,15 @@ class IcosClient:
         in a log line.
         """
         self._log("Connecting to Iowa Courts Online...")
+
+        # Said before ICOS is asked, not after it refuses. If Napier is holding
+        # this account itself then the refusal is already certain and the wait
+        # is already started, and the sentence is worth more now than it is
+        # seventy-five seconds from now.
+        held_by_napier = accounts.describe(username)
+        if held_by_napier:
+            self._log(held_by_napier)
+
         self._retry("search", self.reader.init_request)
 
         started = self._monotonic()
@@ -319,24 +332,47 @@ class IcosClient:
                 # ends our own, which is not the one holding the lock. Waiting is
                 # the only thing that works.
                 elapsed = self._monotonic() - started
+                # Asked again rather than reused, because a run can pick this
+                # account up or put it down while somebody is waiting on it.
+                napier_holds = accounts.describe(username)
                 if elapsed + CONCURRENT_INTERVAL > self.concurrent_budget:
                     self._alert(
                         alerts.CONCURRENT_EXHAUSTED,
                         account=alerts.username_prefix(username),
                         elapsed=_describe(elapsed),
-                        note="ESA never released the lock. This is shared "
-                             "accounts colliding, not an ICOS fault.")
+                        note="Napier's own run held the account for the whole "
+                             "wait. Two staff on one login."
+                             if napier_holds else
+                             "ESA never released the lock, and Napier was not "
+                             "holding the account. Somebody is signed in to "
+                             "Iowa Courts outside Napier.")
+                    if napier_holds:
+                        raise IcosAccountLocked(
+                            "This Iowa Courts account has been busy with another "
+                            "Napier run for the whole wait. Whoever started it can "
+                            "stop it from their own progress page, or you can sign "
+                            "in with a different Iowa Courts account.")
                     raise IcosAccountLocked(
                         "This Iowa Courts account is still logged in from another "
                         "session and Iowa Courts has not released it. Try again in a "
                         "few minutes, or use your own Iowa Courts account so searches "
                         "do not collide.")
                 if not waited_for_lock:
-                    self._log(
-                        "This Iowa Courts account is already logged in somewhere else. "
-                        "Waiting for that session to clear -- Iowa Courts releases it "
-                        "within about 15 minutes. Nothing is lost; the search will run "
-                        "as soon as the account frees up.")
+                    if napier_holds and held_by_napier:
+                        # Named a moment ago, before ICOS was even asked. Saying
+                        # the same paragraph twice reads as the page repeating
+                        # itself rather than as progress.
+                        self._log("Waiting for that run to finish. Nothing is lost; "
+                                  "this search starts as soon as it does.")
+                    elif napier_holds:
+                        self._log(napier_holds)
+                    else:
+                        self._log(
+                            "This Iowa Courts account is already logged in somewhere "
+                            "else, and not by Napier. Waiting for that session to "
+                            "clear -- Iowa Courts releases it within about 15 "
+                            "minutes. Nothing is lost; the search will run as soon "
+                            "as the account frees up.")
                     waited_for_lock = True
                 self._sleep(CONCURRENT_INTERVAL)
                 continue
@@ -368,6 +404,11 @@ class IcosClient:
 
             self.logged_in = True
             self.username = username
+            # Registered here rather than at the top of login, because until
+            # ESA answers with the search screen Napier is not holding
+            # anything and pointing the next staffer at a session that does
+            # not exist is worse than telling them nothing.
+            self._account_handle = accounts.hold(username)
             self._log("Signed in to Iowa Courts Online.")
             return
 
@@ -421,3 +462,10 @@ class IcosClient:
             print("ICOS logoff failed: %s" % type(e).__name__, flush=True)
         finally:
             self.logged_in = False
+            # Released even when the request above failed. ESA may well still
+            # be holding the session, but no Napier run is, and the entry
+            # exists to point the next staffer at a run they can go and stop.
+            # Pointing them at one that has already finished is worse than
+            # saying nothing.
+            accounts.release(self._account_handle)
+            self._account_handle = None

--- a/tasks.py
+++ b/tasks.py
@@ -98,6 +98,7 @@ def search_task(job, username, password, firstname, middlename, lastname):
     client = IcosClient(log=job.log, alert=alerts.emitter(job))
     client.set_stop_check(lambda: job.cancelled)
     keep_session = False
+    person = {'first': firstname, 'middle': middlename, 'last': lastname}
     try:
         client.login(username, password)
         body = client.search(firstname, middlename, lastname)
@@ -114,6 +115,12 @@ def search_task(job, username, password, firstname, middlename, lastname):
             "keys": keys,
             "too_many_results": too_many_results,
             "session_token": token,
+            # Kept because a CRS run that comes back short can only be retried
+            # by putting this same search back in front of ICOS first, and by
+            # then the run has logged off and the terms are gone. It never goes
+            # to the browser: to_dict leaves result alone, and a client's name
+            # is privileged.
+            "person": person,
         }
         job.log("Found %d case%s across %d name%s."
                 % (len(cases), "" if len(cases) == 1 else "s",
@@ -201,6 +208,56 @@ def _pull_cases(job, client, case_ids, offset=0, total=None):
                 "be pulled. The workbook has the rest."
                 % (len(not_attempted), "" if len(not_attempted) == 1 else "s"))
     return cases, failed
+
+
+def _retry_entry(def_name, def_dob, person, case_ids, cases, failed):
+    """One client's share of what a retry needs.
+
+    case_ids is everything that was asked for, in the order it was asked for,
+    so a rebuilt workbook puts the recovered rows back where they were rather
+    than tacked on the end. cases is what came back, kept whole: the retry
+    signs in fresh and re-pulls only the failures, and it has to be able to
+    write the ones that already worked without asking ICOS for them again.
+
+    These sit in the dyno's memory for the two hours the job lives, which is
+    the same window the workbook itself sits in tmp for, so nothing is exposed
+    here that the finished run was not already holding. They reach no log, no
+    alert and no page.
+    """
+    return {'def_name': def_name, 'def_dob': def_dob, 'person': person,
+            'case_ids': list(case_ids), 'cases': cases, 'failed': list(failed)}
+
+
+def _retry_payload(kind, is_lite, entries):
+    """What the finish page needs to offer another go, or None if it cannot.
+
+    Every client of a clinic list is carried, not just the ones that came back
+    short. A retry rebuilds the whole list and re-zips it, so a staffer who
+    recovers one client's four cases still ends up with one file holding all
+    twenty clients instead of having to keep two zips straight.
+
+    None when nothing failed, and None when something failed that cannot be
+    retried. ICOS decides which case a case request means from the last search
+    it answered, so a client whose search terms were never recorded cannot be
+    re-selected, and pulling their cases without re-selecting is exactly the
+    bug that made every case after the first client come back as a stub.
+    """
+    if not any(entry['failed'] for entry in entries):
+        return None
+    if any(entry['failed'] and not entry['person'] for entry in entries):
+        return None
+    return {'kind': kind, 'is_lite': is_lite, 'clients': entries}
+
+
+def _merged_cases(entry, recovered):
+    """Last run's cases plus this run's, back in the order they were asked for.
+
+    Keyed by case number so a case that failed the first time and worked the
+    second appears once, in its own row, rather than twice or at the end.
+    """
+    by_id = {case['id']: case for case in entry['cases']}
+    by_id.update({case['id']: case for case in recovered})
+    return [by_id[case_id] for case_id in entry['case_ids'] if case_id in by_id]
 
 
 def batch_search_task(job, username, password, people, rejected=()):
@@ -344,6 +401,7 @@ def batch_crs_task(job, session_token, picks, is_lite):
     total_cases = sum(len(pick['case_ids']) for pick in picks)
     try:
         built = []
+        retry_entries = []
         pulled = 0
         for index, pick in enumerate(picks, start=1):
             _stop_if_asked(job)
@@ -354,10 +412,17 @@ def batch_crs_task(job, session_token, picks, is_lite):
             record = {'name': pick['def_name'], 'requested': len(pick['case_ids']),
                       'written': 0, 'failed': [], 'file': None, 'error': None}
             built.append(record)
+            # Carried alongside the record rather than inside it, because this
+            # holds whole parsed cases and the record is what the finish page
+            # renders.
+            entry = _retry_entry(pick['def_name'], pick['def_dob'],
+                                 pick.get('person'), pick['case_ids'], [], [])
+            retry_entries.append(entry)
 
             if not _reselect(job, client, pick):
                 pulled += len(pick['case_ids'])
                 record['failed'] = list(pick['case_ids'])
+                entry['failed'] = list(pick['case_ids'])
                 record['error'] = ("Iowa Courts would not answer this client's "
                                    "name a second time, so their cases could "
                                    "not be pulled. Search them on their own.")
@@ -367,6 +432,7 @@ def batch_crs_task(job, session_token, picks, is_lite):
                                         offset=pulled, total=total_cases)
             pulled += len(pick['case_ids'])
             record['failed'] = failed
+            entry['cases'], entry['failed'] = cases, list(failed)
             if not cases:
                 record['error'] = ("Iowa Courts would not give up any of this "
                                    "client's cases, so there is no workbook "
@@ -408,6 +474,7 @@ def batch_crs_task(job, session_token, picks, is_lite):
             "def_name": "a clinic list of %d client%s"
                         % (len(built), "" if len(built) == 1 else "s"),
             "done_url": "/batch-done/%s" % job.id,
+            "retry": _retry_payload('batch_crs', is_lite, retry_entries),
         }
         job.log("Done. %d of %d workbook%s built."
                 % (sum(1 for record in built if record['file']), len(built),
@@ -440,7 +507,14 @@ def _zip_workbooks(built, is_lite):
     return path
 
 
-def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
+def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
+             person=None):
+    """person is the search that produced these cases, carried for the retry.
+
+    Optional because a job that started before the search job recorded it has
+    none, and a run with no way back is still a run worth finishing. The finish
+    page just does not offer another go.
+    """
     client = icos_sessions.claim(session_token)
     if client is None:
         # Two ordinary things land here. Staff left the results page open past
@@ -478,6 +552,8 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
             "requested_cases": len(case_ids),
             "failed_cases": failed,
             "done_url": "/done/%s" % job.id,
+            "retry": _retry_payload('crs', is_lite, [
+                _retry_entry(def_name, def_dob, person, case_ids, cases, failed)]),
         }
 
         if failed:
@@ -494,6 +570,143 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite):
         return "/done/%s" % job.id
     finally:
         # The session was claimed, so nothing else will release it.
+        client.logoff()
+        alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
+
+
+def retry_task(job, username, password, payload):
+    """Another go at just the cases Iowa Courts would not give up.
+
+    Until this, a run that came back four cases short left staff two choices:
+    look those cases up on Iowa Courts by hand, or run the whole thing again
+    and spend another twenty minutes and another turn with the shared account
+    to re-pull sixty-three cases that already worked. Neither is a good day.
+    The July run that dropped sixty-three cases had no third option at all.
+
+    This signs in fresh, because the run that failed logged its session off on
+    the way out and that is the behaviour keeping the shared account usable. It
+    then does per client what the clinic list does: put that client's search
+    back in front of ICOS, pull only their failures, and write a workbook from
+    what came back plus what came back last time.
+
+    Every client of a clinic list is rebuilt, including the ones that had no
+    failures, so the retry produces one complete zip rather than a second
+    partial one to keep straight alongside the first.
+
+    A retry that still comes back short can itself be retried, because it
+    leaves the same thing behind that it was started from.
+    """
+    client = IcosClient(log=job.log, alert=alerts.emitter(job))
+    client.set_stop_check(lambda: job.cancelled)
+    entries = payload['clients']
+    is_lite = payload['is_lite']
+    total = sum(len(entry['failed']) for entry in entries)
+    try:
+        client.login(username, password)
+
+        built, rebuilt, pulled, recovered_total = [], [], 0, 0
+        for index, entry in enumerate(entries, start=1):
+            _stop_if_asked(job)
+            record = {'name': entry['def_name'],
+                      'requested': len(entry['case_ids']),
+                      'written': 0, 'failed': [], 'file': None, 'error': None}
+            built.append(record)
+
+            recovered, still_failed, reselect_failed = [], list(entry['failed']), False
+            if entry['failed']:
+                job.log("Client %d of %d: trying %d case%s again..."
+                        % (index, len(entries), len(entry['failed']),
+                           "" if len(entry['failed']) == 1 else "s"),
+                        count=pulled, total=total)
+                if _reselect(job, client, entry):
+                    recovered, still_failed = _pull_cases(
+                        job, client, entry['failed'], offset=pulled, total=total)
+                else:
+                    reselect_failed = True
+                pulled += len(entry['failed'])
+                recovered_total += len(recovered)
+
+            # Everything that has ever come back for this client, in the order
+            # it was asked for, so the rebuilt workbook is the whole summary
+            # and not a supplement to one.
+            cases = _merged_cases(entry, recovered)
+            record['failed'] = still_failed
+            rebuilt.append(_retry_entry(entry['def_name'], entry['def_dob'],
+                                        entry['person'], entry['case_ids'],
+                                        cases, still_failed))
+            if not cases:
+                record['error'] = (
+                    "Iowa Courts would not answer this client's name, so there "
+                    "is still no workbook for them."
+                    if reselect_failed else
+                    "Iowa Courts still would not give up any of this client's "
+                    "cases, so there is still no workbook for them.")
+                continue
+            try:
+                path, unknown = build_workbook(cases, entry['def_name'],
+                                               entry['def_dob'], is_lite)
+            except Exception as e:
+                print("Workbook failed on retry for client %d: %r" % (index, e),
+                      flush=True)
+                alerts.record(job.id[:8], job.kind, alerts.JOB_FAILED,
+                              progress=alerts.recent_progress(job),
+                              **{'note': "Rebuilding one client of %d on a "
+                                         "retry. The rest carried on."
+                                         % len(entries),
+                                 'traceback': alerts.safe_traceback(e)})
+                record['error'] = ("Napier could not rebuild this client's "
+                                   "workbook. The earlier one is still on the "
+                                   "run you started this from.")
+                continue
+            # Only the cases that came back this time. The rest were reported
+            # when they were first read, and telling somebody twice about a
+            # disposition they have already added to the map is how alerting
+            # stops being read.
+            fresh_ids = {case['id'] for case in recovered}
+            report_unknown_dispositions(job, {
+                wording: [case_id for case_id in case_ids if case_id in fresh_ids]
+                for wording, case_ids in unknown.items()
+                if any(case_id in fresh_ids for case_id in case_ids)})
+            record['written'] = len(cases)
+            record['file'] = path
+
+        if not any(record['file'] for record in built):
+            raise ValueError("no workbooks could be rebuilt")
+
+        still_missing = sum(len(record['failed']) for record in built)
+        job.log("Recovered %d of %d case%s. %s"
+                % (recovered_total, total, "" if total == 1 else "s",
+                   "Iowa Courts still would not give up %d." % still_missing
+                   if still_missing else "Nothing is missing now."))
+
+        after = _retry_payload(payload['kind'], is_lite, rebuilt)
+        if payload['kind'] == 'batch_crs':
+            job.result = {
+                "file": _zip_workbooks(built, is_lite),
+                "is_lite": is_lite,
+                "clients": built,
+                "written_cases": sum(record['written'] for record in built),
+                "requested_cases": sum(record['requested'] for record in built),
+                "def_name": "a clinic list of %d client%s"
+                            % (len(built), "" if len(built) == 1 else "s"),
+                "done_url": "/batch-done/%s" % job.id,
+                "retry": after,
+            }
+            return "/batch-done/%s" % job.id
+
+        record = built[0]
+        job.result = {
+            "file": record['file'],
+            "def_name": record['name'],
+            "is_lite": is_lite,
+            "written_cases": record['written'],
+            "requested_cases": record['requested'],
+            "failed_cases": record['failed'],
+            "done_url": "/done/%s" % job.id,
+            "retry": after,
+        }
+        return "/done/%s" % job.id
+    finally:
         client.logoff()
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 

--- a/templates/_retry.html
+++ b/templates/_retry.html
@@ -1,0 +1,95 @@
+{#
+  The offer to go back for the cases that did not come back.
+
+  Shared by both finish pages because the errand is the same one whether the run
+  was a single client or a clinic list, and the only thing it needs is a sign in.
+  It asks for one because the run this is started from logged its Iowa Courts
+  session off on the way out, which is what keeps the shared account usable by
+  anybody else.
+#}
+{% if can_retry and missing %}
+<style>
+.retry {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: .85rem 1rem;
+  margin-bottom: 1.3rem;
+}
+
+.retry summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.retry summary::-webkit-details-marker { display: none; }
+
+.retry summary::before {
+  content: "+";
+  display: inline-block;
+  width: 1.1rem;
+  font-weight: 700;
+  color: var(--brand-bright);
+}
+
+.retry[open] summary::before { content: "\2212"; }
+.retry[open] summary { margin-bottom: 1.1rem; }
+
+.retry-title { font-weight: 600; }
+
+.retry-note {
+  display: block;
+  margin-left: 1.1rem;
+  font-size: .84rem;
+  color: var(--ink-soft);
+}
+</style>
+
+<details class="retry"{% if error %} open{% endif %}>
+  <summary>
+    <span class="retry-title">
+      Try {{ "that case" if missing == 1 else "those %d cases" % missing }} again
+    </span>
+    <span class="retry-note">
+      Signs in to Iowa Courts again and asks for only
+      {{ "the one that" if missing == 1 else "the ones that" }} did not come
+      back. Everything already in the workbook stays in it.
+    </span>
+  </summary>
+
+  {# What went wrong is said at the top of the page, not down here, because a
+     retry that was refused before it started can also be one this block does
+     not render at all. #}
+  <form method="post" action="/retry/{{ job.id }}" id="retry-form">
+    <div class="row row-two">
+      <label>
+        <span class="field-label">User ID</span>
+        <input type="text" name="username" autocomplete="username"
+               autocapitalize="none" spellcheck="false" required>
+      </label>
+      <label>
+        <span class="field-label">Password</span>
+        <input type="password" name="password"
+               autocomplete="current-password" required>
+      </label>
+    </div>
+    <div class="actions" style="margin-top:1rem">
+      <button type="submit" class="btn btn-primary">
+        Try {{ "it" if missing == 1 else "them" }} again
+      </button>
+    </div>
+  </form>
+</details>
+
+<script>
+// The same saved user ID the start page offers, under the same key. Whether to
+// remember it was decided there; this only reads what that decision left.
+(function () {
+  var user = document.querySelector("#retry-form input[name='username']");
+  if (!user) { return; }
+  try {
+    var saved = window.localStorage.getItem("napier.userid");
+    if (saved) { user.value = saved; }
+  } catch (e) { /* private window. Typing it is not the end of the world. */ }
+})();
+</script>
+{% endif %}

--- a/templates/batch_done.html
+++ b/templates/batch_done.html
@@ -70,6 +70,11 @@
 <div class="card">
   <span class="done-mark" aria-hidden="true">&check;</span>
   <h1>The clinic list is built</h1>
+
+  {% if error %}
+    <div class="notice notice-stop" role="alert">{{ error }}</div>
+  {% endif %}
+
   <p class="lede">
     {{ built }} workbook{{ built | pluralize("","s") }} from
     {{ clients | length }} client{{ clients | length | pluralize("","s") }},
@@ -119,12 +124,15 @@
         {{ "has" if clients | length - built == 1 else "have" }} no workbook.
       </p>
       <p>
-        Look {{ "that one" if clients | length - built == 1 else "those" }} up
+        {% if can_retry %}Try them again below first, then look{% else %}Look{% endif %}
+        {{ "that one" if clients | length - built == 1 else "those" }} up
         by hand. A list that comes back short without saying so is worse than
         one that says so.
       </p>
     </div>
   {% endif %}
+
+  <div style="margin-top:1.2rem">{% include '_retry.html' %}</div>
 
   {% if limits %}
     <div class="notice" role="alert" style="margin-top:1.2rem">
@@ -147,13 +155,16 @@
   </p>
 </div>
 
-<iframe id="grab" title="download" hidden></iframe>
+{% if not error %}
+  <iframe id="grab" title="download" hidden></iframe>
 
-<script>
-// Into a hidden frame so this page stays on screen. What is on it, which
-// client came back short and which has no workbook at all, is the part that
-// matters after the file is saved.
-document.getElementById("grab").src = "/batch/" +
-  encodeURIComponent({{ job.id|tojson }}) + "/download";
-</script>
+  <script>
+  // Into a hidden frame so this page stays on screen. What is on it, which
+  // client came back short and which has no workbook at all, is the part that
+  // matters after the file is saved. Not on a rejected retry: nothing has been
+  // rebuilt, so there is nothing new to save.
+  document.getElementById("grab").src = "/batch/" +
+    encodeURIComponent({{ job.id|tojson }}) + "/download";
+  </script>
+{% endif %}
 {% endblock %}

--- a/templates/done.html
+++ b/templates/done.html
@@ -64,6 +64,10 @@
 <div class="card">
   <span class="done-mark" aria-hidden="true">&check;</span>
   <h1>The workbook is ready</h1>
+
+  {% if error %}
+    <div class="notice notice-stop" role="alert">{{ error }}</div>
+  {% endif %}
   <p class="lede">
     The download starts on its own. If your browser blocked it, use the button.
   </p>
@@ -87,15 +91,24 @@
       <p>
         Iowa Courts would not give {{ "it" if failed | length == 1 else "them" }}
         up, or the page could not be read. The other {{ written }} of
-        {{ requested }} are in the file. Look
-        {{ "this one" if failed | length == 1 else "these" }} up by hand before
-        you rely on the summary being complete.
+        {{ requested }} are in the file.
+        {% if can_retry %}
+          Try {{ "it" if failed | length == 1 else "them" }} again below first.
+          If Iowa Courts still will not answer, look
+          {{ "this one" if failed | length == 1 else "these" }} up by hand
+          before you rely on the summary being complete.
+        {% else %}
+          Look {{ "this one" if failed | length == 1 else "these" }} up by hand
+          before you rely on the summary being complete.
+        {% endif %}
       </p>
       <ul class="missing">
         {% for case_id in failed %}<li>{{ case_id }}</li>{% endfor %}
       </ul>
     </div>
   {% endif %}
+
+  {% include '_retry.html' %}
 
   {% if limits %}
     <div class="notice" role="alert">
@@ -126,12 +139,17 @@
   </p>
 </div>
 
-<iframe id="grab" title="download" hidden></iframe>
+{% if not error %}
+  <iframe id="grab" title="download" hidden></iframe>
 
-<script>
-// Fetching it into a hidden frame keeps this page on screen, so the missing
-// case list above stays readable instead of being replaced by a file save.
-document.getElementById("grab").src = "/job/" +
-  encodeURIComponent({{ job.id|tojson }}) + "/download";
-</script>
+  <script>
+  // Fetching it into a hidden frame keeps this page on screen, so the missing
+  // case list above stays readable instead of being replaced by a file save.
+  // Not on a rejected retry: that lands back here without the run having
+  // finished again, and saving the same file a second time is nobody's idea of
+  // an answer to being told the user ID was wrong.
+  document.getElementById("grab").src = "/job/" +
+    encodeURIComponent({{ job.id|tojson }}) + "/download";
+  </script>
+{% endif %}
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared setup for the whole suite.
+
+The account registry is module-level state, the way the job store and the
+session store are, and it is the only one of the three a test can leave dirty
+without noticing. A client that signs in and is then abandoned, which is most
+of the clients in these files, holds its entry until something logs it off. In
+the app that always happens, because every run logs off in a finally. Here it
+does not, and a leftover entry changes what the next test's sign in is told.
+
+So each test starts with an empty registry, and a test that wants an account
+held says so itself.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import accounts
+
+
+@pytest.fixture(autouse=True)
+def _empty_account_registry():
+    accounts._reset()
+    yield
+    accounts._reset()

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,327 @@
+"""Telling a staffer what is holding the account, instead of making them guess.
+
+Iowa Courts allows one session per ILA account and offers no force-logoff, so
+the second person to sign in on a shared login waits the lock out. Napier used
+to answer that with a shrug: an account is signed in somewhere else, try again
+in about fifteen minutes. Most of the time the somewhere else was Napier, in
+this process, on a run it had known the account of since it signed in.
+
+No client name appears here. An ESA user ID names an office, not a person, and
+the staffer being told already typed it.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import accounts
+import alerts
+import icos
+from icos import IcosAccountLocked, IcosClient
+from reader import OK, FetchResult
+
+LOGIN_OK = b"x" * 28000
+CONCURRENT_PAGE = b"<html>Concurrent Login Error: A user is already logged on</html>"
+
+
+class FakeReader:
+    """Just enough ESA to sign in and sign out."""
+
+    def __init__(self, script, logoff_raises=False):
+        self.script = list(script)
+        self.calls = []
+        self.logoff_raises = logoff_raises
+
+    def fetch_once(self, url, data=None, timeout=8):
+        name = url.rsplit("/", 1)[-1].split("?")[0]
+        self.calls.append(name)
+        if name == "EPALogout" and self.logoff_raises:
+            raise OSError("connection reset")
+        return self.script.pop(0) if self.script else FetchResult(OK, LOGIN_OK)
+
+    def init_request(self):
+        return "https://icos/ESAWebApp/ESALogin.jsp", None
+
+    def login_request(self, username, password):
+        return "https://icos/ESAWebApp/EUACustomLoginServlet", "userid=" + username
+
+    def logoff_request(self):
+        return "https://icos/ESAWebApp/EPALogout", "logoffButton=Logoff"
+
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+    def monotonic(self):
+        return self.now
+
+
+def build(script, logoff_raises=False, **kwargs):
+    clock = Clock()
+    messages = []
+    alerted = []
+    client = IcosClient(log=messages.append,
+                        reader=FakeReader(script, logoff_raises),
+                        sleep=clock.sleep, monotonic=clock.monotonic,
+                        alert=lambda failure, **fields: alerted.append((failure, fields)),
+                        concurrent_budget_seconds=kwargs.pop(
+                            'concurrent_budget_seconds', 16 * 60))
+    return client, messages, alerted
+
+
+def signed_in(username="ILA07"):
+    """A client holding the account, the way a live search job holds one."""
+    client, _, _ = build([FetchResult(OK, LOGIN_OK), FetchResult(OK, LOGIN_OK)])
+    client.login(username, "secret")
+    return client
+
+
+# -- the registry ---------------------------------------------------------
+
+class TestTheRegistry:
+    def test_an_account_nobody_holds_has_no_holder(self):
+        assert accounts.holder("ILA07") is None
+        assert accounts.describe("ILA07") is None
+
+    def test_a_held_account_reports_who_and_since_when(self):
+        accounts.hold("ILA07", now=1000.0)
+        entry = accounts.holder("ILA07", now=1360.0)
+        assert entry["account"] == "ILA07"
+        assert entry["seconds"] == 360.0
+
+    def test_releasing_gives_the_account_back(self):
+        handle = accounts.hold("ILA07")
+        accounts.release(handle)
+        assert accounts.holder("ILA07") is None
+
+    def test_releasing_twice_is_not_an_error(self):
+        """logoff runs in cleanup paths that can be reached more than once, and
+        an exception raised in one of those strands the ESA session."""
+        handle = accounts.hold("ILA07")
+        accounts.release(handle)
+        accounts.release(handle)
+        accounts.release(None)
+        assert accounts.holder("ILA07") is None
+
+    def test_one_run_letting_go_does_not_release_another(self):
+        """Two runs overlap on one account while the first logs off. Keyed by
+        account instead of by handle, the second run's entry disappears with
+        the first one's and the next staffer is told nothing has the account
+        while a run is still using it."""
+        first = accounts.hold("ILA07", now=1000.0)
+        accounts.hold("ILA07", now=1010.0)
+        accounts.release(first)
+        assert accounts.holder("ILA07") is not None
+
+    def test_the_oldest_run_is_the_one_named(self):
+        """The older session is the one ICOS actually let in. A newer entry is
+        somebody who has just been refused, and naming them sends the staffer
+        to a run that is not holding anything."""
+        accounts.hold("ILA07", now=2000.0)
+        accounts.hold("ILA07", now=1000.0)
+        assert accounts.holder("ILA07", now=2000.0)["seconds"] == 1000.0
+
+    def test_accounts_are_matched_however_they_were_typed(self):
+        accounts.hold(" ila07 ")
+        assert accounts.holder("ILA07") is not None
+
+    def test_a_different_account_is_not_a_collision(self):
+        accounts.hold("ILA07")
+        assert accounts.holder("ILA04") is None
+
+    def test_an_empty_user_id_never_matches(self):
+        """A client that never signed in has username None, and None matching
+        None would report every failed sign in as holding the account."""
+        accounts.hold("")
+        assert accounts.holder("") is None
+        assert accounts.holder(None) is None
+
+
+class TestHowLongItSays:
+    @pytest.mark.parametrize("seconds,expected", [
+        (0, "less than a minute ago"),
+        (59, "less than a minute ago"),
+        (60, "a minute ago"),
+        (119, "a minute ago"),
+        (360, "6 minutes ago"),
+        (3600, "1 hour ago"),
+        (9000, "2 hours ago"),
+    ])
+    def test_it_reads_like_a_sentence(self, seconds, expected):
+        assert accounts.describe_wait(seconds) == expected
+
+
+# -- the client ------------------------------------------------------------
+
+class TestSigningInTakesTheAccount:
+    def test_a_signed_in_run_holds_its_account(self):
+        signed_in("ILA07")
+        assert accounts.holder("ILA07") is not None
+
+    def test_signing_off_gives_it_back(self):
+        client = signed_in("ILA07")
+        client.logoff()
+        assert accounts.holder("ILA07") is None
+
+    def test_a_failed_sign_off_still_gives_it_back(self):
+        """ESA may well still be holding the session, but no Napier run is. The
+        entry exists to send the next staffer to a run they can go and stop,
+        and sending them to one that already ended is worse than saying
+        nothing."""
+        client, _, _ = build([FetchResult(OK, LOGIN_OK), FetchResult(OK, LOGIN_OK)],
+                             logoff_raises=True)
+        client.login("ILA07", "secret")
+        client.logoff()
+        assert accounts.holder("ILA07") is None
+
+    def test_a_refused_sign_in_takes_nothing(self):
+        """Registered only once ESA hands back the search screen. Point the
+        next staffer at a session that was never opened and they wait on
+        nothing."""
+        client, _, _ = build([FetchResult(OK, LOGIN_OK),
+                              FetchResult(OK, CONCURRENT_PAGE),
+                              FetchResult(OK, CONCURRENT_PAGE)],
+                             concurrent_budget_seconds=100)
+        with pytest.raises(IcosAccountLocked):
+            client.login("ILA07", "secret")
+        assert accounts.holder("ILA07") is None
+
+
+class TestWhatTheSecondStafferIsTold:
+    def test_the_collision_is_named_before_icos_is_even_asked(self):
+        """The point of the whole thing. The wait is already certain by the
+        time the account is held, so the sentence is worth more now than it is
+        seventy-five seconds into a sixteen minute wait."""
+        accounts.hold("ILA07", now=0.0)
+        client, messages, _ = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login("ILA07", "secret")
+
+        assert "already signed in to Iowa Courts as ILA07" in messages[1]
+        # Before the connection, not after ESA refuses: the first line is the
+        # connecting notice and this is the second thing said.
+        assert "Connecting" in messages[0]
+
+    def test_it_says_which_account_and_how_long(self):
+        import time
+        accounts.hold("ILA07", now=time.time() - 360)
+        client, messages, _ = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login("ILA07", "secret")
+        assert "ILA07" in messages[1]
+        assert "6 minutes ago" in messages[1]
+
+    def test_a_free_account_is_not_mentioned_at_all(self):
+        client, messages, _ = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login("ILA07", "secret")
+        assert not any("already signed in" in m for m in messages)
+
+    def test_somebody_elses_account_is_not_a_collision(self):
+        accounts.hold("ILA04")
+        client, messages, _ = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login("ILA07", "secret")
+        assert not any("already signed in" in m for m in messages)
+
+    def test_a_lock_napier_is_not_holding_says_so(self):
+        """The honest answer when the registry is empty. Somebody is signed in
+        to Iowa Courts outside Napier, or a restart lost the run, and neither
+        is something to invent a Napier run for."""
+        client, messages, _ = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, CONCURRENT_PAGE),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login("ILA07", "secret")
+
+        waiting = [m for m in messages if "already logged in" in m]
+        assert len(waiting) == 1
+        assert "not by Napier" in waiting[0]
+
+    def test_the_collision_is_not_read_out_twice(self):
+        """Named once before connecting, then ESA refuses and the wait starts.
+        Repeating the same paragraph reads as the page stuck, not as
+        progress."""
+        accounts.hold("ILA07", now=0.0)
+        client, messages, _ = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, CONCURRENT_PAGE),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login("ILA07", "secret")
+
+        assert sum("already signed in to Iowa Courts as" in m for m in messages) == 1
+        assert any("Waiting for that run to finish" in m for m in messages)
+
+
+class TestWhenTheWaitRunsOut:
+    def build_locked(self, hold_it):
+        # From empty, so calling this twice in one test does not have the first
+        # scenario's account still held during the second.
+        accounts._reset()
+        if hold_it:
+            accounts.hold("ILA07", now=0.0)
+        client, messages, alerted = build(
+            [FetchResult(OK, LOGIN_OK)] + [FetchResult(OK, CONCURRENT_PAGE)] * 100,
+            concurrent_budget_seconds=200)
+        with pytest.raises(IcosAccountLocked) as caught:
+            client.login("ILA07", "secret")
+        return caught.value, messages, alerted
+
+    def test_napiers_own_run_gets_advice_that_can_be_acted_on(self):
+        """There is a stop button on that run's progress page. Telling somebody
+        to come back in a few minutes when the answer is a colleague two desks
+        away is the whole gap this closes."""
+        error, _, _ = self.build_locked(hold_it=True)
+        assert "another Napier run" in error.message
+        assert "stop it" in error.message
+
+    def test_a_lock_from_outside_napier_keeps_the_old_advice(self):
+        error, _, _ = self.build_locked(hold_it=False)
+        assert "still logged in from another session" in error.message
+        assert "Napier" not in error.message
+
+    def test_the_alert_says_which_of_the_two_it_was(self):
+        _, _, ours = self.build_locked(hold_it=True)
+        _, _, theirs = self.build_locked(hold_it=False)
+
+        assert ours[-1][0] == alerts.CONCURRENT_EXHAUSTED
+        assert "Napier's own run" in ours[-1][1]['note']
+        assert "outside Napier" in theirs[-1][1]['note']
+
+    def test_an_account_taken_after_the_wait_began_is_still_named(self):
+        """Nothing held it when this sign in started, so there was nothing to
+        say up front. The holder is asked for again when the wait runs out
+        rather than reusing that answer, or a run that started in between is
+        invisible for the whole sixteen minutes and the advice at the end of it
+        is the wrong advice.
+        """
+        client, _, _ = build(
+            [FetchResult(OK, LOGIN_OK)] + [FetchResult(OK, CONCURRENT_PAGE)] * 100,
+            concurrent_budget_seconds=200)
+        original_sleep = client._sleep
+        taken = []
+
+        def take_the_account_mid_wait(seconds):
+            if not taken:
+                taken.append(accounts.hold("ILA07", now=0.0))
+            original_sleep(seconds)
+
+        client._sleep = take_the_account_mid_wait
+        with pytest.raises(IcosAccountLocked) as caught:
+            client.login("ILA07", "secret")
+
+        assert "another Napier run" in caught.value.message
+
+    def test_the_alert_still_names_the_family_and_not_the_account(self):
+        """Article 1.2 keeps credentials out of what Napier transmits. The
+        staffer on the page may be told ILA07 because they typed it; an inbox
+        is not the staffer."""
+        _, _, alerted = self.build_locked(hold_it=True)
+        fields = alerted[-1][1]
+        assert fields['account'] == 'ILA##'
+        assert 'ILA07' not in repr(fields)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,618 @@
+"""Going back for the cases Iowa Courts would not give up.
+
+A run that comes back four cases short used to leave two options: look those
+four up on Iowa Courts by hand, or run the whole thing again and spend another
+sign in and another twenty minutes re-pulling the sixty-three that worked. On a
+clinic list the second option also means re-queueing for the shared account
+while somebody else waits.
+
+So the finish page offers a third. Sign in again, ask for only what is missing,
+and rebuild the workbook from what came back plus what came back last time.
+
+The names here are invented and every case number is 00000-shaped. The
+repository is public and a real Iowa case number attached to a real name is a
+person.
+"""
+
+import os
+import sys
+import time
+import zipfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
+
+import app as app_module
+import icos_sessions
+import jobs
+import tasks
+from icos import IcosError
+
+DOE_CASES = ['00000 FECR000000', '00000 SRCR000000', '00000 SMCR000000']
+ROE_CASES = ['00000 CVCV000000']
+
+
+def results_for(surname, given, cases, dob="01/01/1900"):
+    rows = "".join(
+        '<tr><td>%s</td><td></td><td>STATE VS %s</td><td>%s, %s</td>'
+        '<td>%s</td><td>DEFENDANT</td></tr>' % (case, surname, surname, given, dob)
+        for case in cases)
+    return ("<html><table>"
+            "<tr><td>Case ID</td><td></td><td>Title</td><td>Name</td>"
+            "<td>DOB</td><td>Role</td></tr>%s</table></html>" % rows).encode()
+
+
+PEOPLE = {
+    'DOE': results_for('DOE', 'JANE', DOE_CASES),
+    'ROE': results_for('ROE', 'JOHN', ROE_CASES),
+}
+
+
+class FakeClient:
+    """Stands in for IcosClient, and lets a test change its mind mid-scenario.
+
+    fail_cases is on the class rather than the instance because the whole point
+    of these tests is a second run behaving differently from the first, and the
+    second run builds its own client.
+    """
+
+    instances = []
+    fail_cases = set()
+    fail_searches = set()   # surnames Iowa Courts will not answer for
+    login_error = None
+
+    def __init__(self, log=None, alert=None, **kwargs):
+        self.log = log or (lambda m, **kw: None)
+        self.alert = alert
+        self.should_stop = lambda: False
+        self.logged_in = False
+        self.logged_off = False
+        self.searched = []
+        self.cases = []
+        self.trace = []
+        FakeClient.instances.append(self)
+
+    def set_alert(self, alert):
+        self.alert = alert
+
+    def set_log(self, log):
+        self.log = log or (lambda m, **kw: None)
+
+    def set_stop_check(self, should_stop):
+        self.should_stop = should_stop or (lambda: False)
+
+    def login(self, username, password):
+        if FakeClient.login_error:
+            raise FakeClient.login_error
+        self.logged_in = True
+        self.log("Signed in to Iowa Courts Online.")
+
+    def search(self, first, middle, last):
+        self.searched.append((first, middle, last))
+        self.trace.append(('search', last.upper()))
+        if last.upper() in FakeClient.fail_searches:
+            raise IcosError("Iowa Courts did not answer.")
+        return PEOPLE.get(last.upper(), results_for(last.upper(), 'X', []))
+
+    def case_bundle(self, case_id):
+        self.cases.append(case_id)
+        self.trace.append(('case', case_id))
+        if case_id in FakeClient.fail_cases:
+            raise IcosError("Iowa Courts did not answer for this case.")
+        return b"<summary>", b"<charges>", b"<financials>"
+
+    def logoff(self):
+        self.logged_off = True
+        self.logged_in = False
+
+
+UNKNOWN = {}
+
+
+@pytest.fixture(autouse=True)
+def fake_icos(monkeypatch):
+    FakeClient.instances = []
+    FakeClient.fail_cases = set()
+    FakeClient.fail_searches = set()
+    FakeClient.login_error = None
+    UNKNOWN.clear()
+    monkeypatch.setattr(tasks, 'IcosClient', FakeClient)
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_summary',
+                        lambda html, case: case.update(county='DUBUQUE'))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_charges',
+                        lambda html, case: case.update(charges=[]))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
+                        lambda html, case: case.update(financials=[],
+                                                       total_due='$0.00'))
+    # Records what went into each workbook, which is the thing every test here
+    # is really asking about: did the rebuild keep what the first run got.
+    monkeypatch.setattr(tasks, 'build_workbook', _fake_build)
+    yield
+
+
+WRITTEN = []
+
+
+def _fake_build(cases, name, dob, lite):
+    WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases]})
+    path = os.path.join(tasks.tmp_dir,
+                        'test_retry_%s.xlsx' % name.split(',')[0].strip())
+    with open(path, 'wb') as f:
+        f.write(b'PK\x03\x04 stub workbook')
+    return path, dict(UNKNOWN)
+
+
+@pytest.fixture(autouse=True)
+def _empty_written():
+    WRITTEN[:] = []
+    yield
+    WRITTEN[:] = []
+
+
+@pytest.fixture
+def client():
+    app_module.app.config['TESTING'] = True
+    app_module.app.secret_key = 'test'
+    return app_module.app.test_client()
+
+
+def await_job(client, job_id, timeout=5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        state = client.get('/job/' + job_id).get_json()
+        if state['done']:
+            return state
+        time.sleep(0.01)
+    raise AssertionError("job never finished")
+
+
+def run_one(client, surname='Doe', given='Jane'):
+    """Search for one client and build their CRS. Returns the CRS job id."""
+    response = client.post('/search', data={
+        'username': 'ILATEST', 'password': 'secret',
+        'firstname': given, 'middlename': '', 'lastname': surname})
+    search_id = response.headers['Location'].rsplit('/', 1)[-1]
+    await_job(client, search_id)
+    client.get('/results/' + search_id)
+    result = jobs.get(search_id).result
+    response = client.post('/crs-job', json={'search_job_id': search_id,
+                                             'keys': result['keys']})
+    job_id = response.get_json()['job_id']
+    await_job(client, job_id)
+    return search_id, job_id
+
+
+def run_list(client, roster="Doe, Jane\nRoe, John"):
+    """Search a clinic list and build all of it. Returns the CRS job id."""
+    response = client.post('/batch', data={
+        'username': 'ILATEST', 'password': 'secret', 'roster': roster})
+    search_id = response.headers['Location'].rsplit('/', 1)[-1]
+    await_job(client, search_id)
+    client.get('/roster/' + search_id)
+    entries = jobs.get(search_id).result['clients']
+    picks = [{'client': index, 'keys': entry['keys']}
+             for index, entry in enumerate(entries) if entry['keys']]
+    response = client.post('/batch-crs', json={'search_job_id': search_id,
+                                               'picks': picks})
+    job_id = response.get_json()['job_id']
+    await_job(client, job_id)
+    return search_id, job_id
+
+
+def retry(client, job_id, username='ILATEST', password='secret', **extra):
+    form = {'username': username, 'password': password}
+    form.update(extra)
+    return client.post('/retry/' + job_id, data=form)
+
+
+def follow_retry(client, job_id, **kwargs):
+    """Post the retry form and wait for the run it starts. Returns the new job."""
+    response = retry(client, job_id, **kwargs)
+    assert response.status_code == 302, response.get_data(as_text=True)[:400]
+    new_id = response.headers['Location'].rsplit('/', 1)[-1]
+    return new_id, await_job(client, new_id)
+
+
+class TestWhatTheFinishPageOffers:
+    def test_a_short_run_offers_another_go(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        page = client.get('/done/' + job_id).get_data(as_text=True)
+        assert '/retry/' + job_id in page
+        assert 'Try that case again' in page
+
+    def test_a_complete_run_offers_nothing(self, client):
+        """Nothing failed, so there is nothing to go back for and no reason to
+        put a second sign in in front of somebody who is finished."""
+        _, job_id = run_one(client)
+        page = client.get('/done/' + job_id).get_data(as_text=True)
+        assert '/retry/' not in page
+
+    def test_a_short_clinic_list_offers_another_go(self, client):
+        FakeClient.fail_cases = {DOE_CASES[0], ROE_CASES[0]}
+        _, job_id = run_list(client)
+        page = client.get('/batch-done/' + job_id).get_data(as_text=True)
+        assert '/retry/' + job_id in page
+        assert 'Try those 2 cases again' in page
+
+    def test_a_run_with_no_way_back_to_icos_offers_nothing(self, client):
+        """A CRS job started before Napier kept the search terms cannot put the
+        search back in front of ICOS, and pulling cases without re-selecting is
+        how the wrong client's case ends up in somebody's workbook. So it says
+        nothing rather than offering a button that would do that."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        response = client.post('/search', data={
+            'username': 'ILATEST', 'password': 'secret',
+            'firstname': 'Jane', 'middlename': '', 'lastname': 'Doe'})
+        search_id = response.headers['Location'].rsplit('/', 1)[-1]
+        await_job(client, search_id)
+        client.get('/results/' + search_id)
+        result = jobs.get(search_id).result
+        result.pop('person')            # the older job shape
+        response = client.post('/crs-job', json={'search_job_id': search_id,
+                                                 'keys': result['keys']})
+        job_id = response.get_json()['job_id']
+        await_job(client, job_id)
+
+        assert jobs.get(job_id).result['retry'] is None
+        page = client.get('/done/' + job_id).get_data(as_text=True)
+        assert '/retry/' not in page
+        assert 'missing from this workbook' in page   # still says so
+
+    def test_the_case_data_it_carries_never_reaches_the_browser(self, client):
+        """The payload holds whole parsed cases and the client's search terms.
+        It lives in the dyno for the two hours the job does and goes no further:
+        to_dict leaves result alone, and the form posts a sign in and nothing
+        else."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        assert 'result' not in client.get('/job/' + job_id).get_json()
+        page = client.get('/done/' + job_id).get_data(as_text=True)
+        form = page[page.index('id="retry-form"'):]
+        assert 'hidden' not in form[:form.index('</form>')]
+        assert DOE_CASES[0] not in page      # the ones that worked
+
+
+class TestGoingBackForThem:
+    def test_the_missing_case_is_recovered_and_the_rest_are_not_re_pulled(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+
+        new_id, state = follow_retry(client, job_id)
+        assert state['status'] == 'done'
+        pulled = FakeClient.instances[-1].cases
+        assert pulled == [DOE_CASES[1]]
+        assert jobs.get(new_id).result['failed_cases'] == []
+
+    def test_the_recovered_case_goes_back_where_it_belongs(self, client):
+        """Appended to the end, a recovered case reads as the most recent one.
+        The workbook is ordered the way the search was."""
+        FakeClient.fail_cases = {DOE_CASES[0]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+        follow_retry(client, job_id)
+        assert WRITTEN[-1]['ids'] == DOE_CASES
+
+    def test_the_search_is_put_back_in_front_of_icos_first(self, client):
+        """ICOS decides which case a case request means from whatever it
+        answered last. Asking for a case without re-searching is how a stub
+        comes back with the right heading and none of the charges."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+        follow_retry(client, job_id)
+        assert FakeClient.instances[-1].trace == [
+            ('search', 'DOE'), ('case', DOE_CASES[1])]
+
+    def test_it_signs_in_and_signs_out_again(self, client):
+        """The run this is started from logged its session off on the way out,
+        which is what keeps the shared account usable, so a retry has to bring
+        its own. And has to give it back."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        before = len(FakeClient.instances)
+        FakeClient.fail_cases = set()
+        follow_retry(client, job_id)
+
+        fresh = FakeClient.instances[-1]
+        assert len(FakeClient.instances) == before + 1
+        assert fresh.logged_in is False and fresh.logged_off is True
+
+    def test_a_failed_sign_in_leaves_the_first_workbook_alone(self, client):
+        from icos import IcosBadCredentials
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        first = dict(jobs.get(job_id).result)
+
+        FakeClient.login_error = IcosBadCredentials(
+            "Iowa Courts Online did not accept that user ID or password.")
+        _, state = follow_retry(client, job_id)
+        assert state['status'] == 'failed'
+        assert 'did not accept' in state['error']
+        # Still downloadable, still saying what is missing.
+        assert jobs.get(job_id).result['failed_cases'] == first['failed_cases']
+        assert client.get('/job/%s/download' % job_id).status_code == 200
+
+    def test_a_retry_that_is_still_short_offers_another_go(self, client):
+        """Iowa Courts having a bad ten minutes is the ordinary case. Coming
+        back twice is not a reason to send somebody to the court website."""
+        FakeClient.fail_cases = {DOE_CASES[1], DOE_CASES[2]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = {DOE_CASES[2]}
+
+        new_id, _ = follow_retry(client, job_id)
+        result = jobs.get(new_id).result
+        assert result['failed_cases'] == [DOE_CASES[2]]
+        assert result['retry'] is not None
+        page = client.get('/done/' + new_id).get_data(as_text=True)
+        assert '/retry/' + new_id in page
+
+        # And the third go recovers it, on top of what the second one got.
+        FakeClient.fail_cases = set()
+        third_id, _ = follow_retry(client, new_id)
+        assert jobs.get(third_id).result['failed_cases'] == []
+        assert WRITTEN[-1]['ids'] == DOE_CASES
+
+    def test_a_name_icos_will_not_answer_keeps_what_was_already_pulled(self, client):
+        """The re-search failing is the one way a retry can come back with
+        nothing. The workbook it rebuilds still has to be the whole workbook."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+        FakeClient.fail_searches = {'DOE'}
+
+        new_id, state = follow_retry(client, job_id)
+        assert state['status'] == 'done'
+        result = jobs.get(new_id).result
+        assert result['failed_cases'] == [DOE_CASES[1]]
+        assert WRITTEN[-1]['ids'] == [DOE_CASES[0], DOE_CASES[2]]
+        assert result['written_cases'] == 2
+
+    def test_the_counts_on_the_finish_page_are_the_whole_workbook(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+        new_id, _ = follow_retry(client, job_id)
+
+        result = jobs.get(new_id).result
+        assert (result['written_cases'], result['requested_cases']) == (3, 3)
+        page = client.get('/done/' + new_id).get_data(as_text=True)
+        assert '3 cases' in page
+        assert 'missing from this workbook' not in page
+
+    def test_a_disposition_already_reported_is_not_reported_again(self, client):
+        """Every unknown disposition emails somebody, and the map is only
+        updated once. Telling them again about the same one on every rebuild is
+        how alerting stops being read."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        UNKNOWN.update({'HELD IN ABEYANCE': list(DOE_CASES)})
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+        new_id, state = follow_retry(client, job_id)
+
+        reported = [line for line in state['progress']
+                    if 'HELD IN ABEYANCE' in line]
+        assert len(reported) == 1
+        assert DOE_CASES[1] in reported[0]
+        assert DOE_CASES[0] not in reported[0]
+
+    def test_a_disposition_with_nothing_new_under_it_is_not_mentioned(
+            self, client, monkeypatch):
+        """Filtering the case numbers is not enough. A wording left holding an
+        empty list still reads out as "recorded X on 0 cases" and still emails,
+        which is the same nag with the evidence taken out of it."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        UNKNOWN.update({'HELD IN ABEYANCE': [DOE_CASES[0], DOE_CASES[2]]})
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+
+        sent = []
+        monkeypatch.setattr(tasks.alerts, 'record',
+                            lambda *a, **k: sent.append(k.get('disposition')))
+        _, state = follow_retry(client, job_id)
+        assert not any('HELD IN ABEYANCE' in line for line in state['progress'])
+        assert 'HELD IN ABEYANCE' not in sent
+
+
+class TestAWholeClinicList:
+    def test_one_zip_comes_back_with_every_client_in_it(self, client):
+        """Not a second partial zip to keep straight alongside the first. The
+        staffer asked for a clinic list, so a retry produces a clinic list."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_list(client)
+        FakeClient.fail_cases = set()
+        new_id, _ = follow_retry(client, job_id)
+
+        response = client.get('/batch/%s/download' % new_id)
+        assert response.status_code == 200
+        with open(jobs.get(new_id).result['file'], 'rb') as bundle:
+            names = zipfile.ZipFile(bundle).namelist()
+        assert len(names) == 2
+        assert any('DOE' in name for name in names)
+        assert any('ROE' in name for name in names)
+
+    def test_only_the_missing_cases_are_asked_for(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_list(client)
+        FakeClient.fail_cases = set()
+        follow_retry(client, job_id)
+
+        fresh = FakeClient.instances[-1]
+        assert fresh.cases == [DOE_CASES[1]]
+        # The client who had nothing missing is not re-searched either.
+        assert fresh.searched == [('Jane', '', 'Doe')]
+
+    def test_the_client_who_had_nothing_missing_keeps_their_workbook(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_list(client)
+        FakeClient.fail_cases = set()
+        new_id, _ = follow_retry(client, job_id)
+
+        clients = jobs.get(new_id).result['clients']
+        by_name = {record['name']: record for record in clients}
+        assert by_name['DOE, JANE']['written'] == 3
+        assert by_name['ROE, JOHN']['written'] == 1
+        assert all(record['file'] for record in clients)
+
+    def test_a_client_with_no_workbook_at_all_can_still_be_recovered(self, client):
+        """Every one of their cases failed, so the first run had no file for
+        them and said so. The retry has to be able to give them one."""
+        FakeClient.fail_cases = set(DOE_CASES)
+        _, job_id = run_list(client)
+        first = {record['name']: record
+                 for record in jobs.get(job_id).result['clients']}
+        assert first['DOE, JANE']['file'] is None
+
+        FakeClient.fail_cases = set()
+        new_id, _ = follow_retry(client, job_id)
+        after = {record['name']: record
+                 for record in jobs.get(new_id).result['clients']}
+        assert after['DOE, JANE']['written'] == 3
+        assert after['DOE, JANE']['file']
+
+
+class TestWhoCanAskForOne:
+    def test_a_job_this_browser_did_not_start_is_refused(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+
+        stranger = app_module.app.test_client()
+        response = stranger.post('/retry/' + job_id,
+                                 data={'username': 'ILATEST',
+                                       'password': 'secret'})
+        assert response.status_code == 200
+        assert 'Napier restarted' in response.get_data(as_text=True)
+        # Nothing was started on the strength of it.
+        assert all(not instance.logged_in
+                   for instance in FakeClient.instances[1:])
+
+    def test_a_user_id_that_is_not_iowa_legal_aid_is_turned_back(self, client):
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        before = len(FakeClient.instances)
+
+        response = retry(client, job_id, username='someone')
+        page = response.get_data(as_text=True)
+        assert 'not an Iowa Legal Aid' in page
+        assert len(FakeClient.instances) == before
+        # Back on the finish page with the offer still open, not on a dead end.
+        assert '/retry/' + job_id in page
+        assert '/job/%s/download' % job_id in page
+
+    def test_a_search_left_open_is_let_go_before_signing_in_again(self, client):
+        """Iowa Courts allows one session per account. A search still open in
+        another tab is holding the same one the retry is about to sign in on,
+        so leaving it be means the retry collides with the staffer's own
+        session and waits the concurrent-login budget out for nothing."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+
+        held = FakeClient()
+        with client.session_transaction() as browser:
+            browser['icos_token'] = icos_sessions.put(held)
+        follow_retry(client, job_id)
+        assert held.logged_off is True
+
+    def test_a_rebuild_that_produces_no_file_fails_rather_than_saying_nothing(
+            self, client, monkeypatch):
+        """A zip of nothing still downloads, and a finish page saying zero
+        workbooks reads like a run that was never going to work. The staffer
+        still has the first run, so the honest answer is that this one broke."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_list(client)
+        FakeClient.fail_cases = set()
+
+        def explode(*args, **kwargs):
+            raise RuntimeError("no space left on device")
+
+        monkeypatch.setattr(tasks, 'build_workbook', explode)
+        monkeypatch.setattr(tasks.alerts, 'record', lambda *a, **k: None)
+        _, state = follow_retry(client, job_id)
+        assert state['status'] == 'failed'
+        # And the run it was started from is still whole.
+        assert client.get('/batch/%s/download' % job_id).status_code == 200
+
+    def test_a_run_with_nothing_left_to_try_says_so(self, client):
+        _, job_id = run_one(client)
+        response = retry(client, job_id)
+        assert 'nothing on this run left to try again' in \
+            response.get_data(as_text=True)
+
+    def test_the_browser_cannot_name_the_cases_to_pull(self, client):
+        """What gets asked for comes off the run, not off the form. Otherwise
+        the form is a way to pull any case in Iowa on Napier's sign in."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        FakeClient.fail_cases = set()
+
+        follow_retry(client, job_id, case_ids='00000 FECR999999')
+        assert FakeClient.instances[-1].cases == [DOE_CASES[1]]
+
+    def test_a_rejected_retry_does_not_re_download_the_workbook(self, client):
+        """The finish page saves the file on its own when a run lands on it.
+        Reached by a refused form post, nothing has been rebuilt, and saving
+        the same file again is not an answer to being told the user ID is
+        wrong."""
+        FakeClient.fail_cases = {DOE_CASES[1]}
+        _, job_id = run_one(client)
+        response = retry(client, job_id, username='someone')
+        assert 'id="grab"' not in response.get_data(as_text=True)
+        assert 'id="grab"' in client.get('/done/' + job_id).get_data(as_text=True)
+
+
+class TestTheHelpersUnderneath:
+    def test_a_run_with_nothing_missing_has_no_payload(self):
+        entry = tasks._retry_entry('DOE, JANE', '01/01/1900',
+                                   {'first': 'Jane', 'middle': '', 'last': 'Doe'},
+                                   DOE_CASES, [], [])
+        assert tasks._retry_payload('crs', False, [entry]) is None
+
+    def test_a_missing_case_with_no_search_behind_it_has_no_payload(self):
+        entry = tasks._retry_entry('DOE, JANE', '01/01/1900', None,
+                                   DOE_CASES, [], [DOE_CASES[0]])
+        assert tasks._retry_payload('crs', False, [entry]) is None
+
+    def test_one_client_with_no_way_back_costs_the_whole_list_its_payload(self):
+        """Rebuilding a clinic list rebuilds all of it, so a client who cannot
+        be re-searched would come back with an empty workbook rather than the
+        one they already have."""
+        with_terms = tasks._retry_entry(
+            'DOE, JANE', '01/01/1900',
+            {'first': 'Jane', 'middle': '', 'last': 'Doe'},
+            DOE_CASES, [], [DOE_CASES[0]])
+        without = tasks._retry_entry('ROE, JOHN', '01/01/1900', None,
+                                     ROE_CASES, [], [ROE_CASES[0]])
+        assert tasks._retry_payload('batch_crs', False, [with_terms]) is not None
+        assert tasks._retry_payload('batch_crs', False,
+                                    [with_terms, without]) is None
+
+    def test_a_client_with_nothing_missing_does_not_block_the_payload(self):
+        """No failures means no re-search, so no search terms are needed."""
+        short = tasks._retry_entry(
+            'DOE, JANE', '01/01/1900',
+            {'first': 'Jane', 'middle': '', 'last': 'Doe'},
+            DOE_CASES, [], [DOE_CASES[0]])
+        complete = tasks._retry_entry('ROE, JOHN', '01/01/1900', None,
+                                      ROE_CASES, [{'id': ROE_CASES[0]}], [])
+        assert tasks._retry_payload('batch_crs', False,
+                                    [short, complete]) is not None
+
+    def test_merging_keeps_the_order_the_search_came_back_in(self):
+        entry = tasks._retry_entry('DOE, JANE', '01/01/1900', None, DOE_CASES,
+                                   [{'id': DOE_CASES[0]}, {'id': DOE_CASES[2]}],
+                                   [DOE_CASES[1]])
+        merged = tasks._merged_cases(entry, [{'id': DOE_CASES[1]}])
+        assert [case['id'] for case in merged] == DOE_CASES
+
+    def test_a_case_read_twice_is_only_in_the_workbook_once(self):
+        entry = tasks._retry_entry('DOE, JANE', '01/01/1900', None, DOE_CASES,
+                                   [{'id': DOE_CASES[0], 'county': 'OLD'}], [])
+        merged = tasks._merged_cases(entry, [{'id': DOE_CASES[0],
+                                              'county': 'NEW'}])
+        assert len(merged) == 1
+        # The newer read wins, because it is the one that just came off ICOS.
+        assert merged[0]['county'] == 'NEW'


### PR DESCRIPTION
Two things staff have been eating that Napier could just handle.

## Go back for the cases Iowa Courts would not give up

A run that comes back four cases short has had two ways forward: look those four up on Iowa Courts by hand, or run the whole thing again and spend another sign in and twenty minutes re-pulling the sixty-three that already worked. On a clinic list the second one also means re-queueing for the shared account while somebody else waits.

The finish page offers a third now. Sign in, ask ICOS for only what is missing, rebuild the workbook from what came back plus what came back last time. Still short? Retry the retry.

- Signs in fresh, because the run being retried logged its session off on the way out and that is what keeps the shared account usable. A search left open in another tab is let go first, or the retry collides with the staffer's own session.
- The search terms travel with the run, off the search job and never off the browser. ICOS keys case selection to the last search it answered, so the client has to be put back in front of it first. A run with no terms recorded offers nothing rather than a button that would pull without re-selecting.
- A clinic list rebuilds as a clinic list: one zip with all twenty clients, not a second partial one to keep straight.
- Recovered cases go back in their original position, merged by case number, so a case read twice is in the workbook once.
- A re-search that fails keeps everything the first run pulled.
- An unknown disposition already reported is not reported again.

The payload holds parsed cases and search terms. It stays in the dyno for the job's two hours: `to_dict` leaves `result` alone, the form posts a sign in and nothing else, and what gets pulled comes off the run rather than off the form.

## Say which run is holding the shared account

ICOS allows one session per account and has no force-logoff, so a colliding sign in waits it out. Staff waited blind: the page said the account was signed in somewhere else and could not say where, so the honest guess was fifteen minutes of nothing.

Most of the time the answer is Napier, and Napier has known which account each run holds since it signed in. Now it says so, before ICOS is even asked. When the wait runs out it distinguishes the two cases: another Napier run held it the whole time (two staff on one login, and whoever started it can stop it), or ESA never released it and somebody is signed in outside Napier. Alert mail still carries the account family only.

## Testing

575 pass, up from 512. Every new test checked against the code with its fix removed; twenty-two mutations across both commits, all caught.

Fixtures are invented names, `00000`-shaped case numbers, 1900 dates.