### PR TITLE
Say which of five things ICOS did

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,21 @@ detail needed to diagnose a failure without shelling into Heroku.
 
 What sends mail: ICOS exhausting the retry budget, an ESA account still locked
 when the wait gives up, a run that succeeded but needed three or more attempts,
-an unusable response once signed in, a case that would not parse, a case ICOS
-would not retrieve, a job crashing, an unhandled exception in a request, a
-party role or a disposition ICOS used that Napier does not recognise, a
-workbook built and never collected, and a progress page that lost contact with
-the server.
+an unusable response once signed in, ICOS not answering at all, a case that
+would not parse, a case ICOS would not retrieve, a job crashing, an unhandled
+exception in a request, a party role or a disposition ICOS used that Napier
+does not recognise, a workbook built and never collected, and a progress page
+that lost contact with the server.
+
+An unusable response and no answer at all are separate subject lines, and each
+carries the reason as its first line. They used to be one class with a size
+field on it, so a timeout, an empty body, a transport error, an ICOS problem
+report page and a page for the wrong case all arrived worded identically, and
+since it is one email per class per job, whichever happened first silenced the
+rest. On 2026-08-01 that meant one email saying "unusable response, 0b" while
+what actually stopped the run was ICOS serving problem report pages. A court
+site that is down and a session that has lost its place look the same from
+outside, and only one of them is Iowa's fault.
 
 The last two are the ones nothing else would catch, because the server thinks
 those runs went fine. A staffer whose phone drops the progress page sees a

--- a/alerts.py
+++ b/alerts.py
@@ -46,6 +46,11 @@ RETRY_EXHAUSTED = 'ICOS retry budget exhausted'
 CONCURRENT_EXHAUSTED = 'ESA account stayed locked'
 SLOW_RECOVERY = 'ICOS needed repeated retries'
 BAD_RESPONSE = 'unusable response from ICOS'
+# ICOS answering wrongly and ICOS not answering at all were one class, and
+# record() emails only the first of each class per run, so whichever came first
+# silenced the other. They also want opposite things looked at: a bad body is
+# the court site's data, and no body is the path to it.
+NO_ANSWER = 'no answer from ICOS'
 PARSE_FAILURE = 'case could not be read'
 CASE_UNAVAILABLE = 'case could not be retrieved from ICOS'
 JOB_FAILED = 'job failed'
@@ -136,7 +141,11 @@ def safe_traceback(exc):
 
 def _format(job_id, kind, failure, fields, progress):
     lines = ['%s job %s' % (kind, job_id), '']
-    ordered = ('classification', 'endpoint', 'attempts', 'elapsed',
+    # 'reason' leads because it is the sentence that decides whether anyone
+    # needs to do anything, and it used to not exist: an ICOS failure arrived
+    # as an endpoint, an attempt count and a size, and which of five things had
+    # gone wrong had to be worked out from the source.
+    ordered = ('reason', 'classification', 'endpoint', 'attempts', 'elapsed',
                'backoff', 'status', 'response size', 'account', 'case')
     for label in ordered:
         value = fields.get(label)

--- a/icos.py
+++ b/icos.py
@@ -21,7 +21,7 @@ import time
 import accounts
 import alerts
 from opener import Opener
-from reader import Reader
+from reader import EMPTY, TIMEOUT, Reader
 
 # Attempts before a run that still succeeded is worth an early-warning email.
 SLOW_RECOVERY_ATTEMPTS = alerts.SLOW_RECOVERY_ATTEMPTS
@@ -64,8 +64,41 @@ def _squashed(text):
     return "".join(text.split()).upper()
 
 
-def _is_not_a_problem_report(body):
-    return PROBLEM_REPORT_MARKER not in _text(body)
+# Why a body was refused, in the words the alert carries. A validator answers
+# None when the page is good and one of these when it is not.
+#
+# There used to be no such answer. Every refusal reached the alert under one
+# subject line with a size field, and a request that never came back at all
+# reached it the same way with "0b", which reads as a page that arrived wrong
+# rather than one that never arrived. Five causes, one email, and since
+# alerts.record only sends the first of each class per run, whichever happened
+# first silenced the rest. On 2026-08-01 that meant one email about a timeout
+# and nothing about the problem report pages that actually stopped the run.
+PROBLEM_REPORT_REASON = ("ICOS problem report page, meaning its own data source "
+                         "was unreachable")
+WRONG_CASE_REASON = "a page for a different case than the one asked for"
+# Seen against the live site on 2026-08-01: ICOS answers a case request with a
+# 200 and nothing in it when the session has not selected that case through a
+# search first. Worth naming, because a session that has lost its place and a
+# court site that is down are the same event from the outside, and only one of
+# them is Iowa's fault.
+NO_BODY_REASON = "HTTP 200 with an empty body"
+NO_ANSWER_REASON = "no answer inside the request timeout"
+
+
+def _refusal_reason(result):
+    """Why a request that produced no usable body produced none."""
+    if result.outcome == TIMEOUT:
+        return NO_ANSWER_REASON
+    if result.outcome == EMPTY:
+        return NO_BODY_REASON
+    return result.detail or "the request failed before any body arrived"
+
+
+def _problem_report_reason(body):
+    if PROBLEM_REPORT_MARKER in _text(body):
+        return PROBLEM_REPORT_REASON
+    return None
 
 
 def _page_text(body, username=""):
@@ -84,11 +117,13 @@ def _page_text(body, username=""):
     return text[:400]
 
 
-def _is_page_for_case(body, case_id):
+def _case_page_reason(body, case_id):
     page = _text(body)
     if PROBLEM_REPORT_MARKER in page:
-        return False
-    return _squashed(case_id) in _squashed(page)
+        return PROBLEM_REPORT_REASON
+    if _squashed(case_id) not in _squashed(page):
+        return WRONG_CASE_REASON
+    return None
 
 
 def _env_seconds(name, default_minutes):
@@ -237,8 +272,10 @@ class IcosClient:
     def _retry(self, what, build_request, validate=None):
         """Issue a request until it succeeds or the budget runs out.
 
-        validate() may inspect a successful body and raise, or return False to
-        treat the response as a retryable failure.
+        validate() may inspect a successful body and raise, or return a short
+        reason to treat the response as a retryable failure. It returns None
+        when the body is good. The reason is what the alert carries, so it is
+        written to be read in an email at four in the afternoon.
         """
         started = self._monotonic()
         budget = self.budget if what == "search" else self.case_budget
@@ -251,7 +288,8 @@ class IcosClient:
             endpoint = url.rsplit("/", 1)[-1].split("?")[0] or "ESAWebApp"
             result = self.reader.fetch_once(url, data)
             if result.ok:
-                if validate is None or validate(result.body):
+                reason = validate(result.body) if validate is not None else None
+                if reason is None:
                     self.landed_on[attempt + 1] = self.landed_on.get(attempt + 1, 0) + 1
                     if attempt >= SLOW_RECOVERY_ATTEMPTS:
                         # It worked, so staff see nothing. But ICOS needing this
@@ -265,16 +303,27 @@ class IcosClient:
                             note="The search went through, so nobody was told. "
                                  "ICOS is degrading.")
                     return result.body
+                # ICOS answered and the answer was wrong. Kept apart from the
+                # case below all the way to the subject line, because the two
+                # call for opposite things: this one is the court site's data,
+                # that one is the path to it.
+                failure = alerts.BAD_RESPONSE
+                extra = {'response size': '%db' % len(result.body)}
                 last = "unusable response"
             else:
+                reason = _refusal_reason(result)
+                failure = alerts.NO_ANSWER
+                # No body arrived, so its length is not a fact about anything.
+                # Reporting it as 0b was the whole reason a timeout and a
+                # problem report page read identically in the inbox.
+                extra = {}
                 last = result.outcome.lower()
 
             # Only after login: before it, an unusable response is usually a
             # rejected credential working as designed, which is not news.
             if self.logged_in:
-                self._alert(alerts.BAD_RESPONSE, endpoint=endpoint,
-                            attempts=attempt + 1, status=result.status,
-                            **{'response size': '%db' % len(result.body)})
+                self._alert(failure, endpoint=endpoint, reason=reason,
+                            attempts=attempt + 1, status=result.status, **extra)
 
             elapsed = self._monotonic() - started
             wait = backoff_for(attempt)
@@ -282,9 +331,9 @@ class IcosClient:
                 self.given_up += 1
                 self._alert(alerts.RETRY_EXHAUSTED, endpoint=endpoint,
                             attempts=attempt + 1, elapsed=_describe(elapsed),
-                            backoff=_timeline(waits),
+                            backoff=_timeline(waits), reason=reason,
                             note="Last result: %s. Staff were told to try again "
-                                 "later." % last)
+                                 "later." % reason)
                 if what == "search":
                     raise IcosUnavailable(
                         "Iowa Courts Online did not respond after %d minutes of "
@@ -334,7 +383,7 @@ class IcosClient:
             # is down. They then retype credentials that were always correct.
             body = self._retry("search",
                                lambda: self.reader.login_request(username, password),
-                               validate=_is_not_a_problem_report)
+                               validate=_problem_report_reason)
             text = body.decode("utf-8", errors="ignore")
 
             if BAD_CREDS_MARKER in text:
@@ -435,7 +484,7 @@ class IcosClient:
         return self._retry(
             "search",
             lambda: self.reader.search_request(firstname, middlename, lastname),
-            validate=_is_not_a_problem_report)
+            validate=_problem_report_reason)
 
     def case_bundle(self, case_id):
         """Summary, charges and financials for one case.
@@ -454,7 +503,7 @@ class IcosClient:
         """
         summary = self._retry(
             "case", lambda: self.reader.case_summary_request(case_id),
-            validate=lambda body: _is_page_for_case(body, case_id))
+            validate=lambda body: _case_page_reason(body, case_id))
         # These two get the same proof of identity as the summary rather than
         # just the problem report check. When ICOS degrades partway through a
         # case it answers with a stub that carries no problem report wording,
@@ -463,10 +512,10 @@ class IcosClient:
         # and on a criminal record those two mean opposite things.
         charges = self._retry(
             "case", self.reader.case_charges_request,
-            validate=lambda body: _is_page_for_case(body, case_id))
+            validate=lambda body: _case_page_reason(body, case_id))
         financials = self._retry(
             "case", self.reader.case_financials_request,
-            validate=lambda body: _is_page_for_case(body, case_id))
+            validate=lambda body: _case_page_reason(body, case_id))
         return summary, charges, financials
 
     def retry_summary(self):

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -188,6 +188,33 @@ def test_a_different_class_on_the_same_job_still_gets_through(mailbox):
     assert len(mailbox) == 2
 
 
+def test_ICOS_answering_wrongly_and_not_answering_are_separate_classes(mailbox):
+    """Why they are two classes rather than one with a field on it.
+
+    Suppression is keyed on the class and nothing else, so a run where ICOS
+    times out once and then serves problem report pages for an hour used to
+    send a single email about the timeout. The thing that stopped the run was
+    never mentioned.
+    """
+    assert alerts.NO_ANSWER != alerts.BAD_RESPONSE
+    send(alerts.record('job1234', 'crs', alerts.NO_ANSWER, reason='timed out'))
+    send(alerts.record('job1234', 'crs', alerts.BAD_RESPONSE,
+                       reason='problem report page'))
+    assert len(mailbox) == 2
+
+
+def test_the_reason_is_the_first_thing_under_the_failure(mailbox):
+    """It is the sentence that decides whether anyone needs to do anything, so
+    it does not belong in the alphabetical tail with the incidental fields."""
+    send(alerts.record('job1234', 'crs', alerts.BAD_RESPONSE,
+                       endpoint='TViewCaseCivil', attempts=4,
+                       reason='a page for a different case than the one asked for',
+                       **{'response size': '3407b'}))
+    body = mailbox[0]['text']
+    assert 'different case' in body, body
+    assert body.index('reason:') < body.index('endpoint:'), body
+
+
 def test_a_second_job_inside_the_floor_is_suppressed(mailbox):
     send(alerts.record('job1234', 'search', alerts.BAD_RESPONSE, now=1000.0))
     # A clinic morning puts several staff behind the same broken ICOS.

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -10,7 +10,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import icos
 from icos import (IcosAccountLocked, IcosBadCredentials, IcosClient,
                   IcosStopped, IcosUnavailable)
-from reader import EMPTY, OK, TIMEOUT, FetchResult
+import alerts
+from reader import EMPTY, ERROR, OK, TIMEOUT, FetchResult
 
 LOGIN_OK = b"x" * 28000
 CONCURRENT_PAGE = b"<html>Concurrent Login Error: A user is already logged on</html>"
@@ -447,3 +448,102 @@ def test_a_stopped_run_can_still_log_off():
     client.logoff()
     assert "EPALogout" in client.reader.calls
     assert client.logged_in is False
+
+
+class TestWhatTheAlertSays:
+    """Which of five different things went wrong.
+
+    Every failed attempt used to reach the inbox as "unusable response from
+    ICOS" with a size field, including the ones where nothing came back at all
+    and the size was 0b. Five causes, one subject line, and because
+    alerts.record only emails the first of each class per run, whichever
+    happened first silenced the other four.
+
+    That is not a tidiness complaint. On 2026-08-01 a clinic batch stopped at
+    1 of 67 cases and the only email about why said "unusable response, 0b",
+    which is what a timeout looks like. What actually stopped the run was ICOS
+    serving problem report pages, and no email said so. Working out which had
+    happened meant reading the source rather than the alert.
+
+    A court site that is down and a session that has lost its place also look
+    identical from outside, and only one of them is Iowa's fault.
+    """
+
+    def _first_alert(self, script):
+        seen = []
+        client, _, _ = build(script, case_budget_seconds=20)
+        client.set_alert(lambda failure, **fields: seen.append((failure, fields)))
+        client.logged_in = True          # alerts are held until after login
+        with pytest.raises(IcosUnavailable):
+            client.case_bundle(CASE_ID)
+        assert seen, 'a failing case must alert at all before this proves anything'
+        return seen[0]
+
+    def test_a_timeout_is_not_called_an_unusable_response(self):
+        failure, fields = self._first_alert([FetchResult(TIMEOUT)] * 50)
+        assert failure == alerts.NO_ANSWER
+        assert 'timeout' in fields['reason']
+        # 0b is not a fact about a response that never arrived, and printing it
+        # is what made this indistinguishable from a page that came back wrong.
+        assert 'response size' not in fields
+
+    def test_an_empty_body_says_so(self):
+        """The live shape: ICOS answers a case request with 200 and nothing in
+        it when the session never selected that case through a search."""
+        failure, fields = self._first_alert([FetchResult(EMPTY)] * 50)
+        assert failure == alerts.NO_ANSWER
+        assert 'empty body' in fields['reason']
+
+    def test_a_transport_error_carries_what_the_transport_said(self):
+        failure, fields = self._first_alert(
+            [FetchResult(ERROR, b'', '503', 0.1, 'HTTP Error 503')] * 50)
+        assert failure == alerts.NO_ANSWER
+        assert '503' in fields['reason']
+
+    def test_a_problem_report_page_is_named_as_one(self):
+        failure, fields = self._first_alert([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 50)
+        assert failure == alerts.BAD_RESPONSE
+        assert 'problem report' in fields['reason']
+        assert fields['response size'] != '0b'   # this one did arrive
+
+    def test_a_page_for_the_wrong_case_is_named_as_one(self):
+        """The dangerous one. It carries no problem report wording, wears some
+        other case's heading and lists nothing, so accepting it writes a
+        conviction down as a non-conviction."""
+        failure, fields = self._first_alert([FetchResult(OK, STUB_CASE_PAGE)] * 50)
+        assert failure == alerts.BAD_RESPONSE
+        assert 'different case' in fields['reason']
+
+    def test_the_five_causes_do_not_collapse_into_each_other(self):
+        """The property that matters, stated as one assertion.
+
+        alerts.record dedupes on the failure class and on nothing else, so two
+        causes sharing a class means hearing about one of them and never the
+        other. Distinct (class, reason) pairs are what keeps that from
+        happening.
+        """
+        scripts = [
+            [FetchResult(TIMEOUT)] * 50,
+            [FetchResult(EMPTY)] * 50,
+            [FetchResult(ERROR, b'', '503', 0.1, 'HTTP Error 503')] * 50,
+            [FetchResult(OK, PROBLEM_REPORT_PAGE)] * 50,
+            [FetchResult(OK, STUB_CASE_PAGE)] * 50,
+        ]
+        seen = [self._first_alert(script) for script in scripts]
+        pairs = {(failure, fields['reason']) for failure, fields in seen}
+        assert len(pairs) == len(scripts), pairs
+
+    def test_the_giving_up_email_says_what_it_gave_up_on(self):
+        """RETRY_EXHAUSTED used to end on "Last result: unusable response",
+        which is the same sentence for all five."""
+        seen = []
+        client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 50,
+                             case_budget_seconds=20)
+        client.set_alert(lambda failure, **fields: seen.append((failure, fields)))
+        client.logged_in = True
+        with pytest.raises(IcosUnavailable):
+            client.case_bundle(CASE_ID)
+        gave_up = [fields for failure, fields in seen
+                   if failure == alerts.RETRY_EXHAUSTED]
+        assert gave_up, 'a case that ran out its budget must say so'
+        assert 'problem report' in gave_up[0]['note']


### PR DESCRIPTION
Yesterday at 16:45 a clinic batch stopped at 1 of 67 cases. The only email that explained why said `unusable response from ICOS, 3407b`, and the giving-up email that followed said `Last result: unusable response.`

That is also what Napier says when a request times out, when a body comes back empty, when the transport errors, and when ICOS serves a page for a different case than the one asked for. Five causes, one subject line, and three of them produced byte-identical mail down to `response size: 0b`.

`0b` is not a fact about a response that never arrived. Printing it is what made a timeout and a page that came back wrong read the same.

It is worse than confusing, because `alerts.record` sends the first of each failure class per run and suppresses the rest. A run where ICOS times out once and then serves problem report pages for an hour sent one email, about the timeout, and never mentioned the thing that stopped the run.

## What changed

Validators answer with a reason instead of true or false, and the reason is what the alert carries.

`unusable response from ICOS` and the new `no answer from ICOS` are separate classes, because they are suppressed separately and they ask for opposite things to be looked at: a bad body is the court site's data, no body is the path to it.

The reason leads the email, above the endpoint and the attempt count. The size field is dropped when there was no body to size. The giving-up email names the cause it gave up on rather than repeating the class.

## The fifth reason

Found while trying to reproduce the 3407 byte page against the live site: ICOS answers a case request with a 200 and nothing in it when the session has not selected that case through a search first. A court site that is down and a session that has lost its place look identical from outside, and only one of them is Iowa's fault.

## Testing

672 passed, up from 663. All nine new tests were confirmed to fail against the code without this change, each for the reason it names.

The one that matters drives all five causes through a failing case and asserts the resulting alerts are five distinct pairs of class and reason, so a later change that collapses any two of them fails there rather than in an inbox.

No client data in the diff. Fixtures use the synthetic case number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t