### PR TITLE
Say what the August run actually proved, and what it did not

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,13 @@ carries the reason as its first line. They used to be one class with a size
 field on it, so a timeout, an empty body, a transport error, an ICOS problem
 report page and a page for the wrong case all arrived worded identically, and
 since it is one email per class per job, whichever happened first silenced the
-rest. On 2026-08-01 that meant one email saying "unusable response, 0b" while
-what actually stopped the run was ICOS serving problem report pages. A court
-site that is down and a session that has lost its place look the same from
-outside, and only one of them is Iowa's fault.
+rest. On 2026-08-01 that meant one email saying "unusable response, 0b", which
+is what a timeout looks like, while the digest for the same run listed a 3407
+byte reply carrying a 200 under that same subject line. Which of the five that
+body was is no longer recoverable, because the one email that would have said so
+had already been spent on something else. A court site that is down and a
+session that has lost its place look the same from outside, and only one of them
+is Iowa's fault.
 
 The last two are the ones nothing else would catch, because the server thinks
 those runs went fine. A staffer whose phone drops the progress page sees a

--- a/icos.py
+++ b/icos.py
@@ -72,8 +72,10 @@ def _squashed(text):
 # reached it the same way with "0b", which reads as a page that arrived wrong
 # rather than one that never arrived. Five causes, one email, and since
 # alerts.record only sends the first of each class per run, whichever happened
-# first silenced the rest. On 2026-08-01 that meant one email about a timeout
-# and nothing about the problem report pages that actually stopped the run.
+# first silenced the rest. On 2026-08-01 that meant one email about a timeout,
+# while the digest for the same run listed a 3407 byte reply carrying a 200 that
+# had been filed under that same subject line. Which of the five that body was
+# cannot be established from anything that was sent, which is the defect itself.
 PROBLEM_REPORT_REASON = ("ICOS problem report page, meaning its own data source "
                          "was unreachable")
 WRONG_CASE_REASON = "a page for a different case than the one asked for"

--- a/tasks.py
+++ b/tasks.py
@@ -37,10 +37,12 @@ SEARCHES_FAILED_IN_A_ROW_IS_AN_OUTAGE = 3
 # When ICOS says it itself. A problem report page is the court site reporting
 # that its own data source is unreachable, so a request that spent its entire
 # budget being told that is not the ambiguous thing six exists to protect
-# against. On 2026-08-01 a run met one and burned four minutes per case
-# rediscovering what the very first response had already said; under today's
-# threshold the same outage would take twenty three minutes to confirm, or
-# ninety on the search side.
+# against. This is measured on the 2026-07-30 capture, where 45 case requests in
+# a row came back as that page, byte for byte the same, while ICOS was
+# degrading. A run that walks into that spends four minutes per case
+# rediscovering what the first response already said in words, so under the
+# ambiguous threshold it takes twenty three minutes to confirm, or ninety on the
+# search side.
 #
 # Two rather than one, because a court site can serve one of these and come
 # back, and the cost of being wrong is a clinic list that ends early. Sealed

--- a/tests/test_icos_retry.py
+++ b/tests/test_icos_retry.py
@@ -461,9 +461,11 @@ class TestWhatTheAlertSays:
 
     That is not a tidiness complaint. On 2026-08-01 a clinic batch stopped at
     1 of 67 cases and the only email about why said "unusable response, 0b",
-    which is what a timeout looks like. What actually stopped the run was ICOS
-    serving problem report pages, and no email said so. Working out which had
-    happened meant reading the source rather than the alert.
+    which is what a timeout looks like. The digest for the same run also listed
+    a 3407 byte reply carrying a 200, filed under that same subject line. Which
+    of the five that body was cannot be established from what was sent, and that
+    is the defect: the email that would have named it had gone out about
+    something else.
 
     A court site that is down and a session that has lost its place also look
     identical from outside, and only one of them is Iowa's fault.


### PR DESCRIPTION
Follow-up to #78, which was merged before this correction could go into it.

Four source comments and one README paragraph claim that ICOS problem report pages were what stopped the 2026-08-01 clinic batch. That is firmer than the evidence supports.

What is actually known about that run: it stopped at 1 of 67, the one email that went out said `unusable response, 0b`, which is what a timeout looks like, and the digest for the same run listed a 3407 byte reply carrying a 200 under that same subject line. Which of the five causes that body was cannot be recovered from anything that was sent, because at the time all five shared one alert class and the first one out silenced the rest.

That is the defect #77 fixed, not a finding #77 produced. Left in the source it turns an absence of evidence into evidence, in exactly the comments meant to explain why the thresholds are set where they are.

The direct evidence for the page is better anyway, so the comments now point at it instead. On 2026-07-30, widening the parser sample past Polk County against the live site, 45 case requests in a row came back as the problem report page, byte for byte identical. The 3407 bytes seen in August resembles that capture's 3404, and it is now written down as a resemblance.

## Scope

No behaviour changes. Comments, one README paragraph, one test docstring.

## Testing

- Full suite: 687 passed.
- Detectors re-run against the 45 real captured pages: the marker fires on all 45 summaries, and the case number echo catches the charges and financials stubs, which carry no marker at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t