### PR TITLE
Two things a live run found that no test would have

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -82,6 +82,9 @@ NON_PARTY_ROLES = frozenset({
     'ATTORNEY FOR RESPONDENT',
     'ATTORNEY - LIMITED APPEARANCE',
     'ATTORNEY OTHER',
+    # On a probate or trust case because somebody left them something. The
+    # estate is not their record. Seen on a live search on 2026-08-01.
+    'BENEFICIARY',
     'CONSERVATOR',
     'COUNTER DEFENDANT',
     'COUNTER PLAINTIFF',

--- a/crs.py
+++ b/crs.py
@@ -5,6 +5,27 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from openpyxl.styles import Alignment # Added import
 from openpyxl.styles import Font, PatternFill
+from zoneinfo import ZoneInfo
+
+# Iowa keeps one time zone, and this app runs on a dyno that keeps UTC. Every
+# date in a workbook is a court date read against a clinic day: the twenty year
+# cut on the SOL sheet, the two and eight year expungement waits, whether a
+# probation term is still running. A run at nine at night in Des Moines was
+# stamped tomorrow and measured every one of those waits a day early.
+#
+# Verified on the napier-dev dyno on 2026-08-01: date.today() answered
+# 2026-08-02 while Iowa was still on the 1st.
+IOWA = ZoneInfo('America/Chicago')
+
+
+def iowa_now():
+    """The moment, where the client and the courthouse are."""
+    return datetime.now(IOWA)
+
+
+def iowa_today():
+    """The day in Iowa, which is the day the clinic is having."""
+    return iowa_now().date()
 
 MISMATCH_FILL = PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid")
 MISMATCH_FONT = Font(color="9C0006")
@@ -826,7 +847,7 @@ def process_case(case, worksheet, row, as_of=None):
     next year does not silently change what column I said.
     """
     if as_of is None:
-        as_of = date.today()
+        as_of = iowa_today()
     i = str(row)
     worksheet['A' + i] = case['id']
     worksheet['B' + i] = case['county']

--- a/tasks.py
+++ b/tasks.py
@@ -572,7 +572,7 @@ def _zip_workbooks(built, is_lite):
     own from the finish page, for the staffer who only wants the one client
     they are about to see.
     """
-    stamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    stamp = crs.iowa_now().strftime('%Y%m%d%H%M%S')
     path = tmp_dir + "Napier_clinic_list_" + stamp + ".zip"
     with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as bundle:
         for position, record in enumerate(built, start=1):
@@ -846,7 +846,7 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     # probation term is still running, which is only answerable against a day,
     # and it has to be the same day BASIC INFO B3 gets below or the workbook
     # disagrees with itself about when it was built.
-    clinic_date = datetime.date.today()
+    clinic_date = crs.iowa_today()
     row = 4
     unknown = {}
     for case in cases:
@@ -878,7 +878,7 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
 
     # def_name is user-supplied; sanitize it before using it in a filesystem path
     safe_name = secure_filename(def_name.strip().replace(' ', '_')) or "case"
-    stamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    stamp = crs.iowa_now().strftime('%Y%m%d%H%M%S')
     suffix = "_Lite_CRS_" if is_lite else "_CRS_"
     path = tmp_dir + safe_name + suffix + stamp + ".xlsx"
     workbook.save(path)
@@ -889,5 +889,5 @@ def download_name(def_name, is_lite):
     parts = [def_name.strip().replace(" ", "_")]
     if is_lite:
         parts.append("Lite")
-    parts.append(datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    parts.append(crs.iowa_now().strftime("%Y%m%d_%H%M%S"))
     return "%s.xlsx" % "_".join(parts)

--- a/tests/test_basic_info.py
+++ b/tests/test_basic_info.py
@@ -15,6 +15,7 @@ from openpyxl import load_workbook
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import crs
 import tasks
 
 
@@ -32,10 +33,58 @@ def test_the_clinic_date_is_filled_in_with_a_real_date():
         assert not isinstance(value, str), 'text does not do date arithmetic'
         if isinstance(value, datetime.datetime):
             value = value.date()
-        assert value == datetime.date.today()
+        assert value == crs.iowa_today()
         assert 'YY' in sheet['B3'].number_format.upper()
     finally:
         os.remove(path)
+
+
+class TestTheDayItPutsDown:
+    """Whose day it is.
+
+    Napier runs on a dyno that keeps UTC and serves clinics in Iowa, so from
+    seven in the evening Central the machine has already turned the page. A
+    workbook built then was stamped tomorrow, and B3 is what the SOL sheet's
+    twenty year cut and both expungement waits are measured against, so every
+    one of them was measured a day early. Nobody would see it: the sheet would
+    just say a client was eligible.
+
+    Found on 2026-08-01 by running the real thing at eleven at night and
+    reading the date off the file that came back.
+    """
+
+    def _at(self, monkeypatch, when):
+        """Run the build with the clock held at one instant."""
+        real = crs.datetime
+
+        class Held(real):
+            @classmethod
+            def now(cls, tz=None):
+                return when.astimezone(tz) if tz else when.replace(tzinfo=None)
+
+        monkeypatch.setattr(crs, 'datetime', Held)
+        # The dyno's own idea of the day, which is what the old code read.
+        monkeypatch.setattr(tasks.datetime, 'date', type(
+            'UtcDate', (datetime.date,),
+            {'today': classmethod(lambda cls: when.date())}))
+        sheet, path = _build()
+        try:
+            value = sheet['B3'].value
+            return value.date() if isinstance(value, datetime.datetime) else value
+        finally:
+            os.remove(path)
+
+    def test_a_late_evening_clinic_is_not_dated_tomorrow(self, monkeypatch):
+        # 03:30 UTC on the 2nd is 22:30 on the 1st in Des Moines.
+        night = datetime.datetime(2026, 8, 2, 3, 30,
+                                  tzinfo=datetime.timezone.utc)
+        assert self._at(monkeypatch, night) == datetime.date(2026, 8, 1)
+
+    def test_and_a_daytime_clinic_is_still_dated_today(self, monkeypatch):
+        """The fix must not move the ordinary case, which is every clinic."""
+        morning = datetime.datetime(2026, 8, 1, 15, 0,
+                                    tzinfo=datetime.timezone.utc)
+        assert self._at(monkeypatch, morning) == datetime.date(2026, 8, 1)
 
 
 def test_the_lite_template_gets_it_too():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -139,6 +139,21 @@ def test_a_padded_defendant_is_still_read_as_a_defendant():
     assert cases[0]['role'] == 'DEFENDANT'
 
 
+def test_a_beneficiary_is_not_the_person_the_search_is_about():
+    """Found by running a real search on 2026-08-01: ICOS answered with a role
+    of BENEFICIARY, which was in neither list, so it was read as the person
+    searched for and mailed out as unrecognised.
+
+    A beneficiary is on a probate or trust case because somebody left them
+    something. The estate's costs and whatever its parties did are not theirs,
+    and Napier reads every charge row on a case page, so treating one as the
+    party puts an estate's record into a client's criminal record summary. It
+    belongs with EXECUTOR, TRUSTEE, WARD and the rest of that cluster.
+    """
+    cases, _ = case_parser.parse_search(role_row('BENEFICIARY'))
+    assert cases == []
+
+
 def test_the_two_role_lists_do_not_overlap():
     """A role in both would be suppressed and vouched for at the same time."""
     assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)


### PR DESCRIPTION
Ran the whole staff flow against staging and the real Iowa Courts tonight, off
hours, on the shared test account, with a common surname belonging to nobody
Iowa Legal Aid represents. Sign in, search, 106 people on the results page,
picked one, built the CRS, finish page, downloaded the workbook, logged off.
It worked: search 2.3s, a two case CRS 2.3s, the file 0.29s. The workbook that
came back has the payments line, the PAYMENTS sheet and the "Not in this file"
receipt, and the finish page carried both ability to pay figures.

It also found two things no test would have.

## A role nobody had seen

Iowa Courts answered with a party role of `BENEFICIARY`. It was in neither
role list, so it was read as the person searched for, and the only reason
anyone knows is that it sent the unrecognised-role alert.

A beneficiary is on a probate or trust case because somebody left them
something. The charge parser takes every row on a case page, since in the
ordinary case the person searched for is the defendant and there is nothing to
separate out. So an estate's record would have gone into a client's criminal
record summary under the client's name. It belongs with `EXECUTOR`, `TRUSTEE`,
`WARD` and `CONSERVATOR`, which that list already suppresses.

The comment above `NON_PARTY_ROLES` says it has been wrong by omission four
separate times. This is the fifth.

## The workbook was dated tomorrow

It came back stamped 2026-08-02 while Iowa was still on the 1st. Heroku keeps
the dyno on UTC, so from seven in the evening Central the machine has turned
the page.

`BASIC INFO` B3 is not a label. The twenty year cut on the SOL sheet, both
expungement waits and the has-the-client-turned-18 test all measure against
it. An evening run measured every one of them a day early, and there is no
error attached to that, only a sheet saying somebody is eligible.

Checked on the dyno rather than assumed:

    $ heroku run -a napier-dev python -c "..."
    utc 2026-08-02
    central 2026-08-01

Napier keeps one clock now, `America/Chicago`, and every naive `date.today()`
and `datetime.now()` is gone from the app. The download name and the file
stamps came along, because leaving them is leaving the bug a way back in.

## Proof

Both tests were run against the code without their fix first.

* the role test reads the case as a party
* the date test dates the workbook the 2nd

The daytime case passes either way, which is what says the date test fails for
the reason it names rather than because a clock was held still.

Full suite: 663 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
