### PR TITLE
Tell staff how much longer the run has

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -36,6 +36,16 @@ UNCOLLECTED_AFTER = 5 * 60
 # until a staffer has actually taken the file.
 BUILDS_A_WORKBOOK = ('crs', 'batch_crs')
 
+# How many finished units of work are timed to work out how much longer a run
+# has. Kept short so the estimate follows the site Napier is talking to now
+# rather than the one it was talking to ten minutes ago.
+UNITS_TIMED = 20
+
+# And how many of those it takes before saying anything. Two cases is not a
+# rate, and an estimate that lands wrong the first time staff see one teaches
+# them to ignore every one after it.
+UNITS_BEFORE_GUESSING = 3
+
 
 class Job:
     def __init__(self, kind):
@@ -51,6 +61,11 @@ class Job:
         # the page shows an unmeasured bar instead of inventing a number.
         self.count = None
         self.total = None
+        # When each of the last few units of work finished, oldest first. The
+        # page turns these into "about two minutes left", which is the question
+        # staff are actually asking when they watch a bar crawl: whether to wait
+        # or to go and do something else.
+        self.marks = []
         self.created_at = time.time()
         self.updated_at = self.created_at
         # Whether the file this job built ever reached the person who asked for
@@ -77,15 +92,48 @@ class Job:
 
     def log(self, message, count=None, total=None):
         with self._lock:
-            self.progress.append({"t": time.time(), "message": message})
+            now = time.time()
+            self.progress.append({"t": now, "message": message})
             if total is not None:
+                if count != self.count:
+                    self.marks = (self.marks + [now])[-UNITS_TIMED:]
                 self.count = count
                 self.total = total
-            self.updated_at = time.time()
+            self.updated_at = now
         print("JOB %s %s: %s" % (self.kind, self.id[:8], message), flush=True)
+
+    def _seconds_left(self):
+        """How much longer this has, or None when there is nothing honest to say.
+
+        Caller holds the lock.
+
+        The typical case is the middle one rather than the average, because a
+        single case that Iowa Courts stalls on for four minutes would otherwise
+        rewrite the estimate for the sixty behind it and leave staff reading
+        "about 45 minutes left" on a run that has two minutes to go.
+
+        Which leaves the stall itself unaccounted for, and a bar that has not
+        moved in three minutes under an estimate that has not moved either is
+        the page calling itself a liar. So whatever the case in hand has already
+        overrun by is added on. During a stall the estimate climbs, which is
+        both true and the thing worth knowing, and it drops back the moment the
+        case comes through instead of poisoning the rest of the run.
+        """
+        if not self.total or self.count is None:
+            return None
+        remaining = self.total - self.count
+        if remaining <= 0:
+            return None
+        gaps = sorted(b - a for a, b in zip(self.marks, self.marks[1:]))
+        if len(gaps) < UNITS_BEFORE_GUESSING:
+            return None
+        typical = gaps[len(gaps) // 2]
+        overrun = max(0.0, (time.time() - self.marks[-1]) - typical)
+        return typical * remaining + overrun
 
     def to_dict(self):
         with self._lock:
+            seconds_left = self._seconds_left()
             return {
                 "id": self.id,
                 "kind": self.kind,
@@ -95,6 +143,7 @@ class Job:
                 "error": self.error,
                 "count": self.count,
                 "total": self.total,
+                "seconds_left": None if seconds_left is None else round(seconds_left),
                 "next_url": self.next_url,
                 "cancelled": self.cancelled,
                 "done": self.status in (DONE, FAILED),

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -143,6 +143,20 @@ var GIVE_UP_AFTER = 12;
 var waiting = false;
 var next = null;
 var lostSince = null;
+// Whatever the server last said was left. Deliberately not counted down here
+// between polls: the number staff need is whether to wait or go and do
+// something else, and a stopwatch running against a court website that stalls
+// would be wrong in the one direction that matters.
+var secondsLeft = null;
+
+// Rounded hard on purpose. Napier knows this to the second and saying so would
+// be claiming to know what Iowa Courts is about to do.
+function leftText(secs) {
+  if (secs === null || secs === undefined) { return ""; }
+  if (secs < 45) { return ", less than a minute left"; }
+  var m = Math.round(secs / 60);
+  return ", about " + (m <= 1 ? "a minute" : m + " minutes") + " left";
+}
 
 function tick() {
   var s = Math.round((Date.now() - started) / 1000);
@@ -154,11 +168,14 @@ function tick() {
     var r = s % 60;
     text = m + (m === 1 ? " minute " : " minutes ") + r + "s";
   }
-  document.getElementById("elapsed").textContent = "Running for " + text;
+  document.getElementById("elapsed").textContent =
+    "Running for " + text + leftText(secondsLeft);
 }
 
 function render(state) {
   document.getElementById("status").textContent = state.message || "";
+  secondsLeft = state.seconds_left;
+  tick();
 
   // A CRS run is measurable and a search is not, so only claim a number when
   // the server gave one.

--- a/tests/test_eta.py
+++ b/tests/test_eta.py
@@ -1,0 +1,190 @@
+"""Telling staff how much longer a run has.
+
+A staffer with a client in front of them and a bar crawling across the screen
+is asking one question, and it is not what percentage is done. It is whether to
+wait or to go and do something else for five minutes. Napier already knows: it
+is on case 12 of 77 and it has been timing every case it pulled.
+
+Measured against the real site on 2026-08-01, a case takes about half a second
+and the middle 99 percent land inside a second of each other, so the rate is
+steady enough to predict from. What is not steady is a case Iowa Courts stalls
+on, which is why nothing here is an average.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import jobs
+
+
+class Clock:
+    """A clock the test moves by hand, so none of this sleeps."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+    def tick(self, seconds):
+        self.now += seconds
+        return self.now
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = Clock()
+    monkeypatch.setattr(jobs.time, 'time', fake)
+    return fake
+
+
+def pulling(job, count, total=70):
+    job.log("Pulling case %d of %d..." % (count + 1, total), count=count, total=total)
+
+
+def run_at(clock, seconds_each, cases, total=70):
+    """A job that has pulled some cases, each taking the same time."""
+    job = jobs.Job('crs')
+    for n in range(cases):
+        pulling(job, n, total)
+        clock.tick(seconds_each)
+    return job
+
+
+class TestWhenItWillNotGuess:
+    def test_a_search_has_nothing_to_measure(self, clock):
+        """A search does not know how many names it is about to find, so it
+        sets no total and must not be given a made up one."""
+        job = jobs.Job('search')
+        job.log("Searching Iowa Courts Online...")
+        clock.tick(30)
+        assert job.to_dict()['seconds_left'] is None
+
+    def test_two_cases_is_not_a_rate(self, clock):
+        job = run_at(clock, 0.5, 2)
+        assert job.to_dict()['seconds_left'] is None
+
+    def test_three_cases_is(self, clock):
+        job = run_at(clock, 0.5, 4)
+        assert job.to_dict()['seconds_left'] is not None
+
+    def test_a_finished_run_is_not_still_counting_down(self, clock):
+        job = jobs.Job('crs')
+        for n in range(6):
+            pulling(job, n, total=6)
+            clock.tick(0.5)
+        job.log("Building the CRS workbook...", count=6, total=6)
+        assert job.to_dict()['seconds_left'] is None
+
+    def test_a_repeated_line_is_not_a_case(self, clock):
+        """Two log lines at the same count are one unit of work, not two taking
+        no time each. Counting them would halve every estimate."""
+        job = jobs.Job('crs')
+        for n in range(4):
+            pulling(job, n)
+            job.log("Iowa Courts is taking a while on this one...",
+                    count=n, total=70)
+            clock.tick(2.0)
+
+        left = job.to_dict()['seconds_left']
+        assert 130 < left < 140   # 67 cases still to go at two seconds each
+
+
+class TestWhatItSays:
+    def test_it_is_the_cases_left_times_what_a_case_costs(self, clock):
+        job = run_at(clock, 0.5, 10, total=70)
+        # 60 left, half a second each.
+        assert job.to_dict()['seconds_left'] == 30
+
+    def test_a_slower_site_gives_a_longer_estimate(self, clock):
+        quick = run_at(clock, 0.5, 10, total=70)
+        slow = run_at(clock, 3.0, 10, total=70)
+        assert slow.to_dict()['seconds_left'] > quick.to_dict()['seconds_left']
+
+    def test_the_estimate_falls_as_the_run_goes_on(self, clock):
+        job = run_at(clock, 0.5, 10, total=70)
+        early = job.to_dict()['seconds_left']
+        for n in range(10, 40):
+            pulling(job, n)
+            clock.tick(0.5)
+        assert job.to_dict()['seconds_left'] < early * 0.6
+
+
+class TestTheStalledCase:
+    def test_one_four_minute_case_does_not_rewrite_the_run(self, clock):
+        """The whole reason this is a median. Nine cases at half a second and
+        one that Iowa Courts sat on for four minutes averages out to twenty
+        four seconds a case, which would tell a staffer with a two minute run
+        left to expect twenty four minutes."""
+        job = jobs.Job('crs')
+        for n in range(10):
+            pulling(job, n)
+            clock.tick(240 if n == 4 else 0.5)
+        pulling(job, 10)
+
+        left = job.to_dict()['seconds_left']
+        assert left < 60          # 59 cases at about half a second
+        assert left > 25
+
+    def test_a_stall_happening_now_makes_the_estimate_climb(self, clock):
+        """A bar that has not moved in three minutes under an estimate that has
+        not moved either is the page calling itself a liar."""
+        job = run_at(clock, 0.5, 10, total=70)
+        settled = job.to_dict()['seconds_left']
+        clock.tick(180)
+
+        assert job.to_dict()['seconds_left'] > settled + 170
+
+    def test_and_drops_back_once_the_case_comes_through(self, clock):
+        job = run_at(clock, 1.0, 10, total=70)
+        settled = job.to_dict()['seconds_left']
+        clock.tick(180)
+        pulling(job, 10)
+
+        # One bad case among ten, so the middle one is unchanged and the only
+        # difference is the case that is no longer outstanding.
+        assert job.to_dict()['seconds_left'] < settled
+
+    def test_a_site_that_has_gone_slow_is_believed(self, clock):
+        """A stall is one case. Twenty slow ones in a row is the site, and the
+        estimate has to follow it up rather than keep quoting this morning."""
+        job = run_at(clock, 0.5, 10, total=70)
+        quick = job.to_dict()['seconds_left']
+        for n in range(10, 40):
+            pulling(job, n)
+            clock.tick(4.0)
+
+        assert job.to_dict()['seconds_left'] > quick
+
+
+class TestWhatItKeeps:
+    def test_it_does_not_remember_the_whole_run(self, clock):
+        job = run_at(clock, 0.5, 60, total=200)
+        assert len(job.marks) <= jobs.UNITS_TIMED
+
+    def test_which_is_why_it_can_follow_the_site_down(self, clock):
+        """Sixty quick cases then twenty slow ones, and the estimate is about
+        the slow ones. Keeping every mark would leave the quick ones outvoting
+        the site's current behaviour for the rest of the run."""
+        job = run_at(clock, 0.5, 60, total=200)
+        for n in range(60, 85):
+            pulling(job, n, total=200)
+            clock.tick(4.0)
+
+        left = job.to_dict()['seconds_left']
+        assert left > 4 * (200 - 85) * 0.9
+
+
+class TestThePageGetsIt:
+    def test_the_poll_carries_it(self, clock):
+        job = run_at(clock, 0.5, 10, total=70)
+        assert 'seconds_left' in job.to_dict()
+
+    def test_it_is_a_whole_number_of_seconds(self, clock):
+        job = run_at(clock, 0.37, 10, total=70)
+        left = job.to_dict()['seconds_left']
+        assert isinstance(left, int)


### PR DESCRIPTION
The progress bar says what percentage is done. Nobody watching it is asking that. They want to know whether to wait or go do something else, and Napier already knows: it is on case 12 of 77 and it timed every case it pulled.

Backed by a measurement against the real site this morning (ILA04, off-hours, public records for strangers, no client involved): 314 requests, every one succeeded, a case costs 0.79s end to end, median page 0.18s, p99 0.84s, nothing over 1.31s. Steady enough to predict from.

- The typical case is the **median**, not the mean. Nine quick cases and one four-minute stall averages to 24s a case, which would tell someone with two minutes left to expect 24 minutes.
- A stall happening **now** is added on top as an overrun, so the estimate climbs during the stall and drops back when the case clears.
- Only the last 20 cases are timed, so a site that goes slow at 11am is believed rather than outvoted by how it behaved at 9am.
- Nothing is said until 3 cases have gone by. Searches say nothing, since they never know their total.
- Rounded to a minute, or "less than a minute". Claiming second precision would be claiming to know what Iowa Courts is about to do.

616 tests pass (16 new). 14 mutations of the new code all caught by the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t