### PR TITLE
Make the workbook say what is not in it

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -377,7 +377,11 @@ PAYMENT_HEADERS = [
     ("HOW PAID", 11),
 ]
 
-FIRST_ACTION_ROW = 9
+FIRST_ACTION_ROW = 10
+
+# The missing-case line is the one thing on this sheet that has to be read
+# rather than skimmed, so it gets the colour the caveat gets.
+MISSING_FONT = Font(bold=True, color='996600')
 
 
 def _headers(worksheet, row, spec):
@@ -424,12 +428,15 @@ def client_payments(cases, as_of):
     }
 
 
-def build_action_sheet(workbook, cases, written, as_of, def_name):
+def build_action_sheet(workbook, cases, written, as_of, def_name, failed=()):
     """Add ACTION LIST to a workbook Napier has finished writing.
 
     Called after CASE DATA is filled in, because it reads CASE DATA back.
     Returns the ability-to-pay figures, which are a by-product of what it had
     to work out anyway.
+
+    failed is the cases Iowa Courts would not give up. They get a line of their
+    own, because this file outlives the page that says so.
     """
     sheets = set(workbook.sheetnames)
     found = collect(workbook['CASE DATA'], written, as_of, sheets,
@@ -484,8 +491,28 @@ def build_action_sheet(workbook, cases, written, as_of, def_name):
     else:
         worksheet['B6'] = "none"
 
-    worksheet['A7'] = CAVEAT
-    worksheet['A7'].font = CAVEAT_FONT
+    # A workbook gets emailed to a colleague, saved to a shared drive and opened
+    # three weeks later by somebody who never watched it being built. Up to now
+    # the only place that said a run came back short was the finish page and the
+    # progress log, both of which are gone within two hours, so the file itself
+    # read as a complete criminal record when it was two cases shy of one.
+    worksheet['A7'] = 'Not in this file'
+    failed = list(failed)
+    if failed:
+        worksheet['B7'] = (
+            "%d case%s Iowa Courts would not give up: %s. %s on no sheet in "
+            "this workbook. Look %s up on Iowa Courts before relying on this "
+            "being the whole record."
+            % (len(failed), "" if len(failed) == 1 else "s",
+               ", ".join(failed),
+               "It is" if len(failed) == 1 else "They are",
+               "it" if len(failed) == 1 else "them"))
+        worksheet['B7'].font = MISSING_FONT
+    else:
+        worksheet['B7'] = "none. Every case the search turned up is here."
+
+    worksheet['A8'] = CAVEAT
+    worksheet['A8'].font = CAVEAT_FONT
 
     _headers(worksheet, FIRST_ACTION_ROW - 1, ACTION_HEADERS)
     row = FIRST_ACTION_ROW

--- a/tasks.py
+++ b/tasks.py
@@ -518,7 +518,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
                 continue
             try:
                 path, unknown, atp = build_workbook(cases, pick['def_name'],
-                                                    pick['def_dob'], is_lite)
+                                                    pick['def_dob'], is_lite,
+                                                    failed)
             except Exception as e:
                 # The other clients' workbooks are already built or still to
                 # come, and neither should be lost to this one.
@@ -622,7 +623,8 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
         path, unknown_dispositions, atp = build_workbook(cases, def_name,
-                                                         def_dob, is_lite)
+                                                         def_dob, is_lite,
+                                                         failed)
         report_unknown_dispositions(job, unknown_dispositions)
         job.result = {
             "file": path,
@@ -751,7 +753,8 @@ def retry_task(job, username, password, payload):
                 continue
             try:
                 path, unknown, atp = build_workbook(cases, entry['def_name'],
-                                                    entry['def_dob'], is_lite)
+                                                    entry['def_dob'], is_lite,
+                                                    still_failed)
             except Exception as e:
                 print("Workbook failed on retry for client %d: %r" % (index, e),
                       flush=True)
@@ -823,9 +826,14 @@ def retry_task(job, username, password, payload):
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
-def build_workbook(cases, def_name, def_dob, is_lite):
+def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     """Returns the path written, the dispositions Napier could not read, and
     the two figures the ability-to-pay calculator asks for.
+
+    failed is the cases that would not come off Iowa Courts, so the workbook
+    can say what is not in it. The file travels further than any page Napier
+    serves, and one that is quietly short two cases is worse than one that
+    says it is short two cases.
 
     The second value is a map of the ICOS wording to the case numbers it turned
     up on. Empty on almost every run. When it is not, those cases are on the
@@ -863,7 +871,7 @@ def build_workbook(cases, def_name, def_dob, is_lite):
     # Last, and only after BASIC INFO, because the action list reads CASE DATA
     # back rather than recomputing it and puts the client's name at the top.
     atp = actions.build_action_sheet(workbook, cases, row - 4, clinic_date,
-                                     def_name.strip())
+                                     def_name.strip(), failed)
 
     if not os.path.exists(tmp_dir):
         os.mkdir(tmp_dir)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -397,7 +397,7 @@ class TestActionSheet:
 
     def test_the_caveat_is_on_the_sheet_not_in_a_manual(self):
         workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
-        assert 'has been read by a lawyer' in workbook['ACTION LIST']['A7'].value
+        assert 'has been read by a lawyer' in workbook['ACTION LIST']['A8'].value
 
     def test_the_total_owed_adds_up_every_fee_column(self):
         workbook = written_workbook(

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -119,7 +119,7 @@ def fake_icos(monkeypatch):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
+                        lambda cases, name, dob, lite, failed=(): (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
     yield
 
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -80,7 +80,7 @@ def fake_icos(monkeypatch, tmp_path):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
+                        lambda cases, name, dob, lite, failed=(): (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
     yield
 
 

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -70,6 +70,12 @@ class StubClient:
         pass
 
 
+# What the workbook build was told is missing from it. The finish page and the
+# progress log both say so already, and both are gone in two hours; the file is
+# the copy that gets emailed and kept.
+TOLD_MISSING = []
+
+
 def run(monkeypatch, case_ids, unavailable=()):
     """Drive crs_task directly; parsing and workbook building are stubbed."""
     stub = StubClient(unavailable)
@@ -85,9 +91,11 @@ def run(monkeypatch, case_ids, unavailable=()):
                         lambda body, case: case.update(financials=[],
                                                        total_due='$0.00'))
     written = []
+    TOLD_MISSING[:] = []
 
-    def fake_build(cases, name, dob, lite):
+    def fake_build(cases, name, dob, lite, failed=()):
         written.extend(case['id'] for case in cases)
+        TOLD_MISSING.extend(failed)
         return os.path.join(tasks.tmp_dir, 'stub.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}
 
     monkeypatch.setattr(tasks, 'build_workbook', fake_build)
@@ -106,6 +114,20 @@ def test_a_case_icos_will_not_give_up_costs_one_row_not_the_run(monkeypatch):
     assert job.result['failed_cases'] == [case_ids[1]]
     # The run carried on past the bad one rather than dying on it.
     assert stub.asked == case_ids
+
+
+def test_the_workbook_is_told_what_is_missing_from_it(monkeypatch):
+    """crs_task knows which cases it could not get and used to keep it to
+    itself. A workbook that is quietly one case short outlives every page that
+    would have said so."""
+    case_ids = ids(3)
+    run(monkeypatch, case_ids, unavailable=[case_ids[1]])
+    assert TOLD_MISSING == [case_ids[1]]
+
+
+def test_and_told_nothing_is_missing_when_nothing_is(monkeypatch):
+    run(monkeypatch, ids(3))
+    assert TOLD_MISSING == []
 
 
 def test_the_failed_case_is_named_for_staff(monkeypatch):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -102,7 +102,7 @@ def fake_icos(monkeypatch):
     monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
                         lambda html, case: case.update(financials=[], total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite: (_write_stub_workbook(),
+                        lambda cases, name, dob, lite, failed=(): (_write_stub_workbook(),
                                                         {}, dict(ATP)))
     yield
 

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -91,8 +91,9 @@ class StubClient:
 WRITTEN = []
 
 
-def _fake_build(cases, name, dob, lite):
-    WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases]})
+def _fake_build(cases, name, dob, lite, failed=()):
+    WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases],
+                   'failed': list(failed)})
     path = os.path.join(tasks.tmp_dir, 'test_outage.xlsx')
     with open(path, 'wb') as handle:
         handle.write(b'PK\x03\x04 stub workbook')
@@ -256,6 +257,17 @@ class TestAClinicListMeetingADeadSite:
                           dead_cases=dead)
 
         assert len(job.said('rest of the list')) == 1
+
+    def test_each_client_workbook_is_told_its_own_missing_cases(self, monkeypatch):
+        """A clinic list builds twenty files that go twenty different places.
+        Handing every one of them the whole run's missing cases would put
+        another client's case numbers in a workbook, and handing them none
+        leaves each file quietly short."""
+        doe, roe = ids('FECR', 3), ids('SRCR', 3)
+        job, _ = run_list(monkeypatch, [pick('DOE', doe), pick('ROE', roe)],
+                          dead_cases=[doe[1], roe[2]])
+
+        assert [entry['failed'] for entry in WRITTEN] == [[doe[1]], [roe[2]]]
 
     def test_a_bumpy_list_still_finishes(self, monkeypatch):
         """Two refusals apiece across four clients is eight failures and no
@@ -434,6 +446,23 @@ class TestARetryMeetingADeadSite:
         job, _ = run_retry(monkeypatch, entries, dead_cases=dead)
 
         assert [entry['ids'] for entry in WRITTEN] == [[entries[0]['case_ids'][0]]]
+
+    def test_the_rebuilt_workbook_is_told_what_is_still_missing(self, monkeypatch):
+        """A retry rebuilds the file from everything ever recovered, so the
+        line it carried from the first run is stale the moment it is rebuilt.
+        Recovering one of three has to leave the other two named, and a retry
+        that recovered everything has to stop saying anything is missing."""
+        entries = self.entries()
+        dead = entries[0]['failed'] + entries[1]['failed'] + entries[2]['failed']
+        run_retry(monkeypatch, entries, dead_cases=dead)
+
+        assert [entry['failed'] for entry in WRITTEN] == [entries[0]['failed']]
+
+    def test_and_says_nothing_is_missing_once_it_all_came_back(self, monkeypatch):
+        entries = self.entries()
+        run_retry(monkeypatch, entries[:1])
+
+        assert [entry['failed'] for entry in WRITTEN] == [[]]
 
     def test_the_skipped_ones_are_still_offered_a_third_go(self, monkeypatch):
         entries = self.entries()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -135,8 +135,11 @@ def fake_icos(monkeypatch):
 WRITTEN = []
 
 
-def _fake_build(cases, name, dob, lite):
-    WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases]})
+def _fake_build(cases, name, dob, lite, failed=()):
+    # failed is recorded because a rebuilt workbook that still does not name
+    # what is missing from it is the whole point of this going in.
+    WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases],
+                   'failed': list(failed)})
     path = os.path.join(tasks.tmp_dir,
                         'test_retry_%s.xlsx' % name.split(',')[0].strip())
     with open(path, 'wb') as f:

--- a/tests/test_workbook_receipt.py
+++ b/tests/test_workbook_receipt.py
@@ -1,0 +1,180 @@
+"""What the workbook says about what is not in it.
+
+A criminal record summary does not stay on the screen it was built on. It gets
+emailed to the attorney taking the case, dropped on a shared drive, and opened
+three weeks later by somebody who never watched it run. Everything Napier used
+to say about a run coming back short lived on the finish page and in the
+progress log, and both of those are gone two hours after the run.
+
+So a workbook that Iowa Courts had refused two cases out of looked exactly like
+a workbook of a client who only ever had the other cases. Whoever opened it had
+no way to tell, and the way that goes wrong is somebody advising on a record
+they think is complete.
+
+The file says it now, on the sheet that opens, above the fold.
+
+Every case number is the synthetic 00000 FECR000000 family and no real person
+appears anywhere in here, because this repository is public.
+"""
+
+import os
+import sys
+from datetime import date
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
+
+import actions
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+FRESH = '01/01/2020'
+
+MISSING = ['00000  FECR000001', '00000  SRCR000002']
+
+
+def built(failed=(), rows=({'J': 250},)):
+    """A real CRS workbook, built knowing what would not come off ICOS."""
+    workbook = load_workbook(FULL)
+    sheet = workbook['CASE DATA']
+    for offset, values in enumerate(rows):
+        row = crs.FIRST_CASE_ROW + offset
+        cells = dict({'A': '00000  FECR000000', 'B': 'SYNTHETIC',
+                      'D': FRESH, 'G': 'GTR'}, **values)
+        for column, value in cells.items():
+            sheet[column + str(row)] = value
+    actions.build_action_sheet(workbook, [], len(rows), CLINIC,
+                               'SYNTHETIC CLIENT', failed)
+    return workbook['ACTION LIST']
+
+
+class TestWhatTheLineSays:
+    def test_a_run_that_got_everything_says_so_outright(self):
+        """Silence would be ambiguous. A blank cell reads as a sheet that was
+        never filled in, and the whole point is a reader who can tell the
+        difference without asking whoever ran it."""
+        sheet = built()
+        assert sheet['A7'].value == 'Not in this file'
+        assert sheet['B7'].value == "none. Every case the search turned up is here."
+
+    def test_a_short_run_names_every_case_it_could_not_get(self):
+        sheet = built(failed=MISSING)
+        line = sheet['B7'].value
+        for case_id in MISSING:
+            assert case_id in line
+        assert line.startswith("2 cases")
+
+    def test_one_missing_case_is_not_described_in_the_plural(self):
+        line = built(failed=MISSING[:1])['B7'].value
+        assert line.startswith("1 case Iowa Courts")
+        assert "It is on no sheet" in line
+        assert "Look it up" in line
+
+    def test_it_says_what_to_do_about_it(self):
+        """Naming a case number without saying it has to be looked up leaves
+        the reader to work out whether it matters, and the answer is that it
+        always matters."""
+        line = built(failed=MISSING)['B7'].value
+        assert "on no sheet in this workbook" in line
+        assert "Look them up on Iowa Courts" in line
+        assert "the whole record" in line
+
+    def test_the_missing_line_is_not_set_in_the_same_type_as_the_rest(self):
+        """A reader skimming a summary sheet reads the values, not the labels.
+        This one has to stop them."""
+        quiet = built()['B7'].font
+        loud = built(failed=MISSING)['B7'].font
+        assert loud.bold and not quiet.bold
+
+
+class TestWhereItSits:
+    def test_it_is_on_the_sheet_that_opens(self):
+        workbook = load_workbook(FULL)
+        actions.build_action_sheet(workbook, [], 0, CLINIC, 'SYNTHETIC CLIENT',
+                                   MISSING)
+        assert workbook.sheetnames[0] == 'ACTION LIST'
+
+    def test_and_above_the_actions_rather_than_under_them(self):
+        """A list of forty ranked actions is a lot of scrolling, and a warning
+        underneath it is a warning nobody reaches."""
+        assert 7 < actions.FIRST_ACTION_ROW
+
+    def test_the_caveat_and_the_action_rows_came_down_with_it(self):
+        """The row it took was the caveat's. Everything below has to have moved
+        or the sheet writes the header over the caveat and the first action
+        over the header."""
+        sheet = built(failed=MISSING)
+        assert 'has been read by a lawyer' in sheet['A8'].value
+        header = sheet.cell(actions.FIRST_ACTION_ROW - 1, 1)
+        assert header.value == actions.ACTION_HEADERS[0][0]
+        assert header.font.bold
+        assert sheet.freeze_panes == 'A' + str(actions.FIRST_ACTION_ROW)
+
+    def test_the_summary_rows_above_it_are_untouched(self):
+        sheet = built(failed=MISSING)
+        assert sheet['A2'].value == 'Clinic date'
+        assert sheet['A3'].value == 'Cases read'
+        assert sheet['A4'].value == 'Total owed'
+        assert sheet['A5'].value == 'Payments on record'
+        assert sheet['A6'].value == 'Registration hold'
+
+
+class TestItSurvivesTheBuild:
+    def test_the_function_the_jobs_call_writes_it_to_the_file(self, tmp_path):
+        """Everything above works on the sheet in memory. This is the function
+        crs_task calls, and a line that is written and then not saved is worse
+        than none, because the file looks like it was checked."""
+        import tasks
+
+        monkeypatched = tasks.tmp_dir
+        tasks.tmp_dir = str(tmp_path) + os.sep
+        try:
+            path, _, _ = tasks.build_workbook(
+                [], 'SYNTHETIC CLIENT', '01/01/1900', False, MISSING)
+        finally:
+            tasks.tmp_dir = monkeypatched
+
+        try:
+            sheet = load_workbook(path)['ACTION LIST']
+        finally:
+            os.unlink(path)
+        assert MISSING[0] in sheet['B7'].value
+        assert MISSING[1] in sheet['B7'].value
+
+    def test_the_lite_workbook_gets_it_too(self, tmp_path):
+        """Lite is what most clinics actually hand out, and it is the one where
+        a reader has the least else to go on."""
+        import tasks
+
+        monkeypatched = tasks.tmp_dir
+        tasks.tmp_dir = str(tmp_path) + os.sep
+        try:
+            path, _, _ = tasks.build_workbook(
+                [], 'SYNTHETIC CLIENT', '01/01/1900', True, MISSING)
+        finally:
+            tasks.tmp_dir = monkeypatched
+
+        try:
+            sheet = load_workbook(path)['ACTION LIST']
+        finally:
+            os.unlink(path)
+        assert MISSING[0] in sheet['B7'].value
+
+
+class TestWhatItMustNotCarry:
+    def test_no_credential_reaches_the_file(self):
+        """Workbooks get emailed by staff, which puts them outside the ESA
+        agreement's reach. Case numbers are public record and may travel. The
+        account they were pulled with is half a credential and may not."""
+        sheet = built(failed=MISSING)
+        line = " ".join(str(sheet[cell].value) for cell in
+                        ('B2', 'B3', 'B5', 'B6', 'B7', 'A8'))
+        for smell in ('ILA', 'drakelegalclinic', 'password', 'user ID'):
+            assert smell not in line


### PR DESCRIPTION
A CRS that came back short said so on the finish page and in the progress log. Both are gone two hours after the run. The file keeps going: it gets emailed to the attorney taking the case, saved to a shared drive, opened three weeks later by someone who never watched it build. To that reader a workbook Iowa Courts refused two cases out of looked exactly like the workbook of a client who only ever had the other cases.

ACTION LIST is the sheet that opens and already carries the clinic date, the case count, the total owed and the payment record. It now carries one more line above the caveat: what is not in this file.

- A clean run says `none. Every case the search turned up is here.` rather than leaving a blank cell, because a blank cell reads as a sheet nobody filled in.
- A short run names every case number, says it is on no sheet here, and says to look it up on Iowa Courts before relying on this being the whole record. It is the only bold thing in the summary block.
- The caveat moved from A7 to A8 and `FIRST_ACTION_ROW` from 9 to 10.

All three build paths hand it their own list. That is the part worth testing: a clinic list builds twenty files that go twenty different places, so each gets its own missing cases rather than the run's, and a retry rebuilds from everything ever recovered, so the list it inherited from the first run is stale the moment it rebuilds.

## Checks

- 660 tests pass (17 new).
- Mutation tested 14 for 14, nothing missed and nothing skipped. Caught: dropping the line, blanking the clean-run cell, unbolding it, leaving `FIRST_ACTION_ROW` at 9, writing the caveat over the receipt, the plural on a single case, cutting the wiring at any of the three call sites, and rebuilding a retry with the pre-retry list.
- Verified the rendered sheet by hand.
- No PII or real case numbers in the diff. Fixtures are `00000 FECR000000` and family. A test asserts no ESA account id reaches the file, since workbooks travel outside the ESA agreement's reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t