### PR TITLE
Keep the page Iowa Courts serves when it says it is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ progress log, because the log is what alert mail carries out. Nothing about a
 client is written to browser storage, since the machine is shared. Each of these
 guards has a test that fails when the guard is removed.
 
+The one thing Napier ever sends out whole is the page ICOS serves when it has
+declared itself down, and it goes redacted. See "Proving an outage to the
+court" under Alerts for what comes out of it first and why the rest may stay.
+
 ## Production
 
 The application runs on [Heroku](https://www.heroku.com/). `crs-napier` is production; `napier-dev` is staging and auto-deploys from `main`.
@@ -227,6 +231,36 @@ that were suppressed.
 The keepalive used to log every ping, which was 4,300 lines a day and buried
 everything worth reading. It now logs state changes and a heartbeat every ten
 minutes.
+
+### Proving an outage to the court
+
+Every alert above is Napier's account of a bad morning, and Napier's account is
+the thing a court would question. So when ICOS answers with the page that says
+in its own wording that it cannot reach its own data source, Napier keeps that
+page and emails a copy, at most once every fifteen minutes across the whole
+dyno. The mail carries the time in UTC and local, the endpoint, the case that
+was requested, the HTTP status, the attempt count, and a sha256 of the page as
+ICOS served it. That is a report Iowa Courts can act on rather than a
+complaint.
+
+Only that one page type is ever attached. Napier can recognise it, so it knows
+what is on it and can take out what has to come out. A real case page names a
+defendant and a search results page lists everyone who matched with their dates
+of birth, and neither is a shape worth guessing at, so neither is ever sent.
+
+Three things are withheld from the copy and nothing else is: the case caption,
+which on a clinic run is the client's own case, since ICOS keeps serving the
+heading of whichever case the session selected last; any date; and the account
+ICOS stamps into the corner of every page it serves. None of them bear on
+whether ICOS was up, so nothing evidential is lost. The sha256 is of the page
+before any of that came out, so the redacted copy can still be tied to the
+original if it ever has to be.
+
+The scrubbing is checked rather than trusted. Napier reads its own output back
+with a second set of patterns written from the other direction, and if anything
+it was supposed to remove is still there, no mail goes out at all. An email
+that never arrives costs a follow-up. One that arrives carrying a client's name
+cannot be recalled from a court's inbox.
 
 ## Development
 

--- a/alerts.py
+++ b/alerts.py
@@ -31,6 +31,12 @@ and are never assembled into an alert. Exception messages are dropped for the
 same reason: a parser that dies on a case usually quotes that case back. What
 survives is the traceback's frames, which are our own source, plus the exception
 type.
+
+One thing here is not an alert. outage_evidence() mails a redacted copy of the
+page ICOS serves when it has declared itself down, because everything else in
+this module is Napier's word about a bad morning and Napier's word is what a
+court would question. What may be kept and what has to come out first is
+evidence.py's problem, not this module's.
 """
 
 import base64
@@ -40,6 +46,8 @@ import time
 import traceback
 import urllib.parse
 import urllib.request
+
+import evidence
 
 # Failure classes. The wording is the email subject line, so it reads as English.
 RETRY_EXHAUSTED = 'ICOS retry budget exhausted'
@@ -83,6 +91,17 @@ SLOW_RECOVERY_ATTEMPTS = 3
 # of emails rather than one per staffer per attempt.
 CLASS_FLOOR_SECONDS = 10 * 60
 
+# Not a failure class. It never goes through record(), is never suppressed by a
+# job having already alerted, and never appears in a digest. It is a separate
+# piece of mail with a separate subject so it can be filtered, kept, and
+# forwarded to Iowa Courts without the diagnostics around it.
+OUTAGE_EVIDENCE = 'Iowa Courts served its own outage page'
+
+# Its own floor, counted across every job on the dyno. During the 2026-07-30
+# outage ICOS served the same page 45 times in eleven minutes; one copy of a
+# byte-identical page proves as much as forty five do.
+EVIDENCE_FLOOR_SECONDS = 15 * 60
+
 MAILGUN_ENDPOINT = 'https://api.mailgun.net/v3/%s/messages'
 
 # Both maps below are keyed by something unique per job, and the web error path
@@ -94,6 +113,7 @@ MAX_TRACKED_JOBS = 500
 _sent = {}             # job_id -> failure classes already emailed for that job
 _class_floor = {}      # failure class -> when it last went out, any job
 _pending = {}          # job_id -> the events behind the end-of-job digest
+_evidence_floor = [None]   # when an outage page was last mailed, any job
 _lock = threading.Lock()
 
 
@@ -179,29 +199,51 @@ def _format(job_id, kind, failure, fields, progress):
 
 # -- delivery -------------------------------------------------------------
 
-def _mailgun(subject, body):
+def _form_data(fields, attachment):
+    """Encode an attachment the way Mailgun's API wants it.
+
+    Hand rolled because the dyno has no requests library and this is the only
+    thing in Napier that needs multipart.
+    """
+    boundary = 'napier-%s' % os.urandom(16).hex()
+    while boundary.encode('ascii') in attachment['content']:
+        boundary = 'napier-%s' % os.urandom(16).hex()
+    out = []
+    for name, value in fields.items():
+        out.append(('--%s\r\nContent-Disposition: form-data; name="%s"'
+                    '\r\n\r\n%s\r\n' % (boundary, name, value)).encode('utf-8'))
+    out.append(('--%s\r\nContent-Disposition: form-data; name="attachment"; '
+                'filename="%s"\r\nContent-Type: text/html\r\n\r\n'
+                % (boundary, attachment['filename'])).encode('utf-8'))
+    out.append(attachment['content'])
+    out.append(('\r\n--%s--\r\n' % boundary).encode('utf-8'))
+    return 'multipart/form-data; boundary=%s' % boundary, b''.join(out)
+
+
+def _mailgun(subject, body, attachment=None):
     domain = os.environ.get('MAILGUN_DOMAIN')
     key = os.environ.get('MAILGUN_API_KEY')
     to = os.environ.get('ALERT_EMAIL_TO')
     if not (domain and key and to):
         return False
     sender = os.environ.get('ALERT_EMAIL_FROM') or 'Napier <napier@%s>' % domain
-    data = urllib.parse.urlencode({
-        'from': sender,
-        'to': to,
-        'subject': subject,
-        'text': body,
-    }).encode('utf-8')
+    fields = {'from': sender, 'to': to, 'subject': subject, 'text': body}
+    if attachment is None:
+        content_type = 'application/x-www-form-urlencoded'
+        data = urllib.parse.urlencode(fields).encode('utf-8')
+    else:
+        content_type, data = _form_data(fields, attachment)
     request = urllib.request.Request(MAILGUN_ENDPOINT % domain, data=data)
+    request.add_header('Content-Type', content_type)
     request.add_header('Authorization', 'Basic ' + base64.b64encode(
         ('api:%s' % key).encode('utf-8')).decode('ascii'))
     urllib.request.urlopen(request, timeout=10).read()
     return True
 
 
-def _deliver(subject, body):
+def _deliver(subject, body, attachment=None):
     try:
-        if _mailgun(subject, body):
+        if _mailgun(subject, body, attachment):
             print('ALERT sent: %s' % subject, flush=True)
         else:
             print('ALERT not configured, would have sent: %s' % subject, flush=True)
@@ -211,12 +253,12 @@ def _deliver(subject, body):
               flush=True)
 
 
-def _send(subject, body):
+def _send(subject, body, attachment=None):
     """Hand the send to a daemon thread and get out of the way.
 
     Returned so tests can join it. Nothing in the app waits on it.
     """
-    thread = threading.Thread(target=_deliver, args=(subject, body),
+    thread = threading.Thread(target=_deliver, args=(subject, body, attachment),
                               name='alert', daemon=True)
     thread.start()
     return thread
@@ -245,6 +287,68 @@ def record(job_id, kind, failure, progress=None, now=None, **fields):
         _class_floor[failure] = now
     return _send('Napier: %s' % failure,
                  _format(job_id, kind, failure, fields, progress))
+
+
+def outage_evidence(body, endpoint=None, case_id=None, username=None,
+                    status=None, attempts=None, now=None):
+    """Mail a redacted copy of a page on which ICOS declared itself down.
+
+    Every other alert here is Napier's account of what happened, which is
+    exactly what is in dispute when a clinic tells Iowa Courts it lost a
+    morning. This one is Iowa's account, in Iowa's wording, and it is the
+    difference between a complaint and a report.
+
+    Sends at most once every 15 minutes across the whole dyno, and only for a
+    page evidence.package() will vouch for. Returns the send thread, or None if
+    nothing was sent.
+    """
+    now = time.time() if now is None else now
+    stamp = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime(now))
+    document = evidence.package(body, case_id=case_id, stamp=stamp)
+    if document is None:
+        return None
+    with _lock:
+        last = _evidence_floor[0]
+        if last is not None and now - last < EVIDENCE_FLOOR_SECONDS:
+            return None
+        _evidence_floor[0] = now
+
+    lines = [
+        'Iowa Courts answered a request with its own problem report page:',
+        'its web application could not reach the data behind it. The page is',
+        'attached as it was served, less the redactions noted below.',
+        '',
+    ]
+    for label, value in (
+            ('when (UTC)', time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(now))),
+            ('when (local)', time.strftime('%Y-%m-%d %H:%M:%S %Z',
+                                           time.localtime(now))),
+            ('ICOS endpoint', endpoint),
+            ('case requested', case_id),
+            ('HTTP status', status),
+            ('page size', '%db' % document['original size']),
+            ('attempts so far', attempts),
+            ('ESA account', username_prefix(username) if username else None),
+            ('sha256 of the page as served', document['fingerprint'])):
+        if value is not None:
+            lines.append('%s: %s' % (label, value))
+    lines += [
+        '',
+        'Note the case number printed on the attached page. ICOS keeps serving',
+        'the heading of whichever case the session selected last, so on a',
+        'problem report it is usually not the case that was requested, and the',
+        'disposition table under it is empty. That is why this page is a',
+        'hazard rather than an inconvenience: it parses as a real case with no',
+        'charges and nothing owed.',
+        '',
+        'Three things are withheld from the attachment and nothing else is.',
+        'The case caption, because on a clinic run it names the client and is',
+        'privileged. Any date, for the same reason. The signed-in account,',
+        'which ICOS stamps into the corner of every page it serves. None of',
+        'them bear on whether ICOS was up. The sha256 above is of the page as',
+        'ICOS served it, before any of that was taken out.',
+    ]
+    return _send('Napier: %s' % OUTAGE_EVIDENCE, '\n'.join(lines), document)
 
 
 def digest(job_id, kind, progress=None):
@@ -299,3 +403,4 @@ def reset():
         _sent.clear()
         _class_floor.clear()
         _pending.clear()
+        _evidence_floor[0] = None

--- a/evidence.py
+++ b/evidence.py
@@ -1,0 +1,152 @@
+"""What Napier may keep and send when it wants to prove Iowa Courts was down.
+
+An alert says something failed. It is not evidence. A staffer reporting a bad
+morning to Iowa Courts has Napier's word for it and nothing else, and Napier's
+word is exactly the thing in question. The page ICOS serves when it cannot
+reach its own data source says so in Iowa's own wording, under Iowa's own
+heading, over Iowa's own footer. That is worth keeping and worth sending.
+
+Keeping it is only safe because of what that page is. It carries the problem
+report text, an empty disposition table, and the heading of whichever case the
+session had selected last. In a clinic that heading is the client's case
+caption, which is the privileged part under Article 5, so it does not survive
+this module. Nor does the account: ICOS stamps the signed-in distinguished name
+into the corner of every page it serves, and Article 1.2 keeps credentials out
+of anything Napier transmits.
+
+What survives is what actually proves an outage. Iowa's own wording. The case
+number that was asked for, and the different case number the page came back
+wearing, both of which are court public record and neither of which is a
+person. The empty disposition table, which is why every parser accepted the
+page. None of that identifies anybody, and none of the identifying parts prove
+anything about Iowa's outage, so scrubbing costs nothing evidential.
+
+Nothing else is ever packaged. A real case page names a defendant and a search
+results page lists every person who matched along with their dates of birth.
+The marker check below is not a classification convenience. It is the reason
+this module is allowed to exist at all: only a page positively identified as
+ICOS's own outage page has a shape known well enough to scrub with confidence,
+and a scrubber applied to a page whose shape is unknown is a guess about
+whether it worked.
+"""
+
+import hashlib
+import re
+
+# ICOS answers with this when its web tier cannot reach its data source. It
+# lives here rather than in icos.py because recognising this page and being
+# allowed to send it are the same question, and two copies of the string would
+# be two things to keep in step.
+PROBLEM_REPORT_MARKER = "There was a communication problem"
+
+# Article 5. The caption is the parties, and on a clinic run the stale heading
+# this page wears is the client's own case: "STATE VS <client>".
+CAPTION = re.compile(rb"(Title:(?:&nbsp;|\s)*)([^<]*)", re.I)
+# Belt and braces for a caption that reaches the page some other way. A problem
+# report page has exactly one "X VS Y" on it and it is the one above, so this
+# costs nothing here and catches a page shape that changes under us.
+VERSUS = re.compile(rb"[A-Z][A-Z0-9 .,'&/-]{2,}\s+VS\.?\s+[A-Z][A-Z0-9 .,'&/-]{2,}")
+# Article 1.2. "CN=ila04,O=JUDICIAL", bottom right of every authenticated page.
+ACCOUNT_STAMP = re.compile(rb"CN=[^<\s]*", re.I)
+# Nothing on this page type should carry a date at all. If one appears, the
+# page is not the shape this module was written against, and a date next to a
+# name is the combination Article 5 exists for.
+DATE = re.compile(rb"\b\d{1,2}/\d{1,2}/\d{2,4}\b")
+
+WITHHELD = b"[caption withheld under Article 5]"
+ACCOUNT_WITHHELD = b"CN=[account withheld under Article 1.2]"
+DATE_WITHHELD = b"[date withheld]"
+
+# The second look, and deliberately not the patterns above. Checking the output
+# with the same regex that produced it asks whether a regex agrees with itself,
+# which it always does: the template change that stops CAPTION matching stops
+# the check noticing, and nothing says so. So these are written from the other
+# end. They describe what a clean page looks like and fire on anything else,
+# and each one keys on a different part of the text than the scrubber does.
+#
+# They are allowed to be blunter than the scrubbers, because a false alarm here
+# costs one unsent email and a missed one costs a client's name.
+LEAKED_VERSUS = re.compile(rb"\bVS\.?\b", re.I)
+LEAKED_TITLE = re.compile(rb"Title:((?:&nbsp;|\s)*)([^<]*)", re.I)
+LEAKED_ACCOUNT = re.compile(rb"O=JUDICIAL|CN=(?!\[account)", re.I)
+LEAKED_DATE = re.compile(rb"\b\d{1,4}\s*[/-]\s*\d{1,2}\s*[/-]\s*\d{1,4}\b")
+
+# A problem report page is about 3.4 KB. Anything an order of magnitude past
+# that is not the page this module knows how to handle, whatever it says.
+MAX_BYTES = 64 * 1024
+
+
+def _bytes(body):
+    return body if isinstance(body, bytes) else body.encode("utf-8", "ignore")
+
+
+def is_outage_page(body):
+    """Whether ICOS said, in its own words, that it could not reach its data."""
+    if not body:
+        return False
+    raw = _bytes(body)
+    return len(raw) <= MAX_BYTES and PROBLEM_REPORT_MARKER.encode() in raw
+
+
+def scrub(body):
+    """Strip the parties, the account and any date. Keep the rest verbatim."""
+    out = _bytes(body)
+    out = CAPTION.sub(lambda m: m.group(1) + WITHHELD, out)
+    out = VERSUS.sub(WITHHELD, out)
+    out = ACCOUNT_STAMP.sub(ACCOUNT_WITHHELD, out)
+    out = DATE.sub(DATE_WITHHELD, out)
+    return out
+
+
+def leaks(scrubbed):
+    """Anything the scrub was supposed to remove and did not.
+
+    Checked rather than assumed, because the cost of a regex that stopped
+    matching after ICOS changed a template is a privileged name in Alex's inbox
+    and then in a complaint to the court, and nothing would say so. package()
+    refuses to hand back a document that fails this.
+    """
+    raw = _bytes(scrubbed)
+    found = []
+    if LEAKED_ACCOUNT.search(raw):
+        found.append("account stamp")
+    titled = [m.group(2).strip() for m in LEAKED_TITLE.finditer(raw)]
+    if (LEAKED_VERSUS.search(raw)
+            or any(t and not t.startswith(WITHHELD) for t in titled)):
+        found.append("case caption")
+    if LEAKED_DATE.search(raw):
+        found.append("date")
+    return found
+
+
+def fingerprint(body):
+    """sha256 of the page as ICOS served it.
+
+    The original never leaves the machine, so this is what ties the redacted
+    copy in an email to the bytes it was made from, if anyone ever has to ask.
+    """
+    return hashlib.sha256(_bytes(body)).hexdigest()
+
+
+def _slug(case_id):
+    return re.sub(r"[^A-Za-z0-9]+", "-", (case_id or "unknown")).strip("-")
+
+
+def package(body, case_id=None, stamp=None):
+    """A sendable copy of an ICOS outage page, or None if it is not one.
+
+    stamp is a filename-safe timestamp supplied by the caller, because this
+    module should not be the thing deciding what time it is.
+    """
+    if not is_outage_page(body):
+        return None
+    scrubbed = scrub(body)
+    if leaks(scrubbed):
+        return None
+    return {
+        "filename": "iowa-courts-outage-%s-%s.html" % (stamp or "unstamped",
+                                                       _slug(case_id)),
+        "content": scrubbed,
+        "fingerprint": fingerprint(body),
+        "original size": len(_bytes(body)),
+    }

--- a/icos.py
+++ b/icos.py
@@ -17,9 +17,11 @@ Timing is injectable so the retry behaviour can be tested without real waits.
 import os
 import re
 import time
+import urllib.parse
 
 import accounts
 import alerts
+import evidence
 from opener import Opener
 from reader import EMPTY, TIMEOUT, Reader
 
@@ -52,7 +54,11 @@ MIN_SIGNED_IN_BYTES = 8000
 # well as a civil case with nothing owed. A criminal case quietly reported that
 # way is worse than one that fails outright, so a case page has to prove it is
 # the case that was asked for before it is accepted.
-PROBLEM_REPORT_MARKER = "There was a communication problem"
+#
+# The marker itself lives in evidence.py, because recognising this page and
+# being allowed to mail a copy of it are the same question, and two copies of
+# the string would be two things to keep in step.
+PROBLEM_REPORT_MARKER = evidence.PROBLEM_REPORT_MARKER
 
 
 def _text(body):
@@ -150,6 +156,18 @@ def _timeline(waits):
     if not waits:
         return "none"
     return "+".join(str(w) for w in waits) + "s"
+
+
+def _requested_case(url):
+    """The case id in a case request, for evidence that names what was asked.
+
+    Read back off the wire rather than plumbed down from the caller, because
+    what matters on an outage page is the gap between the case requested and
+    the stale case the page came back wearing, and this is the requested one as
+    ICOS received it.
+    """
+    match = re.search(r"[?&]caseid=([^&]*)", url or "", re.I)
+    return urllib.parse.unquote_plus(match.group(1)) if match else None
 
 
 # Said in one place because the run can stop in three, and a staffer who stops
@@ -337,6 +355,16 @@ class IcosClient:
             if self.logged_in:
                 self._alert(failure, endpoint=endpoint, reason=reason,
                             attempts=attempt + 1, status=result.status, **extra)
+
+            # An alert says Napier could not get a case. That is Napier's word
+            # for it, and Napier's word is the thing in question when a clinic
+            # tells the court it lost a morning. When ICOS has said in its own
+            # wording that it cannot reach its own data, keep the page.
+            if evidence.is_outage_page(result.body):
+                alerts.outage_evidence(
+                    result.body, endpoint=endpoint,
+                    case_id=_requested_case(url), username=self.username,
+                    status=result.status, attempts=attempt + 1)
 
             elapsed = self._monotonic() - started
             wait = backoff_for(attempt)

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -12,6 +12,7 @@ not carry a name, a date of birth, or a credential.
 """
 
 import base64
+import email.parser
 import os
 import sys
 import threading
@@ -26,10 +27,37 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
 
 import alerts
+import evidence
 import icos
 import tasks
 from icos import IcosClient, IcosAccountLocked, IcosUnavailable
 from reader import FetchResult, OK, EMPTY
+
+
+def _parse_multipart(raw, content_type):
+    """Read the attachment back with a parser we did not write.
+
+    Napier hand rolls the multipart encoding, because the dyno has no requests
+    library. Checking it by splitting on our own boundary would only prove the
+    encoder agrees with itself, so this hands the bytes to the stdlib email
+    parser and asks it to make sense of them. If it cannot, Mailgun would not
+    either, and the attachment nobody looked at would have been the outage
+    evidence.
+    """
+    message = email.parser.BytesParser().parsebytes(
+        b'MIME-Version: 1.0\r\nContent-Type: %s\r\n\r\n'
+        % content_type.encode('ascii') + raw)
+    assert message.is_multipart(), 'the POST body did not parse as multipart'
+    fields, attachment = {}, None
+    for part in message.get_payload():
+        if part.get_filename():
+            attachment = {'filename': part.get_filename(),
+                          'content': part.get_payload(decode=True)}
+            continue
+        name = part.get_param('name', header='content-disposition')
+        fields.setdefault(name, []).append(
+            part.get_payload(decode=True).decode('utf-8'))
+    return fields, attachment
 
 
 class Mailgun(BaseHTTPRequestHandler):
@@ -38,7 +66,13 @@ class Mailgun(BaseHTTPRequestHandler):
 
     def do_POST(self):
         length = int(self.headers.get('Content-Length') or 0)
-        fields = urllib.parse.parse_qs(self.rfile.read(length).decode('utf-8'))
+        raw = self.rfile.read(length)
+        content_type = self.headers.get('Content-Type') or ''
+        if content_type.startswith('multipart/'):
+            fields, attachment = _parse_multipart(raw, content_type)
+        else:
+            fields = urllib.parse.parse_qs(raw.decode('utf-8'))
+            attachment = None
         Mailgun.received.append({
             'path': self.path,
             'auth': self.headers.get('Authorization'),
@@ -46,6 +80,7 @@ class Mailgun(BaseHTTPRequestHandler):
             'from': fields.get('from', [''])[0],
             'subject': fields.get('subject', [''])[0],
             'text': fields.get('text', [''])[0],
+            'attachment': attachment,
         })
         self.send_response(Mailgun.status)
         self.end_headers()
@@ -789,3 +824,162 @@ def test_another_browser_cannot_make_napier_send_mail(mailbox):
     assert response.status_code == 204
     settle()
     assert mailbox == []
+
+
+# -- proving the outage to the court, not just noticing it -------------------
+#
+# Every other test in this file is about Napier telling Alex something broke.
+# These are about Alex being able to tell Iowa Courts something broke, which is
+# a different burden: his own logs are the thing a court would question, so the
+# mail carries the court's own page.
+
+from test_evidence import OUTAGE_PAGE, REAL_CASE_PAGE   # noqa: E402
+
+
+def test_an_outage_page_arrives_as_a_real_attachment(mailbox):
+    send(alerts.outage_evidence(OUTAGE_PAGE, endpoint='TViewCaseCivil',
+                                case_id='00000  FECR000000', username='ila00',
+                                status=200, attempts=3, now=1000.0))
+    assert len(mailbox) == 1
+    mail = mailbox[0]
+    assert alerts.OUTAGE_EVIDENCE in mail['subject']
+    attached = mail['attachment']
+    assert attached is not None, "the page itself is the point of the email"
+    assert attached['filename'].endswith('-00000-FECR000000.html')
+    assert b'There was a communication problem' in attached['content']
+
+
+def test_the_attachment_carries_no_client_and_no_account(mailbox):
+    send(alerts.outage_evidence(OUTAGE_PAGE, endpoint='TViewCaseCivil',
+                                case_id='00000  FECR000000', username='ila00',
+                                status=200, attempts=3, now=1000.0))
+    everything = mailbox[0]['attachment']['content'] + \
+        mailbox[0]['text'].encode('utf-8') + mailbox[0]['subject'].encode('utf-8')
+    assert b'SYNTHETIC DEFENDANT' not in everything
+    assert b'ila00' not in everything, "Article 1.2: the family, never the account"
+    assert b'ILA##' in everything, "which pool collided is the useful part"
+
+
+def test_the_email_says_what_was_asked_for_and_when(mailbox):
+    send(alerts.outage_evidence(OUTAGE_PAGE, endpoint='TViewCaseCivil',
+                                case_id='00000  FECR000000', username='ila00',
+                                status=200, attempts=3, now=1000.0))
+    text = mailbox[0]['text']
+    # Forwarded to a court, the attachment on its own says a page exists. What
+    # makes it a report is which case was requested, at what time, on which
+    # endpoint, and a hash tying the copy to the bytes ICOS served.
+    assert 'case requested: 00000  FECR000000' in text
+    assert 'ICOS endpoint: TViewCaseCivil' in text
+    assert 'HTTP status: 200' in text
+    assert evidence.fingerprint(OUTAGE_PAGE) in text
+    assert '1970-01-01 00:16:40' in text, "UTC, so a court can line it up"
+
+
+def test_a_second_outage_page_within_fifteen_minutes_is_not_sent(mailbox):
+    # ICOS served this page 45 times in eleven minutes on 2026-07-30. Forty
+    # five byte-identical attachments prove nothing the first one does not.
+    assert alerts.outage_evidence(OUTAGE_PAGE, now=1000.0) is not None
+    settle()
+    assert alerts.outage_evidence(OUTAGE_PAGE, now=1000.0 + 14 * 60) is None
+    assert len(mailbox) == 1
+
+
+def test_an_outage_still_going_an_hour_later_is_sent_again(mailbox):
+    assert alerts.outage_evidence(OUTAGE_PAGE, now=1000.0) is not None
+    settle()
+    assert alerts.outage_evidence(OUTAGE_PAGE, now=1000.0 + 16 * 60) is not None
+    settle()
+    assert len(mailbox) == 2
+
+
+def test_the_floor_is_not_spent_on_a_page_that_was_never_sendable(mailbox):
+    """A refused page must not consume the 15 minutes the real one needs.
+
+    Otherwise a run that hits an unrelated failure first buys ICOS a quarter
+    hour of not being on the record.
+    """
+    assert alerts.outage_evidence(REAL_CASE_PAGE, now=1000.0) is None
+    assert alerts.outage_evidence(OUTAGE_PAGE, now=1000.0) is not None
+    settle()
+    assert len(mailbox) == 1
+
+
+def test_a_run_that_never_saw_an_outage_page_sends_nothing(mailbox):
+    for body in (b'', None, REAL_CASE_PAGE, b'<html>timeout</html>'):
+        assert alerts.outage_evidence(body, now=1000.0) is None
+    settle()
+    assert mailbox == []
+
+
+def test_an_ordinary_alert_still_goes_out_urlencoded(mailbox):
+    """The multipart path is new. The path every other alert takes is not."""
+    send(alerts.record('j1', 'search', alerts.NO_ANSWER, reason='timed out'))
+    assert mailbox[0]['attachment'] is None
+    assert 'timed out' in mailbox[0]['text']
+
+
+def _reader_serving_an_outage():
+    """Signs in, then answers every case request with Iowa's problem report.
+
+    The 200 matters. This page is not an error the client can see coming: ICOS
+    reports it succeeded, hands back a well formed case summary, and the only
+    thing wrong with it is that it is the wrong case with nothing in it.
+    """
+    class Stub:
+        def fetch_once(self, url, data=None, timeout=8):
+            if 'TViewCase' in url or 'TView' in url:
+                return FetchResult(OK, OUTAGE_PAGE, 200, 0.1)
+            return FetchResult(OK, b'x' * 30000, 200, 0.1)
+
+        def init_request(self):
+            return 'https://x/ESAWebApp/ESALogin.jsp', None
+
+        def login_request(self, username, password):
+            return 'https://x/ESAWebApp/EUACustomLoginServlet', b'd'
+
+        def case_summary_request(self, case_id):
+            return ('https://x/ESAWebApp/TViewCaseCivil?caseid='
+                    + case_id.replace(' ', '+')), None
+
+        def logoff_request(self):
+            return 'https://x/ESAWebApp/logoff', None
+
+    return Stub()
+
+
+def test_a_run_that_walks_into_an_outage_mails_the_page(mailbox):
+    """The whole feature, end to end, from a client that only sees HTTP 200s."""
+    client = IcosClient(reader=_reader_serving_an_outage(), case_budget_seconds=1,
+                        sleep=lambda s: None, monotonic=_clock(),
+                        alert=alerts.emitter(FakeJob('crs')))
+    client.login('ILA04', 'password')
+    with pytest.raises(IcosUnavailable):
+        client.case_bundle('00000  FECR000000')
+    settle()
+
+    evidence_mail = [m for m in mailbox if m['attachment'] is not None]
+    assert len(evidence_mail) == 1, "one page proves it; forty five do not"
+    mail = evidence_mail[0]
+    assert alerts.OUTAGE_EVIDENCE in mail['subject']
+    # The case Napier asked for, read back off the wire, next to the different
+    # case the page came back wearing. That gap is the technical argument.
+    assert 'case requested: 00000  FECR000000' in mail['text']
+    assert b'Case: 00000  FECR000000' in mail['attachment']['content']
+    assert b'There was a communication problem' in mail['attachment']['content']
+    assert b'SYNTHETIC DEFENDANT' not in mail['attachment']['content']
+    assert 'ILA04' not in mail['text']
+
+
+def test_an_ordinary_icos_failure_mails_no_page(mailbox):
+    """Nothing is attached unless ICOS itself said it was down.
+
+    A timeout is Napier's word against the court's. Only the page is not.
+    """
+    client = IcosClient(reader=_reader_that('empty'), budget_seconds=200,
+                        sleep=lambda s: None, monotonic=_clock(),
+                        alert=alerts.emitter(FakeJob()))
+    with pytest.raises(IcosUnavailable):
+        client.login('ILA04', 'password')
+    settle()
+    assert mailbox, "expected the ordinary alerts, otherwise this proves nothing"
+    assert all(m['attachment'] is None for m in mailbox)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,189 @@
+"""What may leave the building when Napier keeps proof that ICOS was down.
+
+The point of the feature is that Alex can forward a page to Iowa Courts and say
+"this is what your system served us at 09:14." The point of these tests is that
+doing so can never also forward a client's name.
+
+The fixture below is the shape of a page ICOS really served on 2026-07-30,
+rebuilt with a synthetic caption, a synthetic case number and a synthetic
+account, because this repository is public. Its structure is faithful: the
+caption sits in a bgcolor cell above a case number that belongs to a different
+case than the one requested, the problem report text sits under it, and the
+account is stamped into the footer.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import evidence
+
+
+OUTAGE_PAGE = b"""<HTML>
+<head><title>Trial Court Case Summary</title></head>
+<body bgcolor="white">
+<table border="0" cellspacing="0" cellpadding="8" width="100%">
+\t<tr>
+\t\t<td width="731" height="40" colspan="5" align="left" bgcolor="#cccccc">
+\t\t<b>Summary<br>
+\t\t</b>Title:&nbsp;STATE OF IOWA VS SYNTHETIC DEFENDANT<br>
+\t\tCase: 00000  FECR000000 (SYNTHETIC)<br>
+\t\t</td>
+\t</tr>
+\t<tr>
+\t\t<td colspan=7 bgcolor="#EDEDED" align="left"><br>
+\t\t<u><b>Problem Report:</b></u> There was a communication problem.<br>
+\t\t<br>
+\t\t<u><b>Possible Cause:</b></u> The Web server may be too busy.<br>
+\t\t<br>
+\t\tThe Web server may be unable to contact the data source server.<br>
+\t\t</td>
+\t</tr>
+\t<tr><td colspan=7><b>Disposition</b></td></tr>
+\t<tr><td colspan=7>No Disposition records were found.</td></tr>
+</table>
+<font size="1">For exclusive use by the Iowa Courts<br>
+CN=ila00,O=JUDICIAL</font>
+</body></HTML>
+"""
+
+# A case page and a search results page are the two things that must never be
+# packaged, because both are full of people. This is the shape of the first.
+REAL_CASE_PAGE = OUTAGE_PAGE.replace(
+    b"<u><b>Problem Report:</b></u> There was a communication problem.<br>",
+    b"Filed: 01/14/2019<br>").replace(
+    b"No Disposition records were found.",
+    b"Guilty 03/02/2019")
+
+
+class TestWhatMayBeSent:
+    """Only ICOS's own outage page, and never anything else."""
+
+    def test_the_outage_page_is_recognised(self):
+        assert evidence.is_outage_page(OUTAGE_PAGE)
+
+    def test_a_real_case_page_is_not(self):
+        # It has the same heading, the same footer and the same table. What it
+        # does not have is Iowa saying it could not reach its data, and that is
+        # the only thing that makes a page safe to scrub with confidence.
+        assert not evidence.is_outage_page(REAL_CASE_PAGE)
+        assert evidence.package(REAL_CASE_PAGE, case_id="x", stamp="s") is None
+
+    def test_an_empty_body_is_not(self):
+        assert not evidence.is_outage_page(b"")
+        assert not evidence.is_outage_page(None)
+
+    def test_a_page_too_large_to_be_this_page_is_refused(self):
+        # A search results page carrying the marker in a footnote is still a
+        # list of everyone who matched, with their dates of birth.
+        bloated = OUTAGE_PAGE + b"<!-- %s -->" % (b"x" * evidence.MAX_BYTES)
+        assert not evidence.is_outage_page(bloated)
+
+
+class TestWhatComesOutFirst:
+    """Article 5 and Article 1.2, enforced on the bytes rather than promised."""
+
+    @pytest.fixture
+    def scrubbed(self):
+        return evidence.scrub(OUTAGE_PAGE)
+
+    def test_the_caption_does_not_survive(self, scrubbed):
+        # On a clinic run this line is the client's own case caption, because
+        # ICOS keeps serving the heading of whichever case was selected last.
+        assert b"SYNTHETIC DEFENDANT" not in scrubbed
+        assert b"STATE OF IOWA VS" not in scrubbed
+        assert b"Title:" in scrubbed, "the field should stay, redacted"
+
+    def test_the_account_does_not_survive(self, scrubbed):
+        assert b"ila00" not in scrubbed
+        assert b"CN=ila" not in scrubbed
+
+    def test_a_date_does_not_survive(self):
+        dated = OUTAGE_PAGE.replace(b"(SYNTHETIC)", b"(SYNTHETIC) 07/04/1971")
+        assert b"07/04/1971" not in evidence.scrub(dated)
+
+    def test_the_case_number_does_survive(self, scrubbed):
+        # Court public record, and the whole technical argument. The page came
+        # back wearing a different case than the one asked for, which is how a
+        # court IT department can tell this was their session state and not
+        # Napier asking for the wrong thing.
+        assert b"00000  FECR000000" in scrubbed
+        assert b"SYNTHETIC" in scrubbed
+
+    def test_iowas_own_wording_does_survive(self, scrubbed):
+        assert b"There was a communication problem" in scrubbed
+        assert b"The Web server may be unable to contact the data source" in scrubbed
+        assert b"No Disposition records were found." in scrubbed
+
+    def test_a_clean_scrub_reports_no_leaks(self, scrubbed):
+        assert evidence.leaks(scrubbed) == []
+
+
+class TestTheScrubberIsCheckedRatherThanTrusted:
+    """leaks() is the belt to scrub()'s braces, so it has to actually fire.
+
+    Every regex here is written against a page template ICOS controls and can
+    change without telling anybody. If that happens the failure is silent and
+    the cost is a privileged name in an email to a court, so package() asks
+    whether the scrub worked instead of assuming it did.
+    """
+
+    def test_a_missed_account_stamp_is_caught(self, monkeypatch):
+        monkeypatch.setattr(evidence, 'ACCOUNT_STAMP',
+                            evidence.re.compile(rb"WILL NOT MATCH ANYTHING"))
+        assert 'account stamp' in evidence.leaks(evidence.scrub(OUTAGE_PAGE))
+
+    def test_the_caption_survives_one_pattern_going_stale(self, monkeypatch):
+        # Two passes remove the caption: the one that knows where it sits, and
+        # the one that knows what it looks like. Losing either still leaves a
+        # scrub that works, which is the whole reason there are two.
+        monkeypatch.setattr(evidence, 'CAPTION',
+                            evidence.re.compile(rb"WILL NOT MATCH ANYTHING"))
+        scrubbed = evidence.scrub(OUTAGE_PAGE)
+        assert b"SYNTHETIC DEFENDANT" not in scrubbed
+        assert evidence.leaks(scrubbed) == []
+
+    def test_a_missed_caption_is_caught_when_both_passes_go_stale(self, monkeypatch):
+        monkeypatch.setattr(evidence, 'CAPTION',
+                            evidence.re.compile(rb"WILL NOT MATCH ANYTHING"))
+        monkeypatch.setattr(evidence, 'VERSUS',
+                            evidence.re.compile(rb"WILL NOT MATCH ANYTHING"))
+        assert 'case caption' in evidence.leaks(evidence.scrub(OUTAGE_PAGE))
+
+    def test_a_missed_date_is_caught(self, monkeypatch):
+        monkeypatch.setattr(evidence, 'DATE',
+                            evidence.re.compile(rb"WILL NOT MATCH ANYTHING"))
+        dated = OUTAGE_PAGE.replace(b"(SYNTHETIC)", b"(SYNTHETIC) 07/04/1971")
+        assert 'date' in evidence.leaks(evidence.scrub(dated))
+
+    def test_package_refuses_a_document_that_leaks(self, monkeypatch):
+        # Nothing is sent rather than something is sent redacted-ish. An email
+        # that does not arrive costs a follow-up; one that arrives carrying a
+        # name cannot be recalled from a court's inbox.
+        monkeypatch.setattr(evidence, 'ACCOUNT_STAMP',
+                            evidence.re.compile(rb"WILL NOT MATCH ANYTHING"))
+        assert evidence.package(OUTAGE_PAGE, case_id="x", stamp="s") is None
+
+
+class TestTyingTheCopyToTheOriginal:
+
+    def test_the_fingerprint_is_of_the_page_as_served(self):
+        document = evidence.package(OUTAGE_PAGE, case_id="00000  FECR000000",
+                                    stamp="20260730T213800Z")
+        assert document['fingerprint'] == evidence.fingerprint(OUTAGE_PAGE)
+        assert document['fingerprint'] != evidence.fingerprint(document['content'])
+        assert document['original size'] == len(OUTAGE_PAGE)
+
+    def test_the_filename_says_when_and_which_case(self):
+        document = evidence.package(OUTAGE_PAGE, case_id="00000  FECR000000",
+                                    stamp="20260730T213800Z")
+        assert document['filename'] == (
+            "iowa-courts-outage-20260730T213800Z-00000-FECR000000.html")
+
+    def test_a_case_id_cannot_escape_into_the_path(self):
+        document = evidence.package(OUTAGE_PAGE, case_id="../../etc/passwd",
+                                    stamp="s")
+        assert "/" not in document['filename'].replace(".html", "")


### PR DESCRIPTION
When ICOS cannot reach its own data source it answers with HTTP 200 and a problem report page, wearing the heading of whichever case the session selected last and listing nothing. Napier has recognised that page since #78 and refuses it. It also threw it away.

So a staffer who lost a morning could tell Iowa Courts that Napier reported an outage, and Napier's word is exactly what a court would question. On 2026-08-01 the surviving record of one was a size in a digest, and which of five causes that body had been could not be established from anything that was sent.

## What this does

Keeps the page and mails it, at most once every 15 minutes across the dyno. The mail carries the time in UTC and local, the endpoint, the case that was requested, the HTTP status, the attempt count, and a sha256 of the page as ICOS served it. The requested case number is read back off the wire, because what carries the technical argument is the gap between the case asked for and the stale case the page came back wearing.

## What may be sent

Only the one page type. Napier can recognise it, so it knows what is on it and can take out what has to come out. A real case page names a defendant and a search results page lists everyone who matched with their dates of birth, and neither is a shape worth guessing at.

Three things come out first and nothing else does: the caption, which on a clinic run is the client's own case; any date; and the account ICOS stamps into the corner of every page it serves, under Article 1.2. None of them bear on whether ICOS was up, so nothing evidential is lost. The sha256 is of the page before any of it came out.

The scrub is checked rather than trusted. `leaks()` reads the output back with patterns written from the other direction and keyed on different text than the scrubbers, because checking output with the regex that produced it only asks whether a regex agrees with itself: the template change that stops `CAPTION` matching stops the check noticing, and nothing says so. If anything survives, no mail goes out at all.

## Verification

* All 274 real ICOS pages captured 2026-07-29 and 07-30 are refused by the guard. All 45 real outage pages package with no leaks.
* 715 tests pass, up from 687.
* The 8 new alerting tests were run against this branch with `alerts.py` and `icos.py` rolled back to `main`. All 8 fail, and the end-to-end one fails on its own assertion rather than an import error.
* The multipart encoding is hand rolled, since the dyno has no `requests`. The test reads it back with the stdlib email parser rather than splitting on Napier's own boundary, so it proves the wire format is real and not just self-consistent.

## One call that is yours

The default is a redacted page, because your standing rule is that alert mail never carries a client's name or date of birth, and on a real clinic run that page's frozen heading is the client's case caption. A config toggle could widen it. That is an attorney's call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t