### PR TITLE
Bring the README back in line with the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ This is a tool that collects court case data from Iowa's state court case inform
 The server is a [Flask app](https://flask.palletsprojects.com/) written in Python 3.13, served by gunicorn with threads (`--workers 1 --threads 12`, because the job store and the ICOS session store live in process memory).
 
 The front end is html, css and vanilla javascript, all of it inline in the
-templates. Nothing is fetched from an outside host. The earlier version pulled
-its stylesheet and jQuery from two CDNs, and legal aid offices sit behind
-filtered networks, so a blocked domain meant an unstyled page or a search button
-that did nothing.
+templates. The earlier version pulled its stylesheet from a Bootstrap CDN and
+jQuery from another host. Both are gone: the CSS is in the page and the scripts
+are plain fetch, which is all they were ever doing through jQuery.
 
 ## Flow
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,87 @@ This is a tool that collects court case data from Iowa's state court case inform
 
 ## Stack
 
-The server is a [Flask app](https://flask.palletsprojects.com/) written in Python 3, served by gunicorn with threads. The front end is html and javascript using jQuery and Bootstrap.
+The server is a [Flask app](https://flask.palletsprojects.com/) written in Python 3.13, served by gunicorn with threads (`--workers 1 --threads 12`, because the job store and the ICOS session store live in process memory).
+
+The front end is html, css and vanilla javascript, all of it inline in the
+templates. Nothing is fetched from an outside host. The earlier version pulled
+its stylesheet and jQuery from two CDNs, and legal aid offices sit behind
+filtered networks, so a blocked domain meant an unstyled page or a search button
+that did nothing.
 
 ## Flow
 
 Searches run as background jobs, because ICOS regularly stalls and a search that
-waits it out takes longer than a web request is allowed to last.
+waits it out takes longer than a web request is allowed to last. Closing the
+browser does not stop a job, and the job outlives the page that started it.
+
+### One client
 
 * The user enters a name and clicks search
 * The server starts a background search job and immediately shows a progress page
 * The job logs in to ICOS, runs the search, and retries through court-side stalls, reporting what it is doing as it goes
 * The progress page polls the job and sends the user to the results list when it finishes: unique names / dates of birth and the number of cases for each
 * The user selects a group of cases and clicks Create CRS
-* A second background job collects each case's summary, charges and financials from ICOS, builds the spreadsheet, and offers it for download. Closing the browser does not stop it.
-* The ICOS session is logged off when the CRS finishes, when the user logs out, or by a reaper if the results page is abandoned
+* A second background job collects each case's summary, charges and financials from ICOS, builds the spreadsheet, and shows a finish page
+* The finish page names the file, says how many cases went in, lists any Iowa Courts would not give up, offers a retry for those, and keeps working for two hours so a lost download does not cost another ICOS session
+* The ICOS session is logged off when the CRS finishes, when the user logs out, or by a reaper if the results page is abandoned for ten minutes
 
-### Why the retries and the logoff matter
+### A whole clinic list
+
+A clinic morning is twenty clients, and twenty sign-ins on a shared `ILA##`
+account is twenty chances to collide with a colleague. So a list of up to 40
+names, one per line as `Last, First` or `First Last`, runs on one sign-in.
+
+Napier searches each name, shows a roster page where staff confirm which person
+each name matched, then builds every workbook and offers them as a zip and
+individually. One client's bad luck does not end the list: a name ICOS will not
+answer, a client whose cases all refuse, or a workbook that fails to build
+leaves that row with an explanation and the rest of the list carries on.
+
+### When Iowa Courts will not answer
+
+Napier separates a bad case from a bad site. One case that will not come off
+ICOS costs one row, and the run carries on. Six cases refused in a row, counted
+across the whole run rather than per client, means the site is down, and there
+is no point discovering that twenty times over at four minutes a go, so the run
+stops and builds from what it has. Names are counted separately at three,
+because an unanswered name costs the 45 minute search budget rather than the
+four minute case budget.
+
+Anything left missing is offered back as a retry, on the run's own finish page,
+for the two hours the job is kept. A retry signs in again, puts the same search
+back in front of ICOS, asks only for the cases that are still missing, and
+rebuilds each workbook from everything that has ever come back for that client
+rather than producing a supplement to the first file.
+
+## What the workbook carries
+
+Beyond the CRS template's own sheets, Napier writes three things of its own.
+
+**ACTION LIST** is the sheet that opens. It carries the clinic date, the number
+of cases read, the total owed, the payment record, whether anything on the
+record can hold up a vehicle registration, and what is not in the file. That
+last line matters because the file outlives every page that would otherwise say
+so: a workbook gets emailed to the attorney taking the case and opened weeks
+later by someone who never watched it run, and one that is quietly two cases
+short is worse than one that says it is two cases short. Below that is a ranked
+list of the arguments Napier can spot on the record, each with the authority it
+rests on and the facts it was read from.
+
+**PAYMENTS** is every payment ICOS itemized across every case, with the date,
+amount, receipt and how it was paid.
+
+**Ability to pay** is two figures shown on the finish page rather than written
+into the file: the court debt balance and what has been going toward it each
+month, averaged over the last 12 months of what ICOS recorded. They are the two
+inputs the calculator at abilitytopay.org asks for that a client sitting in a
+clinic cannot answer from memory. They are read from the same numbers the
+workbook was built from, so the screen cannot disagree with the file. A client
+ICOS itemized no payments for is reported as having no itemization rather than
+as having paid zero, because a hearing where someone is recorded as paying
+nothing on a debt they have been paying goes the wrong way.
+
+## Why the retries and the logoff matter
 
 Two different failures were making a majority of searches fail in mid-2026:
 
@@ -32,6 +97,25 @@ Two different failures were making a majority of searches fail in mid-2026:
 should be retried, a concurrent login should be waited out on a slow cadence,
 and a wrong password should fail at once.
 
+A run that had to work for its answers says so in its own progress log, in the
+form "Iowa Courts answered 61 first time, 6 on try 2, 1 on try 4." That line is
+the difference between a slow morning and a degrading court site, and it costs
+nothing to carry.
+
+### Cases cannot be pulled in parallel
+
+`TViewCharges` and `TViewFinancials` take no parameters at all. The case they
+answer about is server-side state, set by the last `TViewCaseCivil?caseid=`
+request. Checked against the live site on 2026-08-01: select case A, select case
+B, read charges, and the charges are B's. Two case pulls sharing a session
+interleave into one wrong case, and a second session means a second ESA account,
+which locks out a colleague. Threads and aiohttp change nothing here.
+
+It does not matter much. Measured against the real site over 209 requests, the
+median page came back in 0.18s and a whole case in 0.81s, so 68 cases were 53
+seconds of actual work. What makes a run long is waiting out a stalled ICOS,
+and doing that on more connections at once would make it worse.
+
 ### Money figures come from the ICOS summary
 
 The itemization at the bottom of an ICOS financial page lists original
@@ -41,6 +125,22 @@ summary is therefore what the CRS reports. If the categories still do not
 reconcile with the ICOS total, the row is flagged and column U (the ICOS total)
 is the figure to trust.
 
+## What may leave the building
+
+The client's name and date of birth are privileged and never leave the machine
+that ran the search. Case numbers are court public record and travel freely,
+which is what makes an alert about a case worth reading.
+
+That rule decides a lot of the design. Alerts carry case numbers and never
+people. Exception messages are dropped, because a parser that dies on a case
+tends to quote that case back; what survives is the traceback's own frames plus
+the exception type. The ESA user ID is reduced to its `ILA##` family before it
+reaches an alert, and the password never appears anywhere. The ability-to-pay
+figures stay on the screen of whoever ran the search and are kept out of the
+progress log, because the log is what alert mail carries out. Nothing about a
+client is written to browser storage, since the machine is shared. Each of these
+guards has a test that fails when the guard is removed.
+
 ## Production
 
 The application runs on [Heroku](https://www.heroku.com/). `crs-napier` is production; `napier-dev` is staging and auto-deploys from `main`.
@@ -48,7 +148,8 @@ The application runs on [Heroku](https://www.heroku.com/). `crs-napier` is produ
 Config vars:
 
 * `SECRET_KEY` (required) - signs session cookies
-* `RETRY_BUDGET_MIN` (default 45) - how long a job keeps retrying a stalled ICOS
+* `RETRY_BUDGET_MIN` (default 45) - how long a job keeps retrying a stalled ICOS search
+* `CASE_RETRY_BUDGET_MIN` (default 4) - the same for one case, kept short because a run has many cases and only one search
 * `CONCURRENT_WAIT_MIN` (default 16) - how long to wait out a locked ESA account
 * `NAPIER_DISABLE_BACKGROUND` - set to `1` to skip the keepalive and reapers (tests)
 * `NAPIER_DUMP_HTML` - set to `1` to write scraped ICOS pages to `tmp/`. Off by
@@ -60,6 +161,10 @@ Config vars:
   turns alerting into a logged no-op
 * `ALERT_EMAIL_FROM` (optional) - defaults to `Napier <napier@MAILGUN_DOMAIN>`
 
+Jobs are kept for two hours after they finish, which is what makes a finish page
+survive a closed laptop. ICOS sessions held between a search and a CRS are reaped
+after ten minutes idle.
+
 Useful log filters: `heroku logs -a crs-napier | grep -E 'ICOS|KEEPALIVE|JOB|ALERT'`.
 
 ### Alerts
@@ -69,13 +174,22 @@ or a case will not parse, the only record used to be a line in `heroku logs`
 that got read after staff complained rather than before. Napier now emails the
 detail needed to diagnose a failure without shelling into Heroku.
 
-Seven things send mail: ICOS exhausting the retry budget, an ESA account still
-locked when the wait gives up, a run that succeeded but needed three or more
-attempts, an unusable response once signed in, a case that would not parse, a
-job crashing, and an unhandled exception in a request. A bad password does not,
-because it is always a typo. Nor does a cold keepalive, which is the normal
-state of an idle path to ICOS and recovers on its own; paging on it would train
-everyone to ignore Napier's mail.
+What sends mail: ICOS exhausting the retry budget, an ESA account still locked
+when the wait gives up, a run that succeeded but needed three or more attempts,
+an unusable response once signed in, a case that would not parse, a case ICOS
+would not retrieve, a job crashing, an unhandled exception in a request, a
+party role or a disposition ICOS used that Napier does not recognise, a
+workbook built and never collected, and a progress page that lost contact with
+the server.
+
+The last two are the ones nothing else would catch, because the server thinks
+those runs went fine. A staffer whose phone drops the progress page sees a
+finished run as a broken one and pulls the same cases again, and every
+server-side signal stays quiet because nothing server-side went wrong.
+
+A bad password does not send mail, because it is always a typo. Nor does a cold
+keepalive, which is the normal state of an idle path to ICOS and recovers on its
+own; paging on it would train everyone to ignore Napier's mail.
 
 Sending is one POST to the Mailgun HTTP API over `urllib`, on a daemon thread
 with its own timeout. No SMTP handshake to stall a worker, no dependency, no
@@ -88,14 +202,6 @@ several staff behind the same broken ICOS. So it is one email per job per
 failure class, with a floor of one per class per ten minutes across all jobs on
 top, and one digest when the job ends carrying every event including the ones
 that were suppressed.
-
-Alerts carry case numbers but never people. A case number is court public record
-and a parse-failure alert without one gives nobody anything to look at. The
-defendant's name and date of birth are the privileged part and are never
-assembled into an alert. Exception messages are dropped for the same reason: a
-parser that dies on a case tends to quote that case back. What survives is the
-traceback's frames, which are our own source, plus the exception type. Both
-guards have tests that fail when the guard is removed.
 
 The keepalive used to log every ping, which was 4,300 lines a day and buried
 everything worth reading. It now logs state changes and a heartbeat every ten
@@ -117,9 +223,13 @@ Open http://127.0.0.1:5000/ and use the website to create a spreadsheet.
 
 `tests/` covers the retry engine (with virtual time, so no real waiting), the
 job engine and session reaper, the staff-facing flow against a fake court site,
-the financial reconciliation against a fixture built from a real case, and
-alerting against a real local HTTP server, so an alert is proven to leave the
-process rather than proven to have been asked to.
+the clinic list and the retry path, the financial reconciliation against a
+fixture built from a real case, the action list against the CRS template's own
+formulas, and alerting against a real local HTTP server, so an alert is proven
+to leave the process rather than proven to have been asked to.
+
+Fixtures use the synthetic case number `00000 FECR000000` and no real person,
+because this repository is public.
 
 Set `NAPIER_DUMP_HTML=1` to have raw ICOS html written to `tmp/` as searches
 run, which is useful when working on the parsers. It is off by default. A

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,10 +8,10 @@
      findable among a row of identical blank tabs without costing a request. -->
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%2317314f'/><path d='M10 23V9h3.1l5.8 8.4V9H22v14h-3.1L13.1 14.6V23z' fill='%23b98900'/></svg>">
 <style>
-/* Everything the page needs is in this file. Nothing is fetched from a CDN.
-   Legal aid offices sit behind filtered networks, and the previous version
-   pulled its stylesheet and jQuery from two outside hosts, so a blocked domain
-   meant an unstyled page or a search button that did nothing. */
+/* Everything the page needs is in this file. The previous version pulled its
+   stylesheet from a Bootstrap CDN and jQuery from another host; both are gone,
+   and the two scripts are plain fetch, which is all they were ever doing
+   through jQuery. */
 
 :root {
   --ink: #151a21;


### PR DESCRIPTION
The README described an app that stopped existing several PRs ago.

**The stack line named jQuery and Bootstrap.** They are gone: the CSS is inline and the two scripts are plain fetch, which is all they were ever doing through jQuery.

**`CASE_RETRY_BUDGET_MIN` was missing** from the config list. It is the one worth knowing, since it is why a refused case costs four minutes and a refused search costs forty-five.

**"Seven things send mail"** has been wrong since the count reached twelve. The two newest are the ones that matter, because they are the only signal for a run the server thinks went fine: a workbook nobody collected, and a progress page that lost contact.

**Flow described one client, one search, one download.** Nothing about clinic lists, the roster, retrying what Iowa Courts refused, cancelling, recovering a run whose page died, the ability-to-pay figures, or the receipt line on the workbook. That is most of what Napier now does.

Two findings that only ever lived in a docstring are now in the README where somebody evaluating this repo will see them: cases cannot be pulled concurrently, because `TViewCharges` and `TViewFinancials` take no parameters and answer about whatever case the session selected last, and a whole case costs 0.81s, so throughput was never the bottleneck.

### Also removes an invented rationale

The redesign commit said the Bootstrap and jQuery CDNs had been giving offices behind filtered networks an unstyled page and a dead search button. That was not reported by anyone and not measured. It had reached a comment in `templates/base.html` and this README, where it would have been read as a known failure. Both copies are gone. The removal of the CDNs stands on its own.

### Checked

- Every number traced to source rather than recalled: `Procfile` threads, `RETENTION_SECONDS`, `IDLE_TIMEOUT`, `roster.MAX_NAMES`, `crs.RECENT_MONTHS`, both outage thresholds, the three budget env vars, the 12 alert constants in `alerts.py`, the routes in `app.py`.
- The timing figures are recomputed from the measurement file rather than quoted from memory: 209 requests, median page 0.18s, median case 0.81s, 68 cases in 53s. An earlier draft cited a figure I could not source, and it is gone.
- 660 tests pass.
- No client name, date of birth, or case number appears in the diff.