### PR TITLE
Stop warning about a fee breakdown of no money

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -806,7 +806,20 @@ def process_financials(case, worksheet, row):
     if total_due is not None:
         worksheet['U' + str(row)] = total_due
 
-    notes = [note] if note else []
+    # A caveat about where the fee columns came from is only worth reading if
+    # there are fees in them. ICOS reporting nothing due means every fee column
+    # on the row is zero however Napier arrived at it, so the caveat describes a
+    # breakdown of no money. That is not a rare shape: of the 25 captured pages
+    # that carried one of these, 23 owed nothing. Column V is also where the
+    # notes that matter go, a disposition Napier had to guess at and a case Iowa
+    # Courts would not give up, and a column staff have learned to skip past is
+    # worse than an empty one.
+    #
+    # Only this caveat goes quiet. The mismatch note below still fires on a paid
+    # off case, because fee columns adding up to something against a zero
+    # balance is a real disagreement and flagging it is that note's whole job.
+    nothing_owed = total_due is not None and total_due == 0
+    notes = [note] if note and not nothing_owed else []
 
     # If the per-category figures still don't add up to the balance ICOS
     # reports, the ICOS figure (column U) is the one to trust -- flag the row so

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -147,6 +147,64 @@ def test_a_collapsed_row_says_it_is_collapsed(felony_case):
     assert 'ICOS total is still right' in note
 
 
+def test_a_paid_off_case_does_not_warn_about_a_breakdown_of_nothing(felony_case):
+    """ICOS says $0.00 due, so every fee column is zero however it got there.
+
+    The caveat explains that sheriff and indigent defense debt is hiding inside
+    MISCELLANEOUS, and on this row there is no debt anywhere to hide. Of the 25
+    captured pages that carried one of these, 23 owed nothing. Column V is also
+    where the notes staff actually have to read go, the disposition Napier had
+    to guess at and the case Iowa Courts would not give up, so filling it with
+    warnings about paid off cases teaches people to skip the column.
+    """
+    felony_case['total_due'] = '$0.00'
+    felony_case['summary_categories'] = _five_buckets(
+        COSTS=(Decimal('100.00'), Decimal('100.00')))
+    felony_case['financials'] = [
+        {'detail': 'SHERIFFS FEES - LOCAL', 'amount': Decimal('50.00'),
+         'paid': None},
+    ]
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    assert sheet.value_of('U4') == Decimal('0.00')
+    assert sheet.value_of('V4') is None
+
+
+def test_the_same_collapsed_row_still_warns_when_money_is_owed(felony_case):
+    """What silences the caveat is the balance, not the fallback that wrote it.
+
+    Same page, same failure to reconcile, one hundred dollars outstanding. If
+    this row goes quiet too then the change has thrown the warning away rather
+    than aimed it.
+    """
+    felony_case['total_due'] = '$100.00'
+    felony_case['summary_categories'] = _five_buckets(
+        COSTS=(Decimal('100.00'), Decimal('0')))
+    felony_case['financials'] = [
+        {'detail': 'SHERIFFS FEES - LOCAL', 'amount': Decimal('50.00'),
+         'paid': None},
+    ]
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    assert 'MISCELLANEOUS' in sheet.value_of('V4')
+
+
+def test_a_zero_balance_does_not_silence_a_real_disagreement(felony_case):
+    """Fee columns adding up to money against a $0.00 balance is worth saying.
+
+    Only the caveat about where the columns came from goes quiet on a paid off
+    case. This note is not that. It is ICOS and the sheet contradicting each
+    other, which is the one thing on this row a staffer has to be told.
+    """
+    felony_case['summary_categories'] = []
+    felony_case['total_due'] = '$0.00'
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    assert sheet.cells['U4'].fill is not None
+    assert 'trust the ICOS total' in sheet.value_of('V4')
+    assert 'assessed rather than owed' not in sheet.value_of('V4')
+
+
 def test_the_itemized_fallback_says_the_figures_are_assessed(felony_case):
     del felony_case['summary_categories']
     sheet = FakeSheet()


### PR DESCRIPTION
Column V is where the notes a staffer has to read go: a disposition Napier had to guess at, a case Iowa Courts would not give up. It also carries a caveat saying the fee columns are ICOS's five summary buckets rather than a per-fee breakdown, so sheriff and indigent defense debt is folded into MISCELLANEOUS instead of sitting in its own column.

On a case ICOS reports as paid off, that caveat is about nothing. Every fee column on the row is zero however Napier arrived at it.

Of the 91 captured ICOS pages, 25 carried one of these and 23 owed $0.00. A column that is wrong 92% of the time is a column people learn to skip, and it is the same column the disposition note lands in.

## What changed

The caveat about where the fee columns came from is written only when ICOS reports a balance. No amount moves and nothing else about the row changes.

The mismatch note is deliberately **not** gated. Fee columns adding up to money against a $0.00 balance is ICOS and the sheet contradicting each other, and flagging that is the whole job of that note, so a paid off row still gets it plus the highlight on column U. The disposition and supervision notes go through `append_note` and were not touched.

## Proof

Replaying the captured pages through the shipping code:

| | before | after |
|---|---|---|
| note, owes money | 2 | 2 |
| note, owes $0.00 | 23 | 0 |

Rebuilding the 20 case workbook end to end changes exactly five rows, all with `U=0.00`. Every other column on every row is byte identical.

Two of the three new tests fail on their own assertions against the old code. The third passes either way on purpose: it is the guard that says the warning was aimed rather than thrown away.

733 pass.