### PR TITLE
Count how hard Iowa Courts made Napier work

### DIFF
--- a/icos.py
+++ b/icos.py
@@ -180,6 +180,18 @@ class IcosClient:
             else _env_seconds("CONCURRENT_WAIT_MIN", 16)
         self.logged_in = False
         self.username = None
+        # Which attempt each request finally landed on, and how many were given
+        # up on. Measured against the real site on 2026-08-01, a healthy ICOS
+        # answered 314 of 314 requests first time, with the slowest taking
+        # 1.31s against an 8 second timeout. So the case budget of four minutes
+        # is not there for a slow site, it is there for a sick one, and nobody
+        # has ever seen what a sick one does: whether a case that fails six
+        # times ever comes back on the seventh, or whether the four minutes are
+        # spent proving something that was decided in the first ten seconds.
+        # That is 23 minutes of a clinic during an outage, so it is worth
+        # knowing rather than guessing. This is the counting.
+        self.landed_on = {}
+        self.given_up = 0
         # The registry entry for the ESA account this client holds, so the next
         # staffer to collide with it can be told what is holding it.
         self._account_handle = None
@@ -240,6 +252,7 @@ class IcosClient:
             result = self.reader.fetch_once(url, data)
             if result.ok:
                 if validate is None or validate(result.body):
+                    self.landed_on[attempt + 1] = self.landed_on.get(attempt + 1, 0) + 1
                     if attempt >= SLOW_RECOVERY_ATTEMPTS:
                         # It worked, so staff see nothing. But ICOS needing this
                         # many tries is how a bad afternoon starts, and knowing
@@ -266,6 +279,7 @@ class IcosClient:
             elapsed = self._monotonic() - started
             wait = backoff_for(attempt)
             if elapsed + wait > budget:
+                self.given_up += 1
                 self._alert(alerts.RETRY_EXHAUSTED, endpoint=endpoint,
                             attempts=attempt + 1, elapsed=_describe(elapsed),
                             backoff=_timeline(waits),
@@ -428,6 +442,15 @@ class IcosClient:
 
         The three pages must be fetched in this order: ICOS keys the charges and
         financials views off the case selected by the summary request.
+
+        Which also settles whether cases could be pulled concurrently, and they
+        cannot. TViewCharges and TViewFinancials take no parameters at all, so
+        the only thing saying which case they answer about is server state.
+        Checked against the real site on 2026-08-01: selecting case A, then
+        case B, then reading charges returns B's charges. Two case pulls
+        sharing a session interleave into one wrong case, and a second session
+        means a second ESA account, which locks a colleague out. Threads and
+        aiohttp change nothing here.
         """
         summary = self._retry(
             "case", lambda: self.reader.case_summary_request(case_id),
@@ -446,6 +469,28 @@ class IcosClient:
             validate=lambda body: _is_page_for_case(body, case_id))
         return summary, charges, financials
 
+    def retry_summary(self):
+        """How hard this session had to work, or None if it did not have to.
+
+        Silent on a healthy run. "Everything answered first time" printed after
+        every run is how a log gets stopped being read, and this line is only
+        worth anything if it is unusual enough that somebody looks at it.
+
+        It goes in the progress log rather than only to stdout because the
+        progress log is what alert emails carry, so the one run that went badly
+        arrives already carrying the shape of how it went badly.
+        """
+        slow = sorted(n for n in self.landed_on if n > 1)
+        if not slow and not self.given_up:
+            return None
+        parts = ["%d first time" % self.landed_on.get(1, 0)]
+        for n in slow:
+            parts.append("%d on try %d" % (self.landed_on[n], n))
+        line = "Iowa Courts answered " + ", ".join(parts)
+        if self.given_up:
+            line += ", and never answered %d" % self.given_up
+        return line + "."
+
     def logoff(self):
         """Release the ESA session.
 
@@ -453,6 +498,12 @@ class IcosClient:
         best-effort but never skipped -- and never allowed to raise, since it
         runs in cleanup paths.
         """
+        # Before the early return, because a session that never got logged in
+        # is a session that spent its whole life retrying, which is exactly the
+        # run worth having the numbers from.
+        summary = self.retry_summary()
+        if summary:
+            self._log(summary)
         if not self.logged_in:
             return
         try:

--- a/tests/test_retry_profile.py
+++ b/tests/test_retry_profile.py
@@ -1,0 +1,126 @@
+"""Counting how hard Iowa Courts made Napier work, so the budgets stop guessing.
+
+A case Napier gives up on costs four minutes. Six in a row is the outage cap,
+so an outage costs about 23 minutes of a clinic before the run stops. Whether
+that four minutes is worth spending has never been measured: nobody knows
+whether a case that has failed five times ever comes back on the sixth, or
+whether the answer was settled in the first ten seconds and the rest is Napier
+waiting to be sure.
+
+Measured against the real site on 2026-08-01, 314 requests answered first time
+and the slowest took 1.31s against an 8 second timeout, so there is nothing to
+learn from a healthy day. The only useful sample is a bad one, and bad days are
+exactly when nobody is taking notes. So Napier takes them.
+
+Silent when there is nothing to say, because a line that appears after every
+run is a line nobody reads.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from icos import IcosUnavailable
+from reader import EMPTY, OK, TIMEOUT, FetchResult
+from test_icos_retry import CASE_ID, CASE_PAGE, RESULTS_PAGE, build
+
+
+class TestWhenItStaysQuiet:
+    def test_a_run_where_everything_worked_says_nothing(self):
+        client, _, _ = build([FetchResult(OK, RESULTS_PAGE)])
+        client.search("PAT", "", "TESTER")
+        assert client.retry_summary() is None
+
+    def test_and_puts_nothing_in_the_progress_log(self):
+        client, _, messages = build([FetchResult(OK, RESULTS_PAGE)])
+        client.search("PAT", "", "TESTER")
+        client.logoff()
+        assert not [m for m in messages if "answered" in m]
+
+    def test_a_session_that_did_nothing_at_all_says_nothing(self):
+        client, _, _ = build([])
+        client.logoff()
+        assert client.retry_summary() is None
+
+
+class TestWhatItCounts:
+    def test_a_request_that_needed_a_second_go(self):
+        client, _, _ = build([FetchResult(TIMEOUT), FetchResult(OK, RESULTS_PAGE)])
+        client.search("PAT", "", "TESTER")
+
+        assert client.landed_on == {2: 1}
+        assert "1 on try 2" in client.retry_summary()
+
+    def test_it_names_the_attempt_it_landed_on(self):
+        client, _, _ = build([FetchResult(TIMEOUT), FetchResult(EMPTY),
+                              FetchResult(TIMEOUT), FetchResult(OK, RESULTS_PAGE)])
+        client.search("PAT", "", "TESTER")
+
+        assert client.landed_on == {4: 1}
+        assert "1 on try 4" in client.retry_summary()
+
+    def test_the_ones_that_worked_first_time_are_counted_too(self):
+        """Three retries out of four requests and three out of four hundred are
+        different afternoons, and the line has to tell them apart."""
+        client, _, _ = build([FetchResult(OK, CASE_PAGE),
+                              FetchResult(OK, CASE_PAGE),
+                              FetchResult(TIMEOUT), FetchResult(OK, CASE_PAGE)])
+        client.case_bundle(CASE_ID)
+
+        assert client.landed_on == {1: 2, 2: 1}
+        assert client.retry_summary().startswith("Iowa Courts answered 2 first time")
+
+    def test_a_whole_bundle_that_worked_is_still_quiet(self):
+        client, _, _ = build([FetchResult(OK, CASE_PAGE)] * 3)
+        client.case_bundle(CASE_ID)
+
+        assert client.landed_on == {1: 3}
+        assert client.retry_summary() is None
+
+
+class TestTheOnesItNeverGot:
+    def test_a_case_given_up_on_is_counted(self):
+        client, _, _ = build([FetchResult(TIMEOUT)] * 6, case_budget_seconds=3)
+        with pytest.raises(IcosUnavailable):
+            client.case_bundle(CASE_ID)
+
+        assert client.given_up == 1
+        assert "never answered 1" in client.retry_summary()
+
+    def test_a_run_that_lost_cases_but_never_retried_still_reports(self):
+        """Nothing landed late, so the attempt tally is empty. A run that gave
+        up on three cases is still the most interesting run of the week."""
+        client, _, _ = build([FetchResult(TIMEOUT)] * 6, case_budget_seconds=3)
+        with pytest.raises(IcosUnavailable):
+            client.case_bundle(CASE_ID)
+
+        assert not [n for n in client.landed_on if n > 1]
+        assert client.retry_summary() is not None
+
+
+class TestHowItGetsOut:
+    def test_logging_off_writes_it_to_the_progress_log(self):
+        """Which is what alert emails carry, so the run that went badly arrives
+        already saying how."""
+        client, _, messages = build([FetchResult(TIMEOUT),
+                                     FetchResult(OK, RESULTS_PAGE)])
+        client.search("PAT", "", "TESTER")
+        client.logoff()
+
+        assert any("on try 2" in m for m in messages)
+
+    def test_a_session_that_never_signed_in_still_reports(self):
+        """logoff() returns early when there is no session to release, so the
+        line has to be written before that check. A run that spent its whole
+        life failing never reaches the logged-in branch to tell anyone."""
+        client, _, messages = build([FetchResult(TIMEOUT)] * 6,
+                                    case_budget_seconds=3)
+        with pytest.raises(IcosUnavailable):
+            client.case_bundle(CASE_ID)
+        assert not client.logged_in
+
+        client.logoff()
+        assert any("never answered" in m for m in messages)


### PR DESCRIPTION
## What this is

Napier spends four minutes on a case before giving up, and stops the run
after six of those. So an outage costs about 23 minutes of a clinic. That
four minutes has never been checked against anything.

I measured the real site (ILA04, off hours, 2026-08-01): 314 requests,
every one answered first time, median 0.18s, slowest 1.31s against an 8
second timeout. A healthy day teaches nothing about retries. The sample
that would settle the budgets can only come from a bad day, and on a bad
day nobody is taking notes.

So each session now counts which attempt every request landed on, and how
many cases it never got, and says so once as it signs off:

> Iowa Courts answered 61 first time, 3 on try 2, 1 on try 4, and never answered 2.

That lands in the progress log, which alert mail already carries. After a
few bad afternoons the budgets can be set from evidence.

Quiet when everything worked. A line that appears after every run stops
being read, and this one is only useful when it is unusual.

It is written before the early return in `logoff()`, so a session that
never managed to sign in still reports. That is the run most worth
hearing from.

## Also

Documents why case pulls cannot run concurrently, since the question
keeps coming back. `TViewCharges` and `TViewFinancials` take no
parameters, so the case they answer about is server-side session state.
Against the real site: select A, select B, read charges, and the charges
belong to B. Two pulls sharing a session interleave into one wrong case,
and a second session means a second ESA account, which locks a colleague
out. Threads and aiohttp do not change that.

## Checks

- 627 tests pass, up from 616
- 9 mutations of the counting and reporting code, all caught, none skipped
- No names, case numbers, or credentials in anything added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
