### PR TITLE
Hand the ability to pay calculator its two court-side numbers

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -428,7 +428,8 @@ def build_action_sheet(workbook, cases, written, as_of, def_name):
     """Add ACTION LIST to a workbook Napier has finished writing.
 
     Called after CASE DATA is filled in, because it reads CASE DATA back.
-    Returns the number of actions it found.
+    Returns the ability-to-pay figures, which are a by-product of what it had
+    to work out anyway.
     """
     sheets = set(workbook.sheetnames)
     found = collect(workbook['CASE DATA'], written, as_of, sheets,
@@ -509,7 +510,31 @@ def build_action_sheet(workbook, cases, written, as_of, def_name):
 
     worksheet.freeze_panes = 'A' + str(FIRST_ACTION_ROW)
     build_payment_sheet(workbook, history)
-    return len(found)
+    return ability_to_pay(total_owed, history)
+
+
+def ability_to_pay(total_owed, history):
+    """The two court-side numbers the ability-to-pay calculator asks for.
+
+    The calculator at abilitytopay.org wants a court debt balance and what the
+    client pays toward it each month, and then asks them for everything else:
+    income, rent, groceries, all the things only the client can answer. These
+    two are the ones a person sitting in a clinic cannot answer from memory,
+    which is why the interview stalls on them.
+
+    Both are already in the workbook. This is the same pair, taken from the
+    same place, so the screen cannot disagree with the file. Returned as
+    formatted text because that is all anyone does with them: read them off
+    and type them in.
+
+    monthly is None when ICOS itemized no payments at all, which is not the
+    same as nothing having been paid and must not be handed over as $0.00.
+    """
+    return {
+        'balance': _dollars(total_owed),
+        'monthly': None if history is None else _dollars(history['recent_monthly']),
+        'months': crs.RECENT_MONTHS,
+    }
 
 
 def build_payment_sheet(workbook, history):

--- a/app.py
+++ b/app.py
@@ -323,6 +323,7 @@ def _finish_page(job, error=None):
     if job.kind == 'batch_crs':
         return render_template('batch_done.html', job=job.to_dict(),
                                clients=result['clients'],
+                               months=crs.RECENT_MONTHS,
                                is_lite=result['is_lite'],
                                built=sum(1 for c in result['clients'] if c['file']),
                                written=result['written_cases'],
@@ -333,6 +334,7 @@ def _finish_page(job, error=None):
                                    max([c['written'] for c in result['clients']]
                                        or [0]), result['is_lite']))
     return render_template('done.html', job=job.to_dict(),
+                           atp=result.get('atp'),
                            def_name=result['def_name'],
                            is_lite=result['is_lite'],
                            written=result['written_cases'],

--- a/tasks.py
+++ b/tasks.py
@@ -517,8 +517,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
                                    "for them.")
                 continue
             try:
-                path, unknown = build_workbook(cases, pick['def_name'],
-                                               pick['def_dob'], is_lite)
+                path, unknown, atp = build_workbook(cases, pick['def_name'],
+                                                    pick['def_dob'], is_lite)
             except Exception as e:
                 # The other clients' workbooks are already built or still to
                 # come, and neither should be lost to this one.
@@ -535,6 +535,7 @@ def batch_crs_task(job, session_token, picks, is_lite):
             report_unknown_dispositions(job, unknown)
             record['written'] = len(cases)
             record['file'] = path
+            record['atp'] = atp
 
         if not any(record['file'] for record in built):
             raise ValueError("no workbooks could be built")
@@ -620,10 +621,12 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
             raise ValueError("no cases could be read")
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
-        path, unknown_dispositions = build_workbook(cases, def_name, def_dob, is_lite)
+        path, unknown_dispositions, atp = build_workbook(cases, def_name,
+                                                         def_dob, is_lite)
         report_unknown_dispositions(job, unknown_dispositions)
         job.result = {
             "file": path,
+            "atp": atp,
             "def_name": def_name,
             "is_lite": is_lite,
             "written_cases": len(cases),
@@ -747,8 +750,8 @@ def retry_task(job, username, password, payload):
                                        "still no workbook for them.")
                 continue
             try:
-                path, unknown = build_workbook(cases, entry['def_name'],
-                                               entry['def_dob'], is_lite)
+                path, unknown, atp = build_workbook(cases, entry['def_name'],
+                                                    entry['def_dob'], is_lite)
             except Exception as e:
                 print("Workbook failed on retry for client %d: %r" % (index, e),
                       flush=True)
@@ -773,6 +776,7 @@ def retry_task(job, username, password, payload):
                 if any(case_id in fresh_ids for case_id in case_ids)})
             record['written'] = len(cases)
             record['file'] = path
+            record['atp'] = atp
 
         if not any(record['file'] for record in built):
             raise ValueError("no workbooks could be rebuilt")
@@ -801,6 +805,10 @@ def retry_task(job, username, password, payload):
         record = built[0]
         job.result = {
             "file": record['file'],
+            # Rebuilt from every case that has ever come back for this client,
+            # so a retry that recovered two cases raises the balance the
+            # calculator is about to be given.
+            "atp": record.get('atp'),
             "def_name": record['name'],
             "is_lite": is_lite,
             "written_cases": record['written'],
@@ -816,7 +824,8 @@ def retry_task(job, username, password, payload):
 
 
 def build_workbook(cases, def_name, def_dob, is_lite):
-    """Returns the path written, and the dispositions Napier could not read.
+    """Returns the path written, the dispositions Napier could not read, and
+    the two figures the ability-to-pay calculator asks for.
 
     The second value is a map of the ICOS wording to the case numbers it turned
     up on. Empty on almost every run. When it is not, those cases are on the
@@ -853,8 +862,8 @@ def build_workbook(cases, def_name, def_dob, is_lite):
 
     # Last, and only after BASIC INFO, because the action list reads CASE DATA
     # back rather than recomputing it and puts the client's name at the top.
-    actions.build_action_sheet(workbook, cases, row - 4, clinic_date,
-                               def_name.strip())
+    atp = actions.build_action_sheet(workbook, cases, row - 4, clinic_date,
+                                     def_name.strip())
 
     if not os.path.exists(tmp_dir):
         os.mkdir(tmp_dir)
@@ -865,7 +874,7 @@ def build_workbook(cases, def_name, def_dob, is_lite):
     suffix = "_Lite_CRS_" if is_lite else "_CRS_"
     path = tmp_dir + safe_name + suffix + stamp + ".xlsx"
     workbook.save(path)
-    return path, unknown
+    return path, unknown, atp
 
 
 def download_name(def_name, is_lite):

--- a/templates/_atp.html
+++ b/templates/_atp.html
@@ -1,0 +1,40 @@
+{#
+  The two numbers the ability-to-pay calculator asks the court side for.
+
+  Both are in the workbook already, on the action list and the payment sheet.
+  They are here because the calculator gets run with the client sitting there,
+  and hunting two figures out of a spreadsheet while somebody waits is how the
+  conversation stops being about them.
+
+  Nothing is sent anywhere. The figures are on screen for reading off, and the
+  client's own answers about income and rent stay between them and the
+  calculator.
+#}
+<div class="atp">
+  <p class="atp-title">For the ability to pay calculator</p>
+  <div class="atp-figures">
+    <span class="atp-figure">
+      <span class="atp-label">Court debt balance</span>
+      <span class="atp-value">{{ atp['balance'] }}</span>
+    </span>
+    <span class="atp-figure">
+      <span class="atp-label">Paid toward it each month</span>
+      {% if atp['monthly'] %}
+        <span class="atp-value">{{ atp['monthly'] }}</span>
+      {% else %}
+        <span class="atp-value atp-unknown">Iowa Courts itemized no payments</span>
+      {% endif %}
+    </span>
+  </div>
+  <p class="atp-note">
+    {% if atp['monthly'] %}
+      The monthly figure is the average over the last {{ atp['months'] }} months
+      of what Iowa Courts recorded, so it says what has been paid rather than
+      what was agreed. The payment sheet in the workbook has every one.
+    {% else %}
+      That is what the record says, not proof nothing was paid. A case whose
+      itemization Iowa Courts does not publish looks exactly the same, so ask
+      before entering a zero.
+    {% endif %}
+  </p>
+</div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -276,6 +276,68 @@ input[type=text]:focus, input[type=password]:focus {
   color: var(--stop-ink);
 }
 
+/* --- ability to pay ---------------------------------------------------- */
+
+.atp {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: .85rem 1rem;
+  margin-bottom: 1.3rem;
+}
+
+.atp-title {
+  font-weight: 600;
+  font-size: .93rem;
+  margin: 0 0 .55rem;
+}
+
+.atp-figures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.6rem;
+  margin: 0 0 .55rem;
+}
+
+.atp-figure { min-width: 0; }
+
+.atp-label {
+  display: block;
+  font-size: .8rem;
+  color: var(--ink-soft);
+}
+
+.atp-value {
+  font-size: 1.12rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.atp-value.atp-unknown {
+  font-size: .93rem;
+  font-weight: 400;
+  color: var(--ink-soft);
+}
+
+.atp-note {
+  margin: 0;
+  font-size: .82rem;
+  color: var(--ink-soft);
+}
+
+/* The clinic-list form of the same thing. One line per client, because a
+   boxed pair of figures twenty times over buries the list it belongs to. */
+.atp-inline {
+  display: block;
+  font-size: .83rem;
+  color: var(--ink-soft);
+  margin-top: .15rem;
+}
+
+.atp-inline b {
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
 footer {
   max-width: 60rem;
   margin: 0 auto;

--- a/templates/batch_done.html
+++ b/templates/batch_done.html
@@ -100,6 +100,16 @@
             {{ "written" if client['written'] == client['requested']
                else "written, the rest would not come off Iowa Courts" }}
           </span>
+          {% if client['atp'] %}
+            <span class="atp-inline">
+              Ability to pay: <b>{{ client['atp']['balance'] }}</b> owed,
+              {% if client['atp']['monthly'] %}
+                <b>{{ client['atp']['monthly'] }}</b> a month
+              {% else %}
+                no payments itemized
+              {% endif %}
+            </span>
+          {% endif %}
           {% if client['failed'] %}
             <ul class="missing">
               {% for case_id in client['failed'] %}<li>{{ case_id }}</li>{% endfor %}
@@ -116,6 +126,15 @@
       {% endif %}
     </div>
   {% endfor %}
+
+  {% if clients | selectattr('atp') | list %}
+    <p class="atp-note" style="margin-top:.9rem">
+      The monthly figure is the average of what Iowa Courts recorded over the
+      last {{ months }} months, so it says what has been paid rather than what
+      was agreed, and a client with no itemized payments is not a client who
+      paid nothing. Every payment is on the payment sheet of their workbook.
+    </p>
+  {% endif %}
 
   {% if built != clients | length %}
     <div class="notice" role="alert" style="margin-top:1.2rem">

--- a/templates/done.html
+++ b/templates/done.html
@@ -82,6 +82,8 @@
     </span>
   </div>
 
+  {% if atp %}{% include '_atp.html' %}{% endif %}
+
   {% if failed %}
     <div class="notice" role="alert">
       <p class="notice-title">

--- a/tests/test_ability_to_pay.py
+++ b/tests/test_ability_to_pay.py
@@ -1,0 +1,228 @@
+"""The two court-side figures the ability-to-pay calculator asks for.
+
+The calculator at abilitytopay.org works out what someone can actually pay on
+their court debt. Most of what it asks, income and rent and groceries, only the
+client can answer. Two of its inputs are court record: what is owed, and what
+has been going toward it each month. Those are the ones a person sitting in a
+clinic cannot answer from memory, and they are the ones Napier already knows.
+
+Both are in the workbook. What is pinned here is that the screen says the same
+thing the file says, that a client with no itemized payments is never handed
+over as having paid zero, and that neither figure gets anywhere near an email.
+
+Every case number is the synthetic 00000 FECR000000 and no real person
+appears anywhere in here, because this repository is public.
+"""
+
+import os
+import sys
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
+
+import actions
+import app as app_module
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+FRESH = '01/01/2020'
+
+
+@pytest.fixture
+def done_page():
+    """The single-client finish page, rendered with figures we choose."""
+    def render(balance="$500.00", monthly="$40.00"):
+        app_module.app.secret_key = 'test'
+        with app_module.app.test_request_context():
+            return app_module.render_template(
+                'done.html',
+                job={'id': 'jobjobjob'},
+                atp={'balance': balance, 'monthly': monthly,
+                     'months': crs.RECENT_MONTHS},
+                def_name='SYNTHETIC CLIENT', is_lite=False, written=2,
+                requested=2, failed=[], can_retry=False, error=None,
+                missing=0, limits=[], filename='SYNTHETIC_CRS.xlsx')
+    return render
+
+
+@pytest.fixture
+def batch_page():
+    """The clinic-list finish page, one row per client."""
+    def render(figures):
+        app_module.app.secret_key = 'test'
+        clients = [
+            {'name': 'SYNTHETIC %d' % index, 'file': '/tmp/w.xlsx',
+             'written': 1, 'requested': 1, 'failed': [], 'error': None,
+             'atp': {'balance': balance, 'monthly': monthly,
+                     'months': crs.RECENT_MONTHS}}
+            for index, (balance, monthly) in enumerate(figures, start=1)]
+        with app_module.app.test_request_context():
+            return app_module.render_template(
+                'batch_done.html', job={'id': 'jobjobjob'}, clients=clients,
+                months=crs.RECENT_MONTHS, is_lite=False, built=len(clients),
+                written=len(clients), can_retry=False, error=None, missing=0,
+                limits=[])
+    return render
+
+
+def payment_row(paid, when, receipt='000001'):
+    return {'detail': 'FINE', 'amount': '500.00', 'paid': paid,
+            'paidDate': when, 'receipt': receipt, 'tender': 'CSH'}
+
+
+def a_case(rows=()):
+    return {'id': '00000  FECR000000', 'financials': list(rows)}
+
+
+def built(rows, cases=(), as_of=CLINIC):
+    """A real CRS workbook with those rows written, and what it reported."""
+    workbook = load_workbook(FULL)
+    sheet = workbook['CASE DATA']
+    for offset, values in enumerate(rows):
+        row = crs.FIRST_CASE_ROW + offset
+        cells = dict({'A': '00000  FECR000000', 'B': 'SYNTHETIC',
+                      'D': FRESH, 'G': 'GTR'}, **values)
+        for column, value in cells.items():
+            sheet[column + str(row)] = value
+    figures = actions.build_action_sheet(workbook, list(cases), len(rows),
+                                         as_of, 'SYNTHETIC CLIENT')
+    return workbook, figures
+
+
+class TestWhatItReports:
+    def test_the_balance_is_what_is_owed(self):
+        _, figures = built([{'J': 250, 'K': 100}])
+        assert figures['balance'] == "$350.00"
+
+    def test_across_every_case(self):
+        _, figures = built([{'J': 250}, {'J': 100.50}, {'J': 40}])
+        assert figures['balance'] == "$390.50"
+
+    def test_the_monthly_figure_is_what_has_been_going_in(self):
+        """Six payments of $500 over the last year, which the calculator wants
+        as a rate rather than a total."""
+        cases = [a_case([payment_row('500.00', '%02d/15/2026' % month,
+                                     receipt='00000%d' % month)
+                         for month in range(1, 7)])]
+        _, figures = built([{'J': 250}], cases=cases)
+        assert figures['monthly'] == "$250.00"
+        assert figures['months'] == crs.RECENT_MONTHS
+
+    def test_a_workbook_with_no_cases_still_answers(self):
+        _, figures = built([])
+        assert figures['balance'] == "$0.00"
+
+
+class TestTheZeroItRefusesToSay:
+    def test_no_itemized_payments_is_not_a_zero(self):
+        """ICOS not publishing an itemization looks exactly like nobody ever
+        paying, and the calculator would treat the two the same. A hearing
+        where the client is recorded as having paid nothing on a debt they have
+        been paying is the whole thing going the wrong way."""
+        _, figures = built([{'J': 250}], cases=[a_case()])
+        assert figures['monthly'] is None
+
+    def test_and_the_page_says_so_in_words(self, done_page):
+        page = done_page(monthly=None)
+        assert "itemized no payments" in page
+        assert "$0.00 a month" not in page
+        assert "not proof nothing was paid" in page
+
+
+class TestItAgreesWithTheWorkbook:
+    def test_the_balance_is_the_action_list_total(self):
+        """Two numbers for the same thing is one number that is wrong. The
+        page reads from what built the sheet rather than working it out again,
+        and this is the test that keeps it that way."""
+        workbook, figures = built([{'J': 250}, {'K': 1000.25}])
+        assert figures['balance'] == "${:,.2f}".format(
+            workbook['ACTION LIST']['B4'].value)
+
+    def test_the_monthly_figure_is_the_payment_sheet_average(self):
+        cases = [a_case([payment_row('120.00', '03/15/2026'),
+                         payment_row('120.00', '04/15/2026', receipt='000002')])]
+        workbook, figures = built([{'J': 250}], cases=cases)
+        total = workbook['PAYMENTS']['B2'].value
+        assert figures['monthly'] == "${:,.2f}".format(
+            Decimal(total) / crs.RECENT_MONTHS)
+
+
+class TestItSurvivesTheBuild:
+    def test_a_real_workbook_build_hands_the_figures_back(self, tmp_path):
+        """Everything above works on the action sheet in isolation. This is the
+        function the jobs actually call, and figures that are worked out and
+        then dropped between there and the finish page are worse than none: the
+        page simply says nothing and nobody knows why."""
+        import tasks
+
+        monkeypatched = tasks.tmp_dir
+        tasks.tmp_dir = str(tmp_path) + os.sep
+        try:
+            path, _, figures = tasks.build_workbook(
+                [], 'SYNTHETIC CLIENT', '01/01/1900', False)
+        finally:
+            tasks.tmp_dir = monkeypatched
+        os.unlink(path)
+
+        assert figures is not None
+        assert figures['balance'] == "$0.00"
+        assert figures['months'] == crs.RECENT_MONTHS
+
+
+class TestWhatTheStafferSees:
+    def test_the_finish_page_carries_both(self, done_page):
+        page = done_page(balance="$1,340.00", monthly="$25.00")
+        assert "$1,340.00" in page
+        assert "$25.00" in page
+        assert "ability to pay calculator" in page
+
+    def test_a_clinic_list_carries_one_line_for_each_client(self, batch_page):
+        page = batch_page([("$100.00", "$10.00"), ("$220.00", None)])
+        assert "$100.00" in page and "$10.00" in page
+        assert "$220.00" in page
+        assert "no payments itemized" in page
+
+    def test_the_monthly_figure_says_what_it_is(self, done_page):
+        """An average of what was recorded, which is not the same as what was
+        agreed, and a court asks about the second one. A staffer who reads it
+        as the agreed payment enters a number the client never promised."""
+        page = done_page(monthly="$25.00")
+        assert "average" in page
+        assert str(crs.RECENT_MONTHS) in page
+        assert "Iowa Courts recorded" in page
+
+
+class TestWhereItMustNotGo:
+    def test_the_figures_stay_off_the_progress_log(self):
+        """The progress log is what alert mail carries out of the building.
+
+        How much a client owes the court is their business and nobody else's,
+        and the rule the rest of Napier's alerting keeps is that case numbers
+        may leave and people may not. A dollar figure attached to a run is a
+        person's finances, so it stays on the screen of whoever ran it.
+        """
+        for name in ('tasks.py', 'actions.py'):
+            with open(os.path.join(ROOT, name)) as handle:
+                for number, line in enumerate(handle, start=1):
+                    if 'job.log(' in line or 'alerts.record(' in line:
+                        assert 'atp' not in line, "%s:%d" % (name, number)
+
+    def test_and_out_of_the_job_state_the_browser_polls(self):
+        """to_dict is the progress page's view of a run and is served as JSON
+        while it is going. The figures live on job.result, which it leaves
+        alone, and a run in flight has no business naming the debt anyway."""
+        import jobs
+
+        job = jobs.Job('crs')
+        job.result = {'atp': {'balance': '$1,000.00', 'monthly': '$25.00'}}
+        assert 'atp' not in str(job.to_dict())
+        assert '1,000.00' not in str(job.to_dict())

--- a/tests/test_basic_info.py
+++ b/tests/test_basic_info.py
@@ -20,7 +20,7 @@ import tasks
 
 def _build(is_lite=False):
     """A workbook with no cases in it. BASIC INFO does not depend on them."""
-    path, _ = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
+    path, _, _ = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
     return load_workbook(path)['BASIC INFO'], path
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -119,7 +119,7 @@ def fake_icos(monkeypatch):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: (_stub_workbook(name), {}))
+                        lambda cases, name, dob, lite: (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
     yield
 
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -80,7 +80,7 @@ def fake_icos(monkeypatch, tmp_path):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: (str(tmp_path / 'w.xlsx'), {}))
+                        lambda cases, name, dob, lite: (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
     yield
 
 

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -88,7 +88,7 @@ def run(monkeypatch, case_ids, unavailable=()):
 
     def fake_build(cases, name, dob, lite):
         written.extend(case['id'] for case in cases)
-        return os.path.join(tasks.tmp_dir, 'stub.xlsx'), {}
+        return os.path.join(tasks.tmp_dir, 'stub.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}
 
     monkeypatch.setattr(tasks, 'build_workbook', fake_build)
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -102,8 +102,15 @@ def fake_icos(monkeypatch):
     monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
                         lambda html, case: case.update(financials=[], total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: (_write_stub_workbook(), {}))
+                        lambda cases, name, dob, lite: (_write_stub_workbook(),
+                                                        {}, dict(ATP)))
     yield
+
+
+# Distinctive on purpose, so the finish-page test below is proving these
+# travelled from the workbook build rather than matching something the page
+# would have said anyway.
+ATP = {'balance': '$1,234.56', 'monthly': '$78.90', 'months': 12}
 
 
 def _write_stub_workbook():
@@ -226,6 +233,37 @@ def test_crs_job_pulls_cases_and_offers_a_download(client):
     download = client.get('/job/%s/download' % crs_job_id)
     assert download.status_code == 200
     assert 'TESTER' in download.headers['Content-Disposition']
+
+
+def test_the_finish_page_carries_the_ability_to_pay_figures(client):
+    """They are worked out while the workbook is built and are wanted on the
+    screen, which is two places for them to be lost between."""
+    search_job_id, _ = run_search(client)
+    client.get('/results/' + search_job_id)
+    crs_job_id = client.post('/crs-job', json={
+        'search_job_id': search_job_id,
+        'keys': ['1900-01-01 TESTER, PAT Q'],
+    }).get_json()['job_id']
+    await_job(client, crs_job_id)
+
+    page = client.get('/done/' + crs_job_id).get_data(as_text=True)
+    assert ATP['balance'] in page
+    assert ATP['monthly'] in page
+
+
+def test_but_the_progress_page_does_not(client):
+    """A run in flight is polled as JSON every two seconds, and what a client
+    owes has no business in a poll."""
+    search_job_id, _ = run_search(client)
+    client.get('/results/' + search_job_id)
+    crs_job_id = client.post('/crs-job', json={
+        'search_job_id': search_job_id,
+        'keys': ['1900-01-01 TESTER, PAT Q'],
+    }).get_json()['job_id']
+    state = await_job(client, crs_job_id)
+
+    assert ATP['balance'] not in str(state)
+    assert ATP['monthly'] not in str(state)
 
 
 def test_a_user_id_typed_on_a_phone_still_signs_in(client):

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -96,7 +96,7 @@ def _fake_build(cases, name, dob, lite):
     path = os.path.join(tasks.tmp_dir, 'test_outage.xlsx')
     with open(path, 'wb') as handle:
         handle.write(b'PK\x03\x04 stub workbook')
-    return path, {}
+    return path, {}, {'balance': '$0.00', 'monthly': None, 'months': 12}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -141,7 +141,7 @@ def _fake_build(cases, name, dob, lite):
                         'test_retry_%s.xlsx' % name.split(',')[0].strip())
     with open(path, 'wb') as f:
         f.write(b'PK\x03\x04 stub workbook')
-    return path, dict(UNKNOWN)
+    return path, dict(UNKNOWN), {'balance': '$0.00', 'monthly': None, 'months': 12}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_unknown_disposition.py
+++ b/tests/test_unknown_disposition.py
@@ -243,6 +243,6 @@ def test_one_alert_per_wording_not_per_case(monkeypatch):
 def test_the_workbook_build_hands_the_wordings_back(tmp_path, monkeypatch):
     """process_case can report all it likes if build_workbook drops it."""
     monkeypatch.setattr(tasks, 'tmp_dir', str(tmp_path) + os.sep)
-    _, unknown = tasks.build_workbook(
+    _, unknown, _ = tasks.build_workbook(
         [_case(NOVEL), _case('GUILTY')], 'TEST CLIENT', '01/01/1980', False)
     assert unknown == {NOVEL: ['00000  FECR000000']}


### PR DESCRIPTION
## What this is

The calculator at abilitytopay.org needs two numbers from the court side:
what is owed, and what has been going toward it each month. Everything
else it asks (income, rent, groceries) only the client can answer. Those
two are the ones a person sitting in a clinic cannot answer from memory,
and Napier has already worked out both by the time the workbook saves.

They were in the file and nowhere else, so running the calculator meant
opening the spreadsheet and reading two figures off two different sheets
while somebody waited. Now the finish page carries both, and a clinic
list carries a line per client.

## What it does not do

Nothing is sent anywhere. A prefilled link would put a client's debt
figure into a URL, which lands in browser history and server logs on a
shared clinic machine. That is a privacy decision, not a coding one, and
this PR does not make it.

## The two things worth reviewing

**The page cannot disagree with the file.** Both figures are returned by
the code that builds the action sheet, not worked out a second time.
Tests hold them to the sheet's own cells (`ACTION LIST` B4 and
`PAYMENTS` B2).

**No client is handed over as having paid $0.00.** Iowa Courts not
publishing an itemization looks exactly like nobody ever paying, and the
difference decides whether an ability-to-pay argument leans on a payment
record or has to be made without one. The page says which it is and says
to ask before entering a zero.

The monthly figure is labeled as an average of what Iowa Courts recorded
over the last 12 months, so it says what has been paid rather than what
was agreed. A court asks about the second one.

## Privacy

The dollar figures stay out of the progress log (which alert mail
carries) and out of the JSON the progress page polls. Both have tests.

## Checks

- 643 tests pass, up from 627
- 12 mutations of the figures, the plumbing and both pages, all caught
- No names, case numbers, or credentials in anything added

`build_workbook` returns three values instead of two, which is why the
test fakes moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
