### PR TITLE
Stop calling an unadjudicated charge NOT FILED

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -409,6 +409,17 @@ def parse_case_charges(html, case):
 
 
         if cur_section == "Charge":
+            if len(texts) >= 4 and texts[0].startswith("Charge:"):
+                # The charge as filed, which ICOS prints above the adjudication
+                # in the same shape. Nothing read it until now, so a count with
+                # no adjudication yet reached the sheet with an empty
+                # description and staff could not tell what the case was even
+                # about. Kept apart from 'description' on purpose: this is what
+                # the State accused someone of rather than what a court decided,
+                # so it must never reach column F, which is the adjudicated
+                # statute the expungement sheet reads in 792 formulas.
+                cur_charge['original_charge'] = texts[1]
+                cur_charge['original_description'] = texts[3]
             if len(texts) >= 3 and texts[0].startswith("Offense Date:"):
                 if 'prior_offenseDate' not in vars():
                     cur_charge['offenseDate'] = texts[1]

--- a/crs.py
+++ b/crs.py
@@ -383,7 +383,19 @@ def get_dominant_charge(charges):
     for disposition in raw_charge:
         disposition = disposition.replace("DNU-", "")
         if not disposition:
-            charge_dict["NOTF"] = 0
+            # ICOS printed no adjudication for this count. That is the absence
+            # of a disposition, and it used to be recorded as NOTF, NOT FILED,
+            # which is a specific thing that was not true of any of the three
+            # real cases it landed on: one filed eleven days earlier and still
+            # open, one ICOS dismissed in 2021, one ICOS closed in 1993.
+            #
+            # It is not a harmless label. The EXPUNGEMENT sheet's DISM ACQ?
+            # column reads NOTF as dismissed or acquitted and answers YES,
+            # eligible under 901C.2, so an open charge was reported as
+            # expungeable. Nothing is recorded here instead, which is the
+            # workbook's own way of saying it: SOL, BANKRUPTCY and EXEMPTIONS
+            # each render column G as IF(G=0, "open charge", G).
+            continue
         elif disposition not in charge_code_map:
             charge_dict["OTH"] = OTH_RANK
             unknown.add(disposition)
@@ -392,9 +404,29 @@ def get_dominant_charge(charges):
             charge_dict[charge_key] = rank
     sorted_tuples = sorted(charge_dict.items(), reverse=True,
                            key=lambda item: item[1] if item[1] is not None else float('inf'))
-    delisted['disposition'] = sorted_tuples[0][0]
+    delisted['disposition'] = sorted_tuples[0][0] if sorted_tuples else ''
     delisted['unknown_dispositions'] = sorted(unknown)
     return delisted
+
+
+def case_level_code(status):
+    """The CRS code for ICOS's case-level status, or None if it is not one.
+
+    The status ICOS prints on the case summary is its own vocabulary. Across 90
+    captured pages it reads GUILTY PLEA/DEFAULT, VIOLATIONS HANDLED BY CLERK,
+    DISMISSED, BY TRIAL TO COURT, OTHER JUDGMENT, CLOSED, TRANSFERRED and SMALL
+    CLAIM-DISPOSED BY CLERK, and it overlaps the per-count adjudication wordings
+    at DISMISSED and nowhere else.
+
+    Only the overlap is read. The rest are not translated here, because whether
+    VIOLATIONS HANDLED BY CLERK is a guilty plea is a question about Iowa
+    practice rather than about parsing, and five sheets key formulas on the
+    answer. An unrecognised status returns None and travels out through
+    unknown_dispositions, which already puts the wording in column V and tells
+    the run, so the case is visibly uncoded rather than quietly miscoded.
+    """
+    entry = charge_code_map.get((status or "").replace("DNU-", "").strip())
+    return next(iter(entry)) if entry else None
 
 
 def get_finance_column(detail):
@@ -897,11 +929,43 @@ def process_case(case, worksheet, row, as_of=None):
           process_financials(case, worksheet, i)
           # return # This was here, but we want to apply alignment, so moved it down
     else:
+        description = charge['description']
+        disposition = charge['disposition']
+        disposition_date = charge['dispositionDate']
+
+        if not disposition:
+            # No count on this case has been adjudicated. ICOS still prints a
+            # status and a date for the case as a whole, and Napier parsed both
+            # off the summary page and then used them only on the civil path.
+            #
+            # The date is the one that hurts. A blank column D is how this
+            # workbook detects an open case: the EXPUNGEMENT sheet's POSSIBLE
+            # PENDING CHARGES column counts case rows that have no disposition
+            # date. So a case ICOS closed in 1993 and one it dismissed in 2021
+            # were both being counted as live charges hanging over the client,
+            # and a pending charge is what blocks expungement under 901C.2.
+            # Filling it from the summary is also what keeps that column honest
+            # in the other direction: the genuinely pending case has no date on
+            # the summary either, so it stays blank and still counts.
+            description = description or charge.get('original_description') or ''
+            disposition_date = disposition_date or case.get(
+                'summary_disposition_date') or ''
+            status = (case.get('summary_dispo_status') or '').strip()
+            if status:
+                code = case_level_code(status)
+                if code is None:
+                    charge.setdefault('unknown_dispositions', [])
+                    if status not in charge['unknown_dispositions']:
+                        charge['unknown_dispositions'] = sorted(
+                            charge['unknown_dispositions'] + [status])
+                else:
+                    disposition = code
+
         worksheet['C' + i] = charge['offenseDate']
-        worksheet['D' + i] = charge['dispositionDate']
-        cell_E.value = charge['description']
+        worksheet['D' + i] = disposition_date
+        cell_E.value = description
         worksheet['F' + i] = charge['charge']
-        worksheet['G' + i] = charge['disposition']
+        worksheet['G' + i] = disposition
         # Only when we can tell. is_vehicular returns None for a case with no
         # adjudicated statute, and the cell is left alone rather than told "NO".
         vehicular = is_vehicular(charge['charge'])

--- a/tests/test_pending_cases.py
+++ b/tests/test_pending_cases.py
@@ -1,0 +1,226 @@
+"""A case ICOS has not adjudicated, and what the workbook is entitled to say.
+
+ICOS prints each count twice: the charge as filed, then the adjudication. Napier
+read only the second one, so a count with nothing adjudicated yet came out
+empty, and an empty disposition was recorded as NOTF, NOT FILED.
+
+Nothing about that was true. Of the three real cases it landed on, one was filed
+eleven days earlier and still open, one ICOS dismissed in 2021, one ICOS closed
+in 1993. All three have a case number, so none of them was never filed.
+
+It was not a cosmetic label either, and the workbook is what says so:
+
+  EXPUNGEMENT & 910.7 column I, "DISM ACQ?", reads NOTF alongside DISM, ACQ,
+  WTHD and TNSF and answers YES, eligible under 901C.2. An open charge was
+  being reported as expungeable.
+
+  EXPUNGEMENT & 910.7 column G is "POSSIBLE PENDING CHARGES" and counts case
+  rows whose disposition date is blank. Napier dropped the case-level date ICOS
+  gave it, so a case closed in 1993 was counted as a live charge hanging over
+  the client, and a pending charge is the thing that blocks expungement.
+
+  SOL, BANKRUPTCY and EXEMPTIONS each render column G as
+  IF(G=0, "open charge", G). A blank is how this workbook already says pending.
+  Napier never produced one.
+
+The pages here are synthetic. This repo is public and a real charges page is one
+person's unredacted criminal record.
+"""
+
+import os
+import sys
+from datetime import date
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+
+
+def _cells(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page(statute, description, outcome=None):
+    """One count in ICOS's real shape: charged, then adjudicated.
+
+    outcome of None is the page ICOS serves before a court has ruled. The
+    adjudication block is present and its cells are empty, which is exactly what
+    the three real captures look like.
+    """
+    html = ['<html><body><table>',
+            _cells('Count 01', 'Original Charge'),
+            _cells('Charge:', statute, 'Description:', description),
+            _cells('Offense Date:', '01/01/1900', 'Arrest Date:', ''),
+            _cells('Adjudication')]
+    if outcome is None:
+        html.append(_cells('Charge:', '', 'Description:', ''))
+        html.append(_cells('Adjudication:', '', 'Adjudication Date:', ''))
+    else:
+        html.append(_cells('Charge:', statute, 'Description:', description))
+        html.append(_cells('Adjudication:', outcome,
+                           'Adjudication Date:', '02/02/1901'))
+    html.append('</table></body></html>')
+    return ''.join(html).encode('utf-8')
+
+
+def parse(statute, description, outcome=None):
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(charges_page(statute, description, outcome),
+                                   case)
+    return case['charges'][0]
+
+
+# -- the parser -------------------------------------------------------------
+
+def test_the_charge_as_filed_is_kept():
+    """It was read for the offence date and thrown away otherwise."""
+    charge = parse('727.5', 'SYNTHETIC OBSTRUCTION')
+    assert charge['original_charge'] == '727.5'
+    assert charge['original_description'] == 'SYNTHETIC OBSTRUCTION'
+
+
+def test_the_charge_as_filed_is_not_the_adjudicated_charge():
+    """Column F is the adjudicated statute and this is not one.
+
+    What the State accused someone of is not what a court decided. If the two
+    ever merge, an unadjudicated statute reaches the expungement sheet as a
+    charge held against the client, which is the bug this file's neighbour
+    covers from the other side.
+    """
+    charge = parse('727.5', 'SYNTHETIC OBSTRUCTION')
+    assert charge['charge'] == ''
+    assert charge['description'] == ''
+
+
+def test_an_unadjudicated_count_is_not_called_not_filed():
+    dominant = crs.get_dominant_charge([parse('727.5', 'SYNTHETIC')])
+    assert dominant['disposition'] == ''
+
+
+def test_an_adjudicated_count_still_codes_from_the_adjudication():
+    """The guard. Reading the charge as filed must not disturb the 87 of 90
+    captured pages that have an adjudication and were always right."""
+    dominant = crs.get_dominant_charge([parse('124.401', 'SYNTHETIC', 'GUILTY')])
+    assert dominant['disposition'] == 'GTR'
+    assert dominant['description'] == 'SYNTHETIC'
+    assert dominant['charge'] == '124.401'
+
+
+# -- into the workbook ------------------------------------------------------
+
+def _case(statute, description, outcome=None, status='', dispo_date=''):
+    case = {'id': '00000  SMSM000000', 'county': 'SYNTHETIC',
+            'financials': [], 'summary_categories': [], 'sentences': [],
+            'summary_created_date': '01/01/1900',
+            'summary_disposition_date': dispo_date,
+            'summary_dispo_status': status}
+    case_parser.parse_case_charges(charges_page(statute, description, outcome),
+                                   case)
+    return case
+
+
+def _row(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    unknown = crs.process_case(case, sheet, crs.FIRST_CASE_ROW, CLINIC)
+    row = str(crs.FIRST_CASE_ROW)
+    return {column: sheet[column + row].value
+            for column in ('D', 'E', 'F', 'G', 'V')}, unknown
+
+
+def test_a_pending_case_says_what_it_is_about():
+    """The row carried a county, a filing date and a balance, and no charge.
+
+    On the real one that was $89.50 owed on a case whose description column was
+    empty, so nothing on the sheet said what the client had been accused of.
+    """
+    cells, _ = _row(_case('321.285', 'SYNTHETIC EXCESSIVE SPEED'))
+    assert cells['E'] == 'SYNTHETIC EXCESSIVE SPEED'
+
+
+def test_a_pending_case_leaves_column_g_blank():
+    """Blank is this workbook's own word for it, in three sheets' formulas."""
+    cells, _ = _row(_case('321.285', 'SYNTHETIC EXCESSIVE SPEED'))
+    assert cells['G'] in (None, '')
+
+
+def test_a_pending_charge_keeps_its_statute_out_of_column_f():
+    """Naming the charge must not smuggle it onto the expungement sheet."""
+    cells, _ = _row(_case('321.285', 'SYNTHETIC EXCESSIVE SPEED'))
+    assert cells['F'] in (None, '')
+
+
+def test_a_pending_case_still_counts_as_a_pending_charge():
+    """Column D stays blank, which is how the expungement sheet detects it.
+
+    The date only ever comes from ICOS. A case ICOS gives no disposition date
+    for has none, so this row goes on setting off POSSIBLE PENDING CHARGES.
+    """
+    cells, _ = _row(_case('321.285', 'SYNTHETIC EXCESSIVE SPEED'))
+    assert cells['D'] in (None, '')
+
+
+def test_a_case_icos_dismissed_is_dismissed_rather_than_never_filed():
+    """ICOS answered on the summary page and Napier used the answer civilly only.
+
+    The real one was dismissed in 2021 with no per-count adjudication
+    recorded, and Napier wrote NOTF and no date, contradicting the ICOS page it
+    had just read.
+    """
+    cells, unknown = _row(_case('727.5', 'SYNTHETIC OBSTRUCTION',
+                                status='DISMISSED', dispo_date='04/29/1902'))
+    assert cells['G'] == 'DISM'
+    assert cells['D'] == '04/29/1902'
+    assert unknown == []
+
+
+def test_a_closed_case_stops_counting_as_a_pending_charge():
+    """A 1993 case was being counted as a live charge blocking expungement.
+
+    CLOSED is not a disposition Napier can code, and the date is a fact ICOS
+    stated either way. Taking the date is what stops the false pending charge;
+    the code stays blank because that part really is unknown.
+    """
+    cells, unknown = _row(_case('CR/OLDCASE', 'SYNTHETIC OLD CASE CODE',
+                                status='CLOSED', dispo_date='09/23/1901'))
+    assert cells['D'] == '09/23/1901'
+    assert cells['G'] in (None, '')
+    assert unknown == ['CLOSED']
+
+
+def test_a_status_napier_cannot_read_is_reported_not_guessed():
+    """The case-level vocabulary is not the per-count one and mostly does not
+    overlap. Whether VIOLATIONS HANDLED BY CLERK is a guilty plea is a question
+    about Iowa practice, and five sheets key formulas on the answer, so it
+    travels out the channel that already writes column V and tells the run.
+    """
+    cells, unknown = _row(_case('321.285', 'SYNTHETIC SPEED',
+                                status='VIOLATIONS HANDLED BY CLERK',
+                                dispo_date='03/03/1903'))
+    assert unknown == ['VIOLATIONS HANDLED BY CLERK']
+    assert 'VIOLATIONS HANDLED BY CLERK' in cells['V']
+    assert cells['G'] in (None, '')
+
+
+def test_an_adjudicated_case_ignores_the_case_level_status():
+    """The count is the better answer and it wins wherever ICOS gave one.
+
+    Written with the two disagreeing on purpose, because a fallback that is not
+    fenced off stops being a fallback.
+    """
+    cells, unknown = _row(_case('124.401', 'SYNTHETIC FELONY', 'GUILTY',
+                                status='DISMISSED', dispo_date='04/29/1902'))
+    assert cells['G'] == 'GTR'
+    assert cells['D'] == '02/02/1901'
+    assert cells['E'] == 'SYNTHETIC FELONY'
+    assert cells['F'] == '124.401'
+    assert unknown == []


### PR DESCRIPTION
## What ICOS actually says

Every count on an ICOS charges page is printed twice: an **Original Charge** block with the statute and description as filed, then an **Adjudication** block with the same shape plus the outcome and its date. When no court has ruled yet, the Adjudication cells are present and empty.

Napier read only the second block. So a pending count parsed as `{'charge': '', 'description': '', 'disposition': ['']}`, and `get_dominant_charge` turned the empty disposition into `NOTF`, NOT FILED.

## The three real cases

Three of the 90 captured charge pages hit this, and no two were the same thing:

| what ICOS said | what Napier wrote |
|---|---|
| filed 07/27/2026, still open, $89.50 owed | `G=NOTF`, no date, no description |
| DISMISSED, disposition date 2021 | `G=NOTF`, no date, no description |
| CLOSED, disposition date 1993 | `G=NOTF`, no date, no description |

All three carry a case number, so none of them was never filed.

## Why the label matters

The workbook's own formulas are what make this more than cosmetic.

**EXPUNGEMENT & 910.7 column I, "DISM ACQ?"** tests column G against `DISM`, `ACQ`, `NOTF`, `WTHD`, `TNSF` and answers YES, eligible under 901C.2. An open charge was being reported as expungeable.

**EXPUNGEMENT & 910.7 column G, " POSSIBLE PENDING CHARGES"** counts case rows whose disposition date is blank. Napier parsed the case-level disposition date off the summary page and then used it only on the civil path, so two closed cases were being counted as live charges hanging over the client. A pending charge is the thing that blocks expungement.

**SOL, BANKRUPTCY and EXEMPTIONS** each render column G as `IF(G=0, "open charge", G)`. Blank is how this workbook already says pending. Napier had no way to produce one.

## The change

- `case_parser` keeps the charge as filed in `original_charge` / `original_description`. Deliberately separate fields: a pending row can now say what the case is about without the accusation reaching column F, which is the adjudicated statute the expungement sheet reads in 792 formulas.
- `get_dominant_charge` no longer invents `NOTF` out of an absence. It returns blank.
- New `crs.case_level_code`, and `process_case` falls back to the summary page's status and date when no count on the case is adjudicated.

## What is deliberately not decided here

The case-level status is ICOS's own vocabulary and it overlaps the per-count adjudication wordings at DISMISSED and nowhere else. Across the 90 pages it also reads GUILTY PLEA/DEFAULT, VIOLATIONS HANDLED BY CLERK, BY TRIAL TO COURT, OTHER JUDGMENT, CLOSED, TRANSFERRED and SMALL CLAIM-DISPOSED BY CLERK.

Only DISMISSED is translated. Whether VIOLATIONS HANDLED BY CLERK is a guilty plea is a question about Iowa practice, not about parsing, and five sheets key formulas on the answer. The rest go out through `unknown_dispositions`, which already writes the wording into column V and reports it, so the case is visibly uncoded rather than quietly miscoded. **This one is Ari's call and it is worth asking him.**

The date is taken either way. A date ICOS stated is a fact whether or not we can code the status next to it, and taking it is what stops the false pending charge.

## Verification

Replayed against all 90 captured charge pages. Exactly 3 rows change, each to the answer ICOS gave:

```
06571 case  D=            G=NOTF  E=
         →  D=<1993 date> G=      E=OLD CASE CHARGE CODE   unknown=['CLOSED']
02981 case  D=            G=NOTF  E=
         →  D=            G=      E=EXCESSIVE SPEED (EXCEPT WORK ZONES) SPEEDING
03181 case  D=            G=NOTF  E=
         →  D=<2021 date> G=DISM  E=OBSTRUCTION OF EMERGENCY COMMUNICATIONS
```

The genuinely open case keeps its blank column D and goes on setting off POSSIBLE PENDING CHARGES, which is the point: filling the date from the summary is also what keeps that column honest in the other direction.

Rebuilding the 20-case workbook moves 2 rows and leaves every other column byte-identical.

745 tests pass, up from 733. Rolled back against the 12 new tests, 7 fail: 6 on their own assertions (`'NOTF' == ''`, `'' == 'SYNTHETIC EXCESSIVE SPEED'`, `'NOTF' in (None, '')`, `'NOTF' == 'DISM'`, `'' == '09/23/1901'`, `[] == ['VIOLATIONS HANDLED BY CLERK']`) and one on `KeyError: 'original_charge'`, which is weaker proof since the field simply does not exist yet.

Fixtures are synthetic. Real charge pages stay out of this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
