### PR TITLE
Stop the whole clinic list when Iowa Courts goes down, not each client

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -21,10 +21,54 @@ import icos_sessions
 import roster
 from icos import IcosClient, IcosError, IcosStopped, STOPPED_MESSAGE
 
-# One case ICOS will not hand over is a bad case. Several in a row is the site
-# being down, and there is no point walking the rest of the list to find that
-# out one four-minute budget at a time.
-CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 3
+# One case ICOS will not hand over is a bad case: sealed, or a page the parser
+# cannot read. Several in a row with nothing in between is the site being down,
+# and there is no point walking the rest of the list to find that out one
+# four-minute budget at a time. See Outage for why this is counted across the
+# whole run and why it is six.
+CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 6
+
+# Searches are counted on their own and stay at three. A name that will not
+# answer costs the 45 minute search budget rather than the four minute case
+# budget, so three of them is already most of an afternoon, and unanswered
+# names do not come in runs the way one client's sealed cases do.
+SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 3
+
+
+class Outage:
+    """How many cases in a row Iowa Courts has refused, counted across a run.
+
+    Reset by any case that comes back, so a run that is merely bumpy carries on
+    to the end and only an unbroken run of refusals stops it.
+
+    The count runs across the whole clinic list rather than per client. A per
+    client counter starts over at every name, so a site that is down costs
+    twenty clients times six cases times four minutes to discover twenty times
+    over, and the staffer watches it happen. Shared, the run stops once.
+
+    Six rather than three because three sealed cases in a row is something one
+    real client can have, and that client's bad luck should not end the list
+    for the nineteen names behind them. Six costs about twenty three minutes
+    during a real outage, which is the price of not throwing away good runs.
+    """
+
+    def __init__(self, threshold=CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE):
+        self.threshold = threshold
+        self.failures = 0
+
+    @property
+    def over(self):
+        return self.failures >= self.threshold
+
+    def worked(self):
+        """A case came back. Whatever came before it was not an outage."""
+        self.failures = 0
+
+    def failed(self):
+        """A case did not come back. True if that is now enough to stop."""
+        self.failures += 1
+        return self.over
+
 
 tmp_dir = '/tmp/'
 if platform.system() == 'Windows':
@@ -142,16 +186,20 @@ def _stop_if_asked(job):
         raise IcosStopped(STOPPED_MESSAGE)
 
 
-def _pull_cases(job, client, case_ids, offset=0, total=None):
+def _pull_cases(job, client, case_ids, offset=0, total=None, outage=None):
     """Fetch and parse a list of cases. Returns what was read and what was not.
 
     Shared by the single-client run and the clinic list, so a case that Iowa
     Courts will not give up costs the same thing either way. offset and total
     are for the progress bar when this is one client's slice of a longer run.
+
+    outage is the run's refusal count, passed in by a caller that has more than
+    one client to get through so the whole list stops together. A caller with
+    one client can leave it out and gets a counter of its own.
     """
     total = len(case_ids) if total is None else total
+    outage = Outage() if outage is None else outage
     cases, failed = [], []
-    failures_in_a_row = 0
     not_attempted = []
     for index, case_id in enumerate(case_ids, start=1):
         _stop_if_asked(job)
@@ -177,12 +225,11 @@ def _pull_cases(job, client, case_ids, offset=0, total=None):
                           case=case_id,
                           note="%s The run carried on without it." % e.message)
             failed.append(case_id)
-            failures_in_a_row += 1
-            if failures_in_a_row >= CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
+            if outage.failed():
                 not_attempted = case_ids[index:]
                 break
             continue
-        failures_in_a_row = 0
+        outage.worked()
         try:
             case_parser.parse_case_summary(summary, case)
             case_parser.parse_case_charges(charges, case)
@@ -309,7 +356,7 @@ def batch_search_task(job, username, password, people, rejected=()):
             except IcosError as e:
                 entry['error'] = e.message
                 failures_in_a_row += 1
-                if failures_in_a_row >= CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
+                if failures_in_a_row >= SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
                     for skipped in people[index:]:
                         clients.append({
                             'name': roster.describe(skipped), 'keys': [],
@@ -403,12 +450,19 @@ def batch_crs_task(job, session_token, picks, is_lite):
         built = []
         retry_entries = []
         pulled = 0
+        # One count for the whole list. Six cases refused in a row is Iowa
+        # Courts being down, and the nineteen names behind this one are not
+        # going to fare any better.
+        outage = Outage()
+        # The same news arriving by the other door, and it arrives first: a
+        # client's turn starts with the re-search, so a site that is properly
+        # down never lets the case count get going at all. Counted at three
+        # like the search task's own, and kept apart from the case count
+        # because the two budgets are nothing like each other.
+        dead_searches = Outage(threshold=SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE)
+        announced = False
         for index, pick in enumerate(picks, start=1):
             _stop_if_asked(job)
-            job.log("Client %d of %d: pulling %d case%s..."
-                    % (index, len(picks), len(pick['case_ids']),
-                       "" if len(pick['case_ids']) == 1 else "s"),
-                    count=pulled, total=total_cases)
             record = {'name': pick['def_name'], 'requested': len(pick['case_ids']),
                       'written': 0, 'failed': [], 'file': None, 'error': None}
             built.append(record)
@@ -419,7 +473,29 @@ def batch_crs_task(job, session_token, picks, is_lite):
                                  pick.get('person'), pick['case_ids'], [], [])
             retry_entries.append(entry)
 
+            # Before the re-search, not after it. A dead site would otherwise
+            # still be asked to answer every remaining name, and a search
+            # carries the 45 minute search budget, which is ten times what
+            # skipping the cases behind it just saved.
+            if outage.over or dead_searches.over:
+                if not announced:
+                    announced = True
+                    job.log("Iowa Courts stopped responding, so the rest of the "
+                            "list was not pulled.")
+                pulled += len(pick['case_ids'])
+                record['failed'] = list(pick['case_ids'])
+                entry['failed'] = list(pick['case_ids'])
+                record['error'] = ("Iowa Courts had stopped responding before "
+                                   "Napier reached this client, so their cases "
+                                   "were not pulled.")
+                continue
+
+            job.log("Client %d of %d: pulling %d case%s..."
+                    % (index, len(picks), len(pick['case_ids']),
+                       "" if len(pick['case_ids']) == 1 else "s"),
+                    count=pulled, total=total_cases)
             if not _reselect(job, client, pick):
+                dead_searches.failed()
                 pulled += len(pick['case_ids'])
                 record['failed'] = list(pick['case_ids'])
                 entry['failed'] = list(pick['case_ids'])
@@ -427,9 +503,11 @@ def batch_crs_task(job, session_token, picks, is_lite):
                                    "name a second time, so their cases could "
                                    "not be pulled. Search them on their own.")
                 continue
+            dead_searches.worked()
 
             cases, failed = _pull_cases(job, client, pick['case_ids'],
-                                        offset=pulled, total=total_cases)
+                                        offset=pulled, total=total_cases,
+                                        outage=outage)
             pulled += len(pick['case_ids'])
             record['failed'] = failed
             entry['cases'], entry['failed'] = cases, list(failed)
@@ -605,6 +683,13 @@ def retry_task(job, username, password, payload):
         client.login(username, password)
 
         built, rebuilt, pulled, recovered_total = [], [], 0, 0
+        # Shared for the same reason the clinic list shares one, and it matters
+        # more here: a retry is somebody's second try, and spending it walking
+        # a dead site client by client is how they stop bothering with the
+        # button at all.
+        outage = Outage()
+        dead_searches = Outage(threshold=SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE)
+        announced = False
         for index, entry in enumerate(entries, start=1):
             _stop_if_asked(job)
             record = {'name': entry['def_name'],
@@ -613,15 +698,28 @@ def retry_task(job, username, password, payload):
             built.append(record)
 
             recovered, still_failed, reselect_failed = [], list(entry['failed']), False
-            if entry['failed']:
+            skipped = False
+            if entry['failed'] and (outage.over or dead_searches.over):
+                # Their earlier cases are still rebuilt below. It is only the
+                # second attempt at the missing ones that is called off.
+                skipped = True
+                if not announced:
+                    announced = True
+                    job.log("Iowa Courts stopped responding, so the rest of "
+                            "the missing cases were not tried again.")
+                pulled += len(entry['failed'])
+            elif entry['failed']:
                 job.log("Client %d of %d: trying %d case%s again..."
                         % (index, len(entries), len(entry['failed']),
                            "" if len(entry['failed']) == 1 else "s"),
                         count=pulled, total=total)
                 if _reselect(job, client, entry):
+                    dead_searches.worked()
                     recovered, still_failed = _pull_cases(
-                        job, client, entry['failed'], offset=pulled, total=total)
+                        job, client, entry['failed'], offset=pulled,
+                        total=total, outage=outage)
                 else:
+                    dead_searches.failed()
                     reselect_failed = True
                 pulled += len(entry['failed'])
                 recovered_total += len(recovered)
@@ -635,12 +733,18 @@ def retry_task(job, username, password, payload):
                                         entry['person'], entry['case_ids'],
                                         cases, still_failed))
             if not cases:
-                record['error'] = (
-                    "Iowa Courts would not answer this client's name, so there "
-                    "is still no workbook for them."
-                    if reselect_failed else
-                    "Iowa Courts still would not give up any of this client's "
-                    "cases, so there is still no workbook for them.")
+                if skipped:
+                    record['error'] = ("Iowa Courts had stopped responding "
+                                       "before Napier reached this client, so "
+                                       "there is still no workbook for them.")
+                elif reselect_failed:
+                    record['error'] = ("Iowa Courts would not answer this "
+                                       "client's name, so there is still no "
+                                       "workbook for them.")
+                else:
+                    record['error'] = ("Iowa Courts still would not give up any "
+                                       "of this client's cases, so there is "
+                                       "still no workbook for them.")
                 continue
             try:
                 path, unknown = build_workbook(cases, entry['def_name'],

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -126,13 +126,24 @@ def test_failures_that_are_not_consecutive_are_not_an_outage(monkeypatch):
 
 
 def test_icos_going_down_mid_run_still_yields_the_cases_already_pulled(monkeypatch):
-    case_ids = ids(8)
+    case_ids = ids(11)
     job, stub, written = run(monkeypatch, case_ids, unavailable=case_ids[2:])
 
     assert written == case_ids[:2]          # the two that came back
-    assert stub.asked == case_ids[:5]       # stopped after three in a row
+    assert stub.asked == case_ids[:8]       # stopped after six in a row
     assert job.result['failed_cases'] == case_ids[2:]   # none quietly dropped
     assert any('stopped responding' in line['message'] for line in job.progress)
+
+
+def test_five_sealed_cases_in_a_row_do_not_end_a_run(monkeypatch):
+    """Five is under the cap, so the sixth case is still asked for. One client
+    with a bad patch in the middle of their record is not an outage, and the
+    old count of three was low enough to call it one."""
+    case_ids = ids(8)
+    _, stub, written = run(monkeypatch, case_ids, unavailable=case_ids[1:6])
+
+    assert stub.asked == case_ids
+    assert written == [case_ids[0], case_ids[6], case_ids[7]]
 
 
 def test_a_run_where_no_case_comes_back_still_fails(monkeypatch):

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -1,0 +1,461 @@
+"""When Iowa Courts goes down, the whole run stops, not each client in turn.
+
+The count of cases refused back to back used to be per client and per _pull_cases
+call, so a clinic list of twenty names discovered the site was down twenty
+separate times. Each discovery cost three cases at four minutes of retrying
+apiece, plus a re-search carrying the forty-five minute search budget, and the
+staffer watched it happen with nothing to show at the end.
+
+One count for the run fixes that: the first client's cases prove the site is
+gone and the rest of the list is marked and skipped without another request.
+The cap moved from three to six at the same time, because three sealed cases in
+a row is something a real client can have and losing nineteen other clients to
+one person's bad patch is the worse failure.
+
+Every name here is invented and every case number is 00000-shaped. This
+repository is public.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import icos_sessions
+import tasks
+from icos import IcosError, IcosUnavailable
+
+
+def ids(prefix, count):
+    return ['00000 %s00000%d' % (prefix, n) for n in range(1, count + 1)]
+
+
+class FakeJob:
+    kind = 'batch_crs'
+    cancelled = False
+
+    def __init__(self):
+        self.id = 'abcdef0123456789'
+        self.progress = []
+        self.result = None
+
+    def log(self, message, count=None, total=None):
+        self.progress.append(message)
+
+    def said(self, fragment):
+        return [line for line in self.progress if fragment in line]
+
+
+class StubClient:
+    """Answers searches and case requests, refusing whatever it was told to."""
+
+    logged_in = True
+
+    def __init__(self, dead_cases=(), dead_searches=()):
+        self.dead_cases = set(dead_cases)
+        self.dead_searches = set(dead_searches)
+        self.searched = []
+        self.asked = []
+
+    def set_alert(self, alert):
+        pass
+
+    def set_log(self, log):
+        pass
+
+    def set_stop_check(self, should_stop):
+        pass
+
+    def login(self, username, password):
+        pass
+
+    def search(self, first, middle, last):
+        self.searched.append(last)
+        if last in self.dead_searches:
+            raise IcosError("Iowa Courts did not answer.")
+        return b'<results>'
+
+    def case_bundle(self, case_id):
+        self.asked.append(case_id)
+        if case_id in self.dead_cases:
+            raise IcosUnavailable("Iowa Courts Online did not return this case "
+                                  "after 4 minutes of retrying")
+        return b'<summary>', b'<charges>', b'<financials>'
+
+    def logoff(self):
+        pass
+
+
+WRITTEN = []
+
+
+def _fake_build(cases, name, dob, lite):
+    WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases]})
+    path = os.path.join(tasks.tmp_dir, 'test_outage.xlsx')
+    with open(path, 'wb') as handle:
+        handle.write(b'PK\x03\x04 stub workbook')
+    return path, {}
+
+
+@pytest.fixture(autouse=True)
+def quiet(monkeypatch):
+    WRITTEN[:] = []
+    monkeypatch.setattr(tasks.alerts, 'record', lambda *a, **k: None)
+    monkeypatch.setattr(tasks.alerts, 'digest', lambda *a, **k: None)
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_summary',
+                        lambda body, case: case.update(county='DUBUQUE'))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_charges',
+                        lambda body, case: case.update(charges=[]))
+    monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
+                        lambda body, case: case.update(financials=[],
+                                                       total_due='$0.00'))
+    monkeypatch.setattr(tasks, 'build_workbook', _fake_build)
+    yield
+    WRITTEN[:] = []
+
+
+def person(surname):
+    return {'first': 'PAT', 'middle': '', 'last': surname}
+
+
+def pick(surname, case_ids):
+    return {'def_name': '%s, PAT Q' % surname, 'def_dob': '01/01/1900',
+            'person': person(surname), 'case_ids': list(case_ids)}
+
+
+def run_list(monkeypatch, picks, dead_cases=(), dead_searches=()):
+    stub = StubClient(dead_cases, dead_searches)
+    monkeypatch.setattr(icos_sessions, 'claim', lambda token: stub)
+    job = FakeJob()
+    try:
+        tasks.batch_crs_task(job, 'tok', picks, False)
+    except ValueError:
+        pass
+    return job, stub
+
+
+def run_retry(monkeypatch, entries, dead_cases=(), dead_searches=()):
+    stub = StubClient(dead_cases, dead_searches)
+    monkeypatch.setattr(tasks, 'IcosClient',
+                        lambda log=None, alert=None, **kw: stub)
+    job = FakeJob()
+    payload = {'kind': 'batch_crs', 'is_lite': False, 'clients': entries}
+    try:
+        tasks.retry_task(job, 'ILATEST', 'secret', payload)
+    except ValueError:
+        pass
+    return job, stub
+
+
+class TestTheCounterItself:
+
+    def test_a_fresh_one_is_not_an_outage(self):
+        assert not tasks.Outage().over
+
+    def test_it_trips_on_the_last_of_its_threshold_and_not_before(self):
+        outage = tasks.Outage(threshold=3)
+        assert outage.failed() is False
+        assert outage.failed() is False
+        assert outage.failed() is True
+        assert outage.over
+
+    def test_one_case_coming_back_clears_what_came_before(self):
+        outage = tasks.Outage(threshold=3)
+        outage.failed()
+        outage.failed()
+        outage.worked()
+        assert outage.failed() is False
+        assert not outage.over
+
+    def test_the_default_is_six(self):
+        """Named here because moving it is a decision about how long staff
+        watch a dead site, not a tuning knob."""
+        assert tasks.Outage().threshold == 6
+        assert tasks.CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE == 6
+
+
+class TestAClinicListMeetingADeadSite:
+
+    def test_the_rest_of_the_list_is_not_pulled(self, monkeypatch):
+        first = ids('FECR', 6)
+        rest = [pick('ROE', ids('SRCR', 4)), pick('POE', ids('SMCR', 4))]
+        job, stub = run_list(monkeypatch, [pick('DOE', first)] + rest,
+                             dead_cases=first + ids('SRCR', 4) + ids('SMCR', 4))
+
+        # Six refusals on the first client is the whole budget, so nobody
+        # behind them is asked for at all.
+        assert stub.asked == first
+        assert job.said('stopped responding')
+
+    def test_the_rest_of_the_list_is_not_searched_either(self, monkeypatch):
+        """The re-search is the expensive part. It carries the 45 minute search
+        budget, so skipping the cases while still asking ICOS for every
+        remaining name would give back none of what this saves."""
+        first = ids('FECR', 6)
+        job, stub = run_list(monkeypatch,
+                             [pick('DOE', first), pick('ROE', ids('SRCR', 4))],
+                             dead_cases=first)
+
+        assert stub.searched == ['DOE']
+
+    def test_the_skipped_clients_are_named_as_missing(self, monkeypatch):
+        """The finish page lists every case that is not in the workbook. A
+        client nobody got as far as has all of theirs missing, and saying so is
+        the difference between a short list and a short list that says so."""
+        first = ids('FECR', 8)
+        later = ids('SRCR', 4)
+        job, _ = run_list(monkeypatch,
+                          [pick('DOE', first), pick('ROE', later)],
+                          dead_cases=first[2:])
+
+        assert job.result is not None
+        skipped = job.result['clients'][1]
+        assert skipped['failed'] == later
+        assert skipped['written'] == 0
+        assert 'stopped responding' in skipped['error']
+
+    def test_a_client_who_came_back_is_still_built(self, monkeypatch):
+        """The list stopping is not the list being thrown away."""
+        good = ids('FECR', 2)
+        dead = ids('SRCR', 6)
+        job, _ = run_list(monkeypatch,
+                          [pick('DOE', good), pick('ROE', dead),
+                           pick('POE', ids('SMCR', 3))],
+                          dead_cases=dead)
+
+        assert [entry['ids'] for entry in WRITTEN] == [good]
+        assert job.result['clients'][0]['written'] == 2
+
+    def test_what_was_skipped_can_be_tried_again(self, monkeypatch):
+        """A skipped client is a client with failures, which is what the retry
+        button reads. Marking them as skipped without that would leave staff
+        the hand lookup this whole feature exists to avoid."""
+        good = ids('FECR', 2)
+        dead = ids('SRCR', 6)
+        later = ids('SMCR', 3)
+        job, _ = run_list(monkeypatch,
+                          [pick('DOE', good), pick('ROE', dead),
+                           pick('POE', later)],
+                          dead_cases=dead)
+
+        payload = job.result['retry']
+        assert payload is not None
+        missing = {entry['def_name']: entry['failed']
+                   for entry in payload['clients']}
+        assert missing['ROE, PAT Q'] == dead
+        assert missing['POE, PAT Q'] == later
+
+    def test_the_list_is_told_once_and_not_per_client(self, monkeypatch):
+        dead = ids('FECR', 6)
+        job, _ = run_list(monkeypatch,
+                          [pick('DOE', dead), pick('ROE', ids('SRCR', 2)),
+                           pick('POE', ids('SMCR', 2)),
+                           pick('MOE', ids('CVCV', 2))],
+                          dead_cases=dead)
+
+        assert len(job.said('rest of the list')) == 1
+
+    def test_a_bumpy_list_still_finishes(self, monkeypatch):
+        """Two refusals apiece across four clients is eight failures and no
+        outage, because none of them ran six deep with nothing in between.
+        Under a per client count this was already true; under a shared one it
+        has to stay true, or every long list ends early."""
+        picks, dead = [], []
+        for surname, prefix in [('DOE', 'FECR'), ('ROE', 'SRCR'),
+                                ('POE', 'SMCR'), ('MOE', 'CVCV')]:
+            case_ids = ids(prefix, 4)
+            dead.extend(case_ids[:2])
+            picks.append(pick(surname, case_ids))
+        job, stub = run_list(monkeypatch, picks, dead_cases=dead)
+
+        assert stub.searched == ['DOE', 'ROE', 'POE', 'MOE']
+        assert len(stub.asked) == 16
+        assert len(WRITTEN) == 4
+
+    def test_refusals_carry_across_the_boundary_between_clients(self, monkeypatch):
+        """Three dead at the end of one client and three at the start of the
+        next is six in a row. A per client count never sees it; that is the
+        whole reason this moved."""
+        doe = ids('FECR', 4)
+        roe = ids('SRCR', 4)
+        poe = ids('SMCR', 3)
+        job, stub = run_list(
+            monkeypatch,
+            [pick('DOE', doe), pick('ROE', roe), pick('POE', poe)],
+            dead_cases=doe[1:] + roe[:3])
+
+        # DOE's first case came back and cleared the count. The three after it
+        # plus ROE's first three make six, so ROE's fourth is never asked for
+        # and POE is not searched.
+        assert stub.asked == doe + roe[:3]
+        assert stub.searched == ['DOE', 'ROE']
+
+
+class TestTheDoorTheOutageComesInFirst:
+    """A client's turn on a clinic list starts with the re-search.
+
+    So a site that is properly down refuses the re-search before it ever gets
+    asked for a case, and a count of refused cases alone never gets going. The
+    run then spends the 45 minute search budget on every remaining name, which
+    is the exact bill the case count exists to stop.
+    """
+
+    def test_three_names_refused_in_a_row_ends_the_list(self, monkeypatch):
+        good = ids('FECR', 2)
+        picks = [pick('DOE', good)] + [pick(surname, ids(prefix, 3))
+                                       for surname, prefix
+                                       in [('ROE', 'SRCR'), ('POE', 'SMCR'),
+                                           ('MOE', 'CVCV'), ('NOE', 'AGCR'),
+                                           ('LOE', 'OWCR')]]
+        job, stub = run_list(monkeypatch, picks,
+                             dead_searches=['ROE', 'POE', 'MOE', 'NOE', 'LOE'])
+
+        assert stub.searched == ['DOE', 'ROE', 'POE', 'MOE']
+        assert job.said('rest of the list was not pulled')
+
+    def test_a_name_answering_in_between_clears_the_count(self, monkeypatch):
+        """Two names Iowa Courts will not answer either side of one it will is
+        not an outage. It is what a clinic list has always looked like."""
+        picks = [pick(surname, ids(prefix, 2)) for surname, prefix
+                 in [('DOE', 'FECR'), ('ROE', 'SRCR'), ('POE', 'SMCR'),
+                     ('MOE', 'CVCV'), ('NOE', 'AGCR')]]
+        job, stub = run_list(monkeypatch, picks,
+                             dead_searches=['DOE', 'ROE', 'MOE', 'NOE'])
+
+        assert stub.searched == ['DOE', 'ROE', 'POE', 'MOE', 'NOE']
+        assert not job.said('rest of the list was not pulled')
+
+    def retry_entries(self, surnames):
+        entries = []
+        for surname, prefix in surnames:
+            case_ids = ids(prefix, 2)
+            entries.append(tasks._retry_entry(
+                '%s, PAT Q' % surname, '01/01/1900', person(surname),
+                case_ids, [{'id': case_ids[0]}], case_ids[1:]))
+        return entries
+
+    def test_a_retry_stops_on_them_too(self, monkeypatch):
+        entries = self.retry_entries([('DOE', 'FECR'), ('ROE', 'SRCR'),
+                                      ('POE', 'SMCR'), ('MOE', 'CVCV'),
+                                      ('NOE', 'AGCR')])
+        job, stub = run_retry(monkeypatch, entries,
+                              dead_searches=['DOE', 'ROE', 'POE', 'MOE', 'NOE'])
+
+        assert stub.searched == ['DOE', 'ROE', 'POE']
+        assert job.said('not tried again')
+
+    def test_a_retry_clears_the_count_on_a_name_that_answers(self, monkeypatch):
+        """Same rule as the first run. A retry is often started because Iowa
+        Courts was flaky, so names that answer in between are the normal case
+        and must not be spent toward the cap."""
+        entries = self.retry_entries([('DOE', 'FECR'), ('ROE', 'SRCR'),
+                                      ('POE', 'SMCR'), ('MOE', 'CVCV'),
+                                      ('NOE', 'AGCR'), ('LOE', 'OWCR')])
+        job, stub = run_retry(monkeypatch, entries,
+                              dead_searches=['DOE', 'POE', 'MOE', 'NOE', 'LOE'])
+
+        # ROE answering puts the count back to nought, so POE, MOE and NOE are
+        # the three in a row and NOE is still reached.
+        assert stub.searched == ['DOE', 'ROE', 'POE', 'MOE', 'NOE']
+        assert job.said('not tried again')
+
+
+class TestTheSearchSideCount:
+    """Names are counted on their own and still stop at three.
+
+    A name Iowa Courts will not answer costs the 45 minute search budget rather
+    than a case's four minutes, so three of them is already most of an
+    afternoon. They also do not come in runs the way one client's sealed cases
+    do, which is the reason cases moved to six and this did not.
+    """
+
+    def run_search(self, monkeypatch, people, dead_searches=()):
+        stub = StubClient(dead_searches=dead_searches)
+        monkeypatch.setattr(tasks, 'IcosClient',
+                            lambda log=None, alert=None, **kw: stub)
+        monkeypatch.setattr(tasks.icos_sessions, 'put', lambda client: 'tok')
+        monkeypatch.setattr(tasks.case_parser, 'parse_search',
+                            lambda body: ([], False))
+        job = FakeJob()
+        tasks.batch_search_task(job, 'ILATEST', 'secret', people)
+        return job, stub
+
+    def test_three_names_in_a_row_ends_the_list(self, monkeypatch):
+        names = ['DOE', 'ROE', 'POE', 'MOE', 'NOE']
+        job, stub = self.run_search(monkeypatch, [person(n) for n in names],
+                                    dead_searches=names)
+
+        assert stub.searched == names[:3]
+        assert job.said('rest of the list was not searched')
+
+    def test_two_names_in_a_row_does_not(self, monkeypatch):
+        names = ['DOE', 'ROE', 'POE', 'MOE']
+        job, stub = self.run_search(monkeypatch, [person(n) for n in names],
+                                    dead_searches=names[:2])
+
+        assert stub.searched == names
+        assert not job.said('rest of the list was not searched')
+
+    def test_the_two_counts_are_separate_numbers(self, monkeypatch):
+        assert (tasks.SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE
+                != tasks.CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE)
+        assert tasks.SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE == 3
+
+
+class TestARetryMeetingADeadSite:
+
+    def entries(self):
+        doe, roe, poe = ids('FECR', 8), ids('SRCR', 4), ids('SMCR', 4)
+        return [
+            tasks._retry_entry('DOE, PAT Q', '01/01/1900', person('DOE'),
+                               doe, [{'id': doe[0]}], doe[1:]),
+            tasks._retry_entry('ROE, PAT Q', '01/01/1900', person('ROE'),
+                               roe, [], roe),
+            tasks._retry_entry('POE, PAT Q', '01/01/1900', person('POE'),
+                               poe, [], poe),
+        ]
+
+    def test_the_rest_of_the_missing_cases_are_left_alone(self, monkeypatch):
+        entries = self.entries()
+        dead = entries[0]['failed'] + entries[1]['failed'] + entries[2]['failed']
+        job, stub = run_retry(monkeypatch, entries, dead_cases=dead)
+
+        assert stub.asked == entries[0]['failed'][:6]
+        assert stub.searched == ['DOE']
+        assert job.said('not tried again')
+
+    def test_what_the_first_run_got_is_still_rebuilt(self, monkeypatch):
+        """A retry that meets a dead site must still hand back the workbook the
+        first run earned. Otherwise pressing the button is a way to lose work."""
+        entries = self.entries()
+        dead = entries[0]['failed'] + entries[1]['failed'] + entries[2]['failed']
+        job, _ = run_retry(monkeypatch, entries, dead_cases=dead)
+
+        assert [entry['ids'] for entry in WRITTEN] == [[entries[0]['case_ids'][0]]]
+
+    def test_the_skipped_ones_are_still_offered_a_third_go(self, monkeypatch):
+        entries = self.entries()
+        dead = entries[0]['failed'] + entries[1]['failed'] + entries[2]['failed']
+        job, _ = run_retry(monkeypatch, entries, dead_cases=dead)
+
+        missing = {entry['def_name']: entry['failed']
+                   for entry in job.result['retry']['clients']}
+        assert missing['ROE, PAT Q'] == entries[1]['case_ids']
+        assert missing['POE, PAT Q'] == entries[2]['case_ids']
+
+    def test_a_client_skipped_with_nothing_saved_says_why(self, monkeypatch):
+        entries = self.entries()
+        dead = entries[0]['failed'] + entries[1]['failed'] + entries[2]['failed']
+        job, _ = run_retry(monkeypatch, entries, dead_cases=dead)
+
+        assert 'stopped responding' in job.result['clients'][1]['error']
+
+    def test_a_retry_that_works_is_not_stopped(self, monkeypatch):
+        entries = self.entries()
+        job, stub = run_retry(monkeypatch, entries)
+
+        assert stub.searched == ['DOE', 'ROE', 'POE']
+        assert len(WRITTEN) == 3
+        assert not job.said('not tried again')


### PR DESCRIPTION
## What this changes

Refused cases were counted per client and per pull, so a clinic list of twenty names discovered the site was down twenty separate times. Each discovery cost three cases at four minutes of retrying apiece, plus a re-search carrying the forty-five minute search budget.

One count now runs across the whole run. The first client's cases prove the site is gone and the rest of the list is marked and skipped without another request.

The cap moved from 3 to 6. Three sealed cases back to back is something one real client can have, and losing nineteen other clients to one person's bad patch is the worse failure. Six costs about twenty three minutes during a real outage.

Because the count is shared, it also runs across the boundary between clients. Three dead at the end of one name and three at the start of the next is six in a row, which a per client counter could never see.

## Two things that fell out of it

**Searches are counted separately and stay at 3.** They were sharing the case constant and would have quietly become six. A name that will not answer costs the search budget, not a case budget, so three is already most of an afternoon.

**The check sits before the re-search, not after.** That is the door an outage actually comes in by: a client's turn starts with putting their search back in front of ICOS, so a site that is properly down refuses there and the case count never gets going. Three refused re-searches in a row now ends the list too, counted apart from the cases for the same budget reason. Without this, the case cap was toothless in the exact scenario it exists for.

## What a skipped client gets

All of their cases recorded as missing, so the finish page names them and the retry button offers them. Skipping is not dropping. Everything the run did get is still built and still downloaded.

The retry path gets the same treatment. A retry is somebody's second try, and spending it walking a dead site client by client is how people stop pressing the button.

## Verification

- 600 tests pass, up from 575. 24 of the new ones are in `tests/test_outage.py`.
- 22 mutations run against the new code, all 22 caught. The one that got through on the first pass (removing the re-search reset in the retry loop) is now covered by `test_a_retry_clears_the_count_on_a_name_that_answers`.
- Fixtures are `00000`-shaped case numbers, invented surnames, 1900 dates of birth. Nothing real in a public repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t