### PR TITLE
Stop two misc-sounding fees costing a row its fee breakdown

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -457,6 +457,13 @@ COSTS_MARKERS = (
     'SHERIFF', 'INDIGENT DEFENSE', 'COURT COSTS', 'FILING', 'CLERK',
     'WITNESS', 'JURY', 'SERVICE', 'ROOM/BOARD', 'ATTORNEY FEE',
     'TRANSCRIPT', 'APPEAL FEES', 'DEPOSITION',
+    # Both of these read like OTHER and are not. Polk County put $5.27 of
+    # postage in COSTS and $37.00 of city/county misc fees in COSTS, in its own
+    # summary, on pages where the itemization was otherwise exact. Guessing
+    # wrong here is cheap and self-announcing: the bucket stops adding up and
+    # the row falls back to category totals, which is where both of these
+    # already were.
+    'POSTAGE', 'MISC FEES BY CITY/COUNTY',
 )
 
 FINE_MARKERS = (
@@ -663,10 +670,11 @@ def reconcile_financials(case):
 
     notes = []
     if unreconciled:
-        text = ("%s did not add up against the itemization, so %s balance is "
+        text = ("%s did not add up against the itemization, so %s "
                 "ICOS's category total rather than a per-fee breakdown"
                 % (_and_list(unreconciled),
-                   "those" if len(unreconciled) > 1 else "that"))
+                   "those balances are" if len(unreconciled) > 1
+                   else "that balance is"))
         if any(get_finance_column(summary[name]['label']) == 'O'
                for name in unreconciled):
             text += (", and those fees are in MISCELLANEOUS rather than in "

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -300,9 +300,48 @@ def test_third_party_fee_stays_out_of_the_partition(felony_case):
     ("IOWA DEPT OF REVENUE COLLECTIONS FEE", "OTHER"),
     ("", "OTHER"),
     (None, "OTHER"),
+    # Both of these read like OTHER. ICOS's own summary says otherwise, on
+    # pages where every other fee matched to the cent, so the only thing
+    # keeping those two rows from reconciling was this classification.
+    ("POSTAGE FEES", "COSTS"),
+    ("MISC FEES BY CITY/COUNTY", "COSTS"),
 ])
 def test_summary_bucket_classification(detail, bucket):
     assert crs.get_summary_bucket(detail) == bucket
+
+
+def test_a_misc_sounding_fee_does_not_cost_the_row_its_breakdown():
+    """The shape of a real Polk County page, with the amounts it carried.
+
+    ICOS put all four of these in COSTS and reported 227.00 assessed. Napier
+    read the city/county line as OTHER, so COSTS came up 37.00 short and OTHER
+    37.00 over, both failed the partition check, and every fee on the row
+    collapsed into one category total. Columns J and M are where the
+    statute-of-limitations and Polk room-and-board sheets look for indigent
+    defense and jail debt, and they came out empty on a case that had both.
+    """
+    case = {
+        'summary_categories': _five_buckets(
+            COSTS=(Decimal('227.00'), Decimal('0'))),
+        'financials': [
+            {'detail': 'FILING AND DOCKETING FEES CRIMINAL',
+             'amount': Decimal('100.00'), 'paid': None},
+            {'detail': 'SHERIFFS FEES - LOCAL',
+             'amount': Decimal('30.00'), 'paid': None},
+            {'detail': 'MISC FEES BY CITY/COUNTY',
+             'amount': Decimal('37.00'), 'paid': None},
+            {'detail': 'INDIGENT DEFENSE-MISDM-REIMBURSE STATE',
+             'amount': Decimal('60.00'), 'paid': None},
+        ],
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert columns is not None, 'the row fell back to category totals'
+    assert note is None
+    assert columns['J'] == Decimal('60.00'), 'indigent defense'
+    assert columns['M'] == Decimal('30.00'), 'sheriff'
+    # Still lands on the balance ICOS reports, which is the check that says the
+    # breakdown was not bought by inventing money.
+    assert sum(columns.values()) == Decimal('227.00')
 
 
 @pytest.mark.parametrize("text,expected", [


### PR DESCRIPTION
Same method as #82: replay the real captured ICOS pages through the shipping code and see what the real data says. This time the 91 financials pages, through the reconciler.

## What the measurement showed

73 of 91 pages reconcile fee by fee. 18 fall back to ICOS category totals.

Of those 18, 14 have nothing itemized to break down, so the fallback is the only answer available. Four fail on a genuine mismatch, and three of those are a single fee classified into the wrong summary bucket.

## What changed

Two are provable from the pages themselves. ICOS put `$5.27` of `POSTAGE FEES` in COSTS, and `$37.00` of `MISC FEES BY CITY/COUNTY` in COSTS, in its own summary, on pages where every other fee matched to the cent. Napier read both as OTHER, so COSTS came up short by exactly that amount and OTHER over by exactly that amount. Both failed the partition check and the whole row collapsed into category totals.

On the city/county page that emptied columns J and M for a case carrying `$60` of indigent defense and `$30` of sheriff fees. Those are the columns the statute-of-limitations and Polk room-and-board sheets read.

The asymmetry here is favourable: guessing a marker wrong is cheap and announces itself, because the bucket stops adding up and the row falls back to category totals, which is where both of these already were. A guess is only accepted when the bucket matches ICOS to the cent.

## Proof

Measured across all 91 pages before and after. Fallbacks go from 18 to 16. Exactly two rows change and no other row moves by a cent.

- One now carries `J=60.00 M=30.00 O=137.00`, summing to the `$227.00` ICOS reports as due.
- The other reconciles to nothing owed, which is correct: ICOS reports a total due of `$0.00` for that case and lists the full `35.27` as paid.

The three new tests fail against the code without the fix, one of them on `the row fell back to category totals`. Full suite: 730 passed.

## Deliberately not changed

Polk rolls `COLLECTION BY CO ATTY (THRESHOLD MET)` into FINE, but `get_finance_column` deliberately sends that fee to column P with no recorded reason. Reconciling it would move `$60` out of FINE and into UNKNOWN. That is a question about what column P is for, and it is not the parser's to answer. Flagging rather than deciding.

Also fixes number agreement in the note written into column V, which read `those balance is ICOS's category total` whenever more than one category failed.

No page bodies, names, or dates of birth are added to the repo. The new fixture is synthetic and carries only the amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t