### PR TITLE
Believe ICOS when it says it is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ stops and builds from what it has. Names are counted separately at three,
 because an unanswered name costs the 45 minute search budget rather than the
 four minute case budget.
 
+Six and three are both guesses about what the silence means. Sometimes ICOS says
+it in words instead: a request that spent its whole budget being handed the court
+site's own problem report page, which is ICOS reporting that its own data source
+is unreachable, is counted a second time on its own and stops the run at two.
+Sealed cases and stalls cannot produce that page, so the reason six exists is
+untouched. Two rather than one, because a court site can serve one of these and
+come back. The progress log says which of the two stopped the run, since one of
+them means the account and the machine in front of the staffer are fine.
+
 Anything left missing is offered back as a retry, on the run's own finish page,
 for the two hours the job is kept. A retry signs in again, puts the same search
 back in front of ICOS, asks only for the cases that are still missing, and

--- a/icos.py
+++ b/icos.py
@@ -174,7 +174,18 @@ class IcosAccountLocked(IcosError):
 
 
 class IcosUnavailable(IcosError):
-    pass
+    """ICOS would not hand something over inside its retry budget.
+
+    court_site_down says ICOS gave the reason itself rather than leaving it to
+    be worked out. A problem report page is the court site reporting that its
+    own data source is unreachable, which is a different quality of evidence
+    from a request that simply never came back, and the run's outage counter is
+    allowed to believe it sooner.
+    """
+
+    def __init__(self, message, court_site_down=False):
+        super().__init__(message)
+        self.court_site_down = court_site_down
 
 
 class IcosStopped(IcosError):
@@ -334,16 +345,23 @@ class IcosClient:
                             backoff=_timeline(waits), reason=reason,
                             note="Last result: %s. Staff were told to try again "
                                  "later." % reason)
+                # Carried out to the caller because the run's outage counter
+                # wants it: six cases that never arrived is a guess about the
+                # site, two that spent their whole budget being told ICOS
+                # cannot reach its own data is not.
+                declared = reason == PROBLEM_REPORT_REASON
                 if what == "search":
                     raise IcosUnavailable(
                         "Iowa Courts Online did not respond after %d minutes of "
                         "retrying (last result: %s). The court site is likely down. "
-                        "Please try again later." % (round(budget / 60), last))
+                        "Please try again later." % (round(budget / 60), last),
+                        court_site_down=declared)
                 # The caller drops this one case and carries on, so this text
                 # is not staff-facing advice about the whole run.
                 raise IcosUnavailable(
                     "Iowa Courts Online did not return this case after %d minutes of "
-                    "retrying (last result: %s)." % (round(budget / 60), last))
+                    "retrying (last result: %s)." % (round(budget / 60), last),
+                    court_site_down=declared)
             # Checked here rather than only between cases, because the whole
             # reason somebody reaches for stop is that a wait is in progress.
             if self._should_stop():

--- a/tasks.py
+++ b/tasks.py
@@ -34,6 +34,20 @@ CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 6
 # names do not come in runs the way one client's sealed cases do.
 SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 3
 
+# When ICOS says it itself. A problem report page is the court site reporting
+# that its own data source is unreachable, so a request that spent its entire
+# budget being told that is not the ambiguous thing six exists to protect
+# against. On 2026-08-01 a run met one and burned four minutes per case
+# rediscovering what the very first response had already said; under today's
+# threshold the same outage would take twenty three minutes to confirm, or
+# ninety on the search side.
+#
+# Two rather than one, because a court site can serve one of these and come
+# back, and the cost of being wrong is a clinic list that ends early. Sealed
+# cases, stalls and timeouts cannot produce it at all, so the reason cases stop
+# at six and names at three is untouched.
+ICOS_DECLARED_ITSELF_DOWN_IS_AN_OUTAGE = 2
+
 
 class Outage:
     """How many cases in a row Iowa Courts has refused, counted across a run.
@@ -50,24 +64,63 @@ class Outage:
     real client can have, and that client's bad luck should not end the list
     for the nineteen names behind them. Six costs about twenty three minutes
     during a real outage, which is the price of not throwing away good runs.
+
+    Refusals where ICOS reported its own outage are counted a second time on
+    their own and stop the run at two, because that price is only worth paying
+    while the cause is still in doubt.
     """
 
-    def __init__(self, threshold=CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE):
+    def __init__(self, threshold=CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE,
+                 declared_threshold=ICOS_DECLARED_ITSELF_DOWN_IS_AN_OUTAGE):
         self.threshold = threshold
+        self.declared_threshold = declared_threshold
         self.failures = 0
+        self.declared = 0
 
     @property
     def over(self):
-        return self.failures >= self.threshold
+        return self.failures >= self.threshold or self.declared_down
+
+    @property
+    def declared_down(self):
+        """The run stopped because ICOS said it was down, not because we guessed.
+
+        Staff are told which of the two it was, since one of them means the
+        account and the machine in front of them are fine.
+        """
+        return self.declared >= self.declared_threshold
 
     def worked(self):
         """A case came back. Whatever came before it was not an outage."""
         self.failures = 0
+        self.declared = 0
 
-    def failed(self):
-        """A case did not come back. True if that is now enough to stop."""
+    def failed(self, declared=False):
+        """A case did not come back. True if that is now enough to stop.
+
+        declared is ICOS having reported its own outage rather than having
+        simply not answered.
+        """
         self.failures += 1
+        if declared:
+            self.declared += 1
         return self.over
+
+
+def stopped_responding(*counters, past=False):
+    """How the run describes a dead site to staff, in half a sentence.
+
+    Written once and used at every place a run says this, because a staffer
+    reading that Iowa Courts reported its own system unavailable stops
+    wondering whether it is their account, their password or their laptop, and
+    that is the whole value of having told the two apart upstream.
+    """
+    if any(counter.declared_down for counter in counters):
+        return ("Iowa Courts had reported that its own system was unavailable"
+                if past else
+                "Iowa Courts reported that its own system is unavailable")
+    return "Iowa Courts had stopped responding" if past else \
+        "Iowa Courts stopped responding"
 
 
 tmp_dir = '/tmp/'
@@ -225,7 +278,7 @@ def _pull_cases(job, client, case_ids, offset=0, total=None, outage=None):
                           case=case_id,
                           note="%s The run carried on without it." % e.message)
             failed.append(case_id)
-            if outage.failed():
+            if outage.failed(declared=getattr(e, 'court_site_down', False)):
                 not_attempted = case_ids[index:]
                 break
             continue
@@ -251,9 +304,10 @@ def _pull_cases(job, client, case_ids, offset=0, total=None, outage=None):
 
     if not_attempted:
         failed.extend(not_attempted)
-        job.log("Iowa Courts stopped responding, so the last %d case%s could not "
-                "be pulled. The workbook has the rest."
-                % (len(not_attempted), "" if len(not_attempted) == 1 else "s"))
+        job.log("%s, so the last %d case%s could not be pulled. The workbook "
+                "has the rest."
+                % (stopped_responding(outage), len(not_attempted),
+                   "" if len(not_attempted) == 1 else "s"))
     return cases, failed
 
 
@@ -336,7 +390,11 @@ def batch_search_task(job, username, password, people, rejected=()):
         client.login(username, password)
 
         clients = []
-        failures_in_a_row = 0
+        # A counter rather than an int, so a name refused because ICOS said it
+        # was down stops the list at two. A name costs the 45 minute search
+        # budget, so the third one is an hour and a half spent confirming what
+        # the first refusal already said in words.
+        dead_searches = Outage(threshold=SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE)
         for index, person in enumerate(people, start=1):
             _stop_if_asked(job)
             job.log("Searching Iowa Courts for name %d of %d..."
@@ -355,19 +413,20 @@ def batch_search_task(job, username, password, people, rejected=()):
                 raise
             except IcosError as e:
                 entry['error'] = e.message
-                failures_in_a_row += 1
-                if failures_in_a_row >= SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE:
+                if dead_searches.failed(
+                        declared=getattr(e, 'court_site_down', False)):
                     for skipped in people[index:]:
                         clients.append({
                             'name': roster.describe(skipped), 'keys': [],
                             'cases': {}, 'too_many_results': False,
-                            'error': "Iowa Courts had stopped responding "
-                                     "before Napier reached this name."})
-                    job.log("Iowa Courts stopped responding, so the rest of the "
-                            "list was not searched.")
+                            'error': "%s before Napier reached this name."
+                                     % stopped_responding(dead_searches,
+                                                          past=True)})
+                    job.log("%s, so the rest of the list was not searched."
+                            % stopped_responding(dead_searches))
                     break
                 continue
-            failures_in_a_row = 0
+            dead_searches.worked()
             cases, too_many = case_parser.parse_search(body)
             report_novel_roles(job, cases)
             entry['cases'], entry['keys'] = group_cases(cases)
@@ -388,7 +447,11 @@ def batch_search_task(job, username, password, people, rejected=()):
 
 
 def _reselect(job, client, pick):
-    """Put this client's search results back in front of ICOS. True if it took.
+    """Put this client's search results back in front of ICOS.
+
+    Answers (whether it took, whether ICOS reported its own outage), because
+    the caller's dead-search counter believes the second one sooner than it
+    believes a name that merely went unanswered.
 
     Nothing is read out of the response. The point is the side effect: ICOS
     decides which case a case request means from whatever it answered last,
@@ -401,7 +464,7 @@ def _reselect(job, client, pick):
     """
     person = pick.get('person')
     if not person:
-        return False
+        return False, False
     try:
         client.search(person['first'], person['middle'], person['last'])
     except IcosStopped:
@@ -411,8 +474,8 @@ def _reselect(job, client, pick):
                       progress=alerts.recent_progress(job),
                       case="(re-search before pulling a client's cases)",
                       note="%s That client was skipped." % e.message)
-        return False
-    return True
+        return False, getattr(e, 'court_site_down', False)
+    return True, False
 
 
 def batch_crs_task(job, session_token, picks, is_lite):
@@ -480,22 +543,24 @@ def batch_crs_task(job, session_token, picks, is_lite):
             if outage.over or dead_searches.over:
                 if not announced:
                     announced = True
-                    job.log("Iowa Courts stopped responding, so the rest of the "
-                            "list was not pulled.")
+                    job.log("%s, so the rest of the list was not pulled."
+                            % stopped_responding(outage, dead_searches))
                 pulled += len(pick['case_ids'])
                 record['failed'] = list(pick['case_ids'])
                 entry['failed'] = list(pick['case_ids'])
-                record['error'] = ("Iowa Courts had stopped responding before "
-                                   "Napier reached this client, so their cases "
-                                   "were not pulled.")
+                record['error'] = ("%s before Napier reached this client, so "
+                                   "their cases were not pulled."
+                                   % stopped_responding(outage, dead_searches,
+                                                        past=True))
                 continue
 
             job.log("Client %d of %d: pulling %d case%s..."
                     % (index, len(picks), len(pick['case_ids']),
                        "" if len(pick['case_ids']) == 1 else "s"),
                     count=pulled, total=total_cases)
-            if not _reselect(job, client, pick):
-                dead_searches.failed()
+            reselected, site_down = _reselect(job, client, pick)
+            if not reselected:
+                dead_searches.failed(declared=site_down)
                 pulled += len(pick['case_ids'])
                 record['failed'] = list(pick['case_ids'])
                 entry['failed'] = list(pick['case_ids'])
@@ -710,21 +775,23 @@ def retry_task(job, username, password, payload):
                 skipped = True
                 if not announced:
                     announced = True
-                    job.log("Iowa Courts stopped responding, so the rest of "
-                            "the missing cases were not tried again.")
+                    job.log("%s, so the rest of the missing cases were not "
+                            "tried again."
+                            % stopped_responding(outage, dead_searches))
                 pulled += len(entry['failed'])
             elif entry['failed']:
                 job.log("Client %d of %d: trying %d case%s again..."
                         % (index, len(entries), len(entry['failed']),
                            "" if len(entry['failed']) == 1 else "s"),
                         count=pulled, total=total)
-                if _reselect(job, client, entry):
+                reselected, site_down = _reselect(job, client, entry)
+                if reselected:
                     dead_searches.worked()
                     recovered, still_failed = _pull_cases(
                         job, client, entry['failed'], offset=pulled,
                         total=total, outage=outage)
                 else:
-                    dead_searches.failed()
+                    dead_searches.failed(declared=site_down)
                     reselect_failed = True
                 pulled += len(entry['failed'])
                 recovered_total += len(recovered)
@@ -739,9 +806,11 @@ def retry_task(job, username, password, payload):
                                         cases, still_failed))
             if not cases:
                 if skipped:
-                    record['error'] = ("Iowa Courts had stopped responding "
-                                       "before Napier reached this client, so "
-                                       "there is still no workbook for them.")
+                    record['error'] = ("%s before Napier reached this client, "
+                                       "so there is still no workbook for them."
+                                       % stopped_responding(outage,
+                                                            dead_searches,
+                                                            past=True))
                 elif reselect_failed:
                     record['error'] = ("Iowa Courts would not answer this "
                                        "client's name, so there is still no "

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -547,3 +547,51 @@ class TestWhatTheAlertSays:
                    if failure == alerts.RETRY_EXHAUSTED]
         assert gave_up, 'a case that ran out its budget must say so'
         assert 'problem report' in gave_up[0]['note']
+
+
+class TestWhatTheRunIsToldToBelieve:
+    """Whether ICOS said it was down, or merely failed to answer.
+
+    The run's outage counter stops a clinic list after six refused cases,
+    which is about twenty three minutes, and that price buys the difference
+    between one client's sealed cases and a dead court site. When ICOS has
+    already answered that question by serving its problem report page, the
+    price is not owed, so the flag has to reach the caller. It travels on the
+    exception because that is the only thing the caller gets.
+    """
+
+    def _bundle_failure(self, script):
+        client, _, _ = build(script, case_budget_seconds=20)
+        client.logged_in = True
+        with pytest.raises(IcosUnavailable) as caught:
+            client.case_bundle(CASE_ID)
+        return caught.value
+
+    def test_a_problem_report_page_reaches_the_caller_as_one(self):
+        failure = self._bundle_failure([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 50)
+        assert failure.court_site_down is True
+
+    def test_a_timeout_does_not_claim_ICOS_said_anything(self):
+        """It is the same outage from the outside and a different one to
+        anybody diagnosing it, which is the whole reason for the flag."""
+        failure = self._bundle_failure([FetchResult(TIMEOUT)] * 50)
+        assert failure.court_site_down is False
+
+    def test_nor_does_a_page_for_the_wrong_case(self):
+        failure = self._bundle_failure([FetchResult(OK, STUB_CASE_PAGE)] * 50)
+        assert failure.court_site_down is False
+
+    def test_a_search_carries_it_too(self):
+        """A refused name costs the 45 minute search budget rather than a
+        case's four, so this is worth more on the search side than the case
+        side."""
+        client, _, _ = build([FetchResult(OK, PROBLEM_REPORT_PAGE)] * 50,
+                             budget_seconds=20)
+        client.logged_in = True
+        with pytest.raises(IcosUnavailable) as caught:
+            client.search('PAT', '', 'DOE')
+        assert caught.value.court_site_down is True
+
+    def test_the_default_is_no_claim(self):
+        """Every other raise site in the app builds one of these by hand."""
+        assert IcosUnavailable('anything').court_site_down is False

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -53,9 +53,13 @@ class StubClient:
 
     logged_in = True
 
-    def __init__(self, dead_cases=(), dead_searches=()):
+    def __init__(self, dead_cases=(), dead_searches=(), court_site_down=False):
         self.dead_cases = set(dead_cases)
         self.dead_searches = set(dead_searches)
+        # ICOS refusing with its own problem report page rather than simply
+        # not answering. The client hands that out to the run as a flag on the
+        # exception, so a stub that cannot set it cannot exercise the path.
+        self.court_site_down = court_site_down
         self.searched = []
         self.asked = []
 
@@ -74,6 +78,9 @@ class StubClient:
     def search(self, first, middle, last):
         self.searched.append(last)
         if last in self.dead_searches:
+            if self.court_site_down:
+                raise IcosUnavailable("Iowa Courts Online did not respond",
+                                      court_site_down=True)
             raise IcosError("Iowa Courts did not answer.")
         return b'<results>'
 
@@ -81,7 +88,8 @@ class StubClient:
         self.asked.append(case_id)
         if case_id in self.dead_cases:
             raise IcosUnavailable("Iowa Courts Online did not return this case "
-                                  "after 4 minutes of retrying")
+                                  "after 4 minutes of retrying",
+                                  court_site_down=self.court_site_down)
         return b'<summary>', b'<charges>', b'<financials>'
 
     def logoff(self):
@@ -126,8 +134,9 @@ def pick(surname, case_ids):
             'person': person(surname), 'case_ids': list(case_ids)}
 
 
-def run_list(monkeypatch, picks, dead_cases=(), dead_searches=()):
-    stub = StubClient(dead_cases, dead_searches)
+def run_list(monkeypatch, picks, dead_cases=(), dead_searches=(),
+             court_site_down=False):
+    stub = StubClient(dead_cases, dead_searches, court_site_down)
     monkeypatch.setattr(icos_sessions, 'claim', lambda token: stub)
     job = FakeJob()
     try:
@@ -175,6 +184,119 @@ class TestTheCounterItself:
         watch a dead site, not a tuning knob."""
         assert tasks.Outage().threshold == 6
         assert tasks.CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE == 6
+
+
+class TestWhenICOSSaysItItself:
+    """Six is the price of not knowing. It is not owed when ICOS has said so.
+
+    A problem report page is the court site reporting that its own data source
+    is unreachable. Napier already told that apart from a request that never
+    came back, but only in the alert: the run's counter treated the two the
+    same and spent six cases at four minutes apiece, about twenty three
+    minutes, rediscovering what the very first response had said in words. On
+    the search side, where a name carries the forty-five minute budget, three
+    of them is an hour and a half.
+
+    Six exists to protect one client's sealed cases from ending the list for
+    the nineteen names behind them. Sealed cases cannot produce a problem
+    report page, so nothing about that is given up here.
+    """
+
+    def test_two_refusals_ICOS_declared_are_enough(self):
+        outage = tasks.Outage()
+        assert outage.failed(declared=True) is False
+        assert outage.failed(declared=True) is True
+        assert outage.over
+
+    def test_a_refusal_that_says_nothing_still_costs_the_full_six(self):
+        """The whole point of splitting them. If an ordinary refusal tripped at
+        two, one client's bad patch would end a clinic list."""
+        outage = tasks.Outage()
+        for _ in range(5):
+            assert outage.failed() is False
+        assert not outage.over
+        assert outage.failed() is True
+
+    def test_a_case_coming_back_clears_the_declared_count_too(self):
+        """Otherwise a site that blinked twice across a whole morning would
+        stop a run that was working fine in between."""
+        outage = tasks.Outage()
+        outage.failed(declared=True)
+        outage.worked()
+        assert outage.failed(declared=True) is False
+        assert not outage.over
+
+    def test_the_number_is_named_and_is_below_both_others(self):
+        """Named here because moving it is a decision about how long staff
+        watch a site that has already said it is down."""
+        assert tasks.ICOS_DECLARED_ITSELF_DOWN_IS_AN_OUTAGE == 2
+        assert (tasks.ICOS_DECLARED_ITSELF_DOWN_IS_AN_OUTAGE
+                < tasks.SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE
+                < tasks.CASES_FAILED_IN_A_ROW_IS_AN_OUTAGE)
+
+    def test_it_applies_to_the_search_counter_at_the_same_two(self):
+        """A refused name costs the 45 minute search budget, so this saves more
+        here than it does on cases."""
+        searches = tasks.Outage(
+            threshold=tasks.SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE)
+        assert searches.failed(declared=True) is False
+        assert searches.failed(declared=True) is True
+
+    def test_a_clinic_list_stops_after_two_cases_not_six(self, monkeypatch):
+        dead = ids('FECR', 8)
+        job, stub = run_list(monkeypatch,
+                             [pick('DOE', dead), pick('ROE', ids('SRCR', 4))],
+                             dead_cases=dead, court_site_down=True)
+
+        assert stub.asked == dead[:2], stub.asked
+        assert stub.searched == ['DOE']
+
+    def test_the_same_list_without_the_page_still_costs_six(self, monkeypatch):
+        """The control. Same stub, same refusals, one flag different."""
+        dead = ids('FECR', 8)
+        job, stub = run_list(monkeypatch,
+                             [pick('DOE', dead), pick('ROE', ids('SRCR', 4))],
+                             dead_cases=dead, court_site_down=False)
+
+        assert stub.asked == dead[:6], stub.asked
+
+    def test_staff_are_told_the_court_site_said_so(self, monkeypatch):
+        """A staffer watching a run die wants to know whether it is their
+        account, their password or their laptop. When ICOS has answered that
+        question, passing the answer on costs nothing."""
+        dead = ids('FECR', 8)
+        job, _ = run_list(monkeypatch,
+                          [pick('DOE', dead), pick('ROE', ids('SRCR', 4))],
+                          dead_cases=dead, court_site_down=True)
+
+        assert job.said('reported that its own system is unavailable')
+        assert not job.said('Iowa Courts stopped responding')
+
+    def test_a_client_nobody_reached_says_the_same_thing(self, monkeypatch):
+        """The finish page outlives the progress log, so the row for a client
+        who was never pulled has to carry it too."""
+        doe, roe = ids('FECR', 8), ids('SRCR', 4)
+        job, _ = run_list(monkeypatch, [pick('DOE', doe), pick('ROE', roe)],
+                          dead_cases=doe[2:], court_site_down=True)
+
+        skipped = job.result['clients'][1]
+        assert skipped['failed'] == roe
+        assert 'its own system was unavailable' in skipped['error'], skipped
+
+    def test_a_batch_search_stops_after_two_names(self, monkeypatch):
+        names = ['DOE', 'ROE', 'POE', 'MOE']
+        stub = StubClient(dead_searches=names, court_site_down=True)
+        monkeypatch.setattr(tasks, 'IcosClient',
+                            lambda log=None, alert=None, **kw: stub)
+        monkeypatch.setattr(tasks.icos_sessions, 'put', lambda client: 'tok')
+        monkeypatch.setattr(tasks.case_parser, 'parse_search',
+                            lambda body: ([], False))
+        job = FakeJob()
+        tasks.batch_search_task(job, 'ILATEST', 'secret',
+                               [person(n) for n in names])
+
+        assert stub.searched == names[:2], stub.searched
+        assert job.said('reported that its own system is unavailable')
 
 
 class TestAClinicListMeetingADeadSite:


### PR DESCRIPTION
A run stops a clinic list after six cases in a row refuse. Six is a guess about what silence means, and it costs about twenty three minutes to make, or ninety on the search side where a name carries the 45 minute retry budget rather than the four minute one.

ICOS does not always leave it to be guessed. When it cannot reach its own data source it answers with a problem report page saying so, and #77 gave that page a name. Nothing then read the name, so a case that spent its whole budget being told in words that the court site was down cost exactly what a case that never answered cost.

That page is not hypothetical. On 2026-07-30, widening the parser sample past Polk County against the live site, 45 case requests in a row came back as it, byte for byte identical. Notably the charges and financials pages during the same outage carried no problem report wording at all, which is why the detector is the marker plus a case number echo rather than the marker alone.

Refusals ICOS declared are now counted a second time, on their own, and stop the run at two. Two rather than one because a court site can serve one of these and come back, and the cost of being wrong is a clinic list that ends early. The ambiguous count is untouched: sealed cases, stalls and timeouts cannot produce a problem report page, so nothing the six was protecting is given up. The search counter gets the same treatment at the same two.

Staff are told which of the two happened, since "Iowa Courts reported that its own system is unavailable" means the account and the laptop in front of them are fine. That sentence lived in seven places and now lives in one.

## Also in here

Four comments claimed problem report pages were what stopped the 2026-08-01 run. That was firmer than the evidence. What is known is that the run stopped at 1 of 67, that the one email said "unusable response, 0b", and that the digest listed a 3407 byte reply carrying a 200 under the same subject line. Which of the five that body was cannot be recovered from what was sent, which is the defect #77 fixed rather than a finding it produced. The July capture is the direct evidence; the August run is a size that matches it.

## Testing

- Full suite: 687 passed.
- 15 new tests, each run against the code without the change: 14 fail, and the one that passes is the control asserting a refusal with no reason attached still costs the full six.
- Shipped detectors run against the 45 real captured outage pages: the marker fires on all 45 summaries, and the case number echo catches the charges and financials stubs that carry no marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t