### PR TITLE
Stop telling an attorney a licence is safe when nobody checked

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -132,11 +132,46 @@ UNKNOWN_DISPOSITION_NOTE = (
 # the distinction the sheet is drawing. So the test is the chapter the statute
 # sits in, which Napier already has: it is the adjudicated statutory code in
 # column F.
-VEHICULAR_CHAPTER = re.compile(r'^\s*321[A-Z]?\.', re.I)
+# A city or county prosecuting a traffic offence under its own ordinance puts
+# the ordinance citation in the adjudicated code, and ICOS prints that instead of
+# the state section. Nine of 90 captured cases are charged that way and every one
+# of them is a motor vehicle matter: speeding, seat belts, parking, driving an
+# unregistered vehicle. The chapter test used to anchor at the start of the
+# string, so all nine read as not a chapter 321 matter at all.
+#
+# They come in two shapes and only one of them is answerable.
+#
+# DU/32-321.285(d)(3) is Dubuque adopting the state speeding section by number,
+# and the state section is right there in the code. So the chapter is looked for
+# at the start of the code or straight after an ordinance citation's / or -,
+# which finds it in both shapes and still will not match a chapter that merely
+# ends in those digits.
+VEHICULAR_CHAPTER = re.compile(r'(?:^\s*|[-/])321[A-Z]?\.', re.I)
+# MA/62.01(120)-0198 is the other shape: a bare municipal code section. 62.01 in
+# one city's code has nothing to do with 62.01 in another's and neither has
+# anything to do with the state chapters, so there is no chapter in it to read.
+ORDINANCE_CITATION = re.compile(r'^[A-Z]{2}/', re.I)
 # Homicide and serious injury by vehicle live in chapter 707 rather than 321 and
 # revoke a licence on conviction, so they are vehicular for this purpose even
 # though the chapter does not say so.
 VEHICULAR_SECTIONS = ('707.6A',)
+
+# The three codes LICENSE-REGIS treats as a conviction. On anything else it says
+# "Z - Neither license nor registration" and never looks at column H at all.
+LICENCE_DISPOSITIONS = frozenset({'GTR', 'GPL', 'DEF'})
+
+# Leaving column H blank is honest but it is not visible: LICENSE-REGIS reads a
+# blank exactly as it reads "NO" and prints "Registration only", which is a
+# sentence about the client's driving licence that nobody checked. So on the rows
+# where that sentence actually gets printed, the row says why.
+ORDINANCE_VEHICULAR_NOTE = (
+    "Column H is blank because Iowa Courts give the adjudicated charge as %s, a "
+    "city or county ordinance citation with no state chapter in it, so Napier "
+    "cannot tell whether this is a chapter 321 offence. LICENSE-REGIS reads the "
+    "blank as \"Registration only\". If the ordinance mirrors a chapter 321 "
+    "offence the licence is at stake too, so check this one before advising on "
+    "it."
+)
 
 
 def is_vehicular(statutes):
@@ -147,6 +182,10 @@ def is_vehicular(statutes):
     conviction for a licence to hang off. Saying "NO" there would be asserting
     something Napier does not know, and the sheet reads a blank and a "NO"
     identically anyway, so the honest answer costs nothing.
+
+    A bare municipal ordinance citation is the same situation and used to get a
+    confident "NO". It is a section number in one city's code and says nothing
+    about which state chapter, if any, the offence answers to.
 
     Any vehicular count carries the case. A client who pleaded to OWI and a
     drugs count has a licence problem regardless of which count the CRS picked
@@ -159,10 +198,12 @@ def is_vehicular(statutes):
     if not codes:
         return None
     for code in codes:
-        if VEHICULAR_CHAPTER.match(code):
+        if VEHICULAR_CHAPTER.search(code):
             return "YES"
         if any(code.upper().startswith(section) for section in VEHICULAR_SECTIONS):
             return "YES"
+    if any(ORDINANCE_CITATION.match(code) for code in codes):
+        return None
     return "NO"
 
 
@@ -888,6 +929,25 @@ def append_note(worksheet, row, text):
     cell.value = ("%s %s" % (cell.value, text)).strip() if cell.value else text
 
 
+def owes_money(worksheet, row):
+    """Whether this row's fee columns add up to anything, read back off the sheet.
+
+    The same SUM(J:S) the analysis sheets take, asked after process_financials
+    has written them, so a caveat about what one of those sheets will print only
+    goes on a row that sheet is going to print about.
+    """
+    total = Decimal(0)
+    for column in 'JKLMNOPQRS':
+        value = worksheet[column + str(row)].value
+        if value in (None, ''):
+            continue
+        try:
+            total += Decimal(str(value))
+        except InvalidOperation:
+            continue
+    return total > 0
+
+
 def process_case(case, worksheet, row, as_of=None):
     """Write one case into CASE DATA. Returns the dispositions it could not read.
 
@@ -905,7 +965,8 @@ def process_case(case, worksheet, row, as_of=None):
     worksheet['A' + i] = case['id']
     worksheet['B' + i] = case['county']
     charge = get_dominant_charge(case['charges'])
-    
+    ordinance_note = None
+
     cell_E = worksheet['E' + i] # Get cell E
 
     if charge is None:
@@ -971,6 +1032,11 @@ def process_case(case, worksheet, row, as_of=None):
         vehicular = is_vehicular(charge['charge'])
         if vehicular is not None:
             worksheet['H' + i] = vehicular
+        elif charge['charge'] and disposition in LICENCE_DISPOSITIONS:
+            # Held until the fees are in, because LICENSE-REGIS only prints its
+            # verdict on a case that owes something and this note is only worth
+            # reading where that verdict appears.
+            ordinance_note = ORDINANCE_VEHICULAR_NOTE % charge['charge']
 
     # Outside the charge branch on purpose. The sentence table is read off the
     # charges page whatever get_dominant_charge made of the adjudications, and a
@@ -1000,6 +1066,8 @@ def process_case(case, worksheet, row, as_of=None):
     # it wrote about the money rather than being overwritten by it.
     if supervision_note:
         append_note(worksheet, i, supervision_note)
+    if ordinance_note and owes_money(worksheet, i):
+        append_note(worksheet, i, ordinance_note)
     unknown = charge.get('unknown_dispositions') or []
     if unknown:
         append_note(worksheet, i,

--- a/tests/test_vehicular.py
+++ b/tests/test_vehicular.py
@@ -16,6 +16,7 @@ column, the sheet goes quietly wrong again and these fail instead.
 import os
 import re
 import sys
+from decimal import Decimal
 
 import pytest
 from openpyxl import load_workbook
@@ -208,3 +209,138 @@ def test_the_sheet_only_asks_once_the_case_is_a_conviction_with_debt():
     """
     formula = _license_regis_formula(FULL)
     assert 'GTR' in formula and 'GPL' in formula and 'DEF' in formula
+
+
+# -- charged under a city ordinance -----------------------------------------
+
+# Nine of 90 captured cases are prosecuted under a local ordinance rather than
+# the state section, and Iowa Courts print the ordinance citation in the
+# adjudicated code. Every one of the nine is a motor vehicle matter and every one
+# of them used to answer "NO".
+#
+# The citations below keep the real shapes and drop the real numbers.
+
+ORDINANCE_WITH_THE_CHAPTER_IN_IT = [
+    ('SY/32-321.285(d)(3)', 'a city adopting the state speeding section'),
+    ('SY/9-7-321.285.D-C', 'the same city, a different ordinance numbering'),
+    ('SY/321.218', 'no intervening ordinance number at all'),
+]
+
+
+@pytest.mark.parametrize('statute,why', ORDINANCE_WITH_THE_CHAPTER_IN_IT)
+def test_an_ordinance_that_cites_the_state_section_is_read(statute, why):
+    """No judgement call in this one. The chapter is written in the code.
+
+    It only ever read "NO" because the test was anchored to the start of the
+    string and an ordinance citation puts two letters and a slash in front.
+    """
+    assert crs.is_vehicular(statute) == "YES", why
+
+
+BARE_ORDINANCE = [
+    ('SY/62.01(120)-0198', 'a municipal code section, seat belts in that city'),
+    ('SY/61.107', 'a municipal code section, parking'),
+    ('SY/51.013-0063', 'a municipal code section, no registration'),
+]
+
+
+@pytest.mark.parametrize('statute,why', BARE_ORDINANCE)
+def test_a_bare_ordinance_citation_is_not_answered_at_all(statute, why):
+    """Not "NO". There is no chapter in it to disagree with.
+
+    62.01 in one city's code has nothing to do with 62.01 in another's, and
+    neither has anything to do with the state chapters. Napier saying "NO" here
+    was the same confident answer it gives about a forgery statute, off a code
+    it cannot read.
+    """
+    assert crs.is_vehicular(statute) is None, why
+
+
+def test_an_ordinance_alongside_a_state_statute_still_answers():
+    """The unreadable code only withholds the answer when nothing else gives one."""
+    assert crs.is_vehicular('SY/62.01;321J.2') == "YES"
+
+
+def test_a_state_statute_that_is_not_vehicular_is_still_a_confident_no():
+    """The guard on the whole change.
+
+    Chapter 714 is theft in the state code and stays a "NO". Withholding an
+    answer is only for a citation Napier cannot read, not for every case that is
+    not a traffic case, or LICENSE-REGIS loses the distinction entirely.
+    """
+    assert crs.is_vehicular('714.2(3);714.2(3)') == "NO"
+
+
+def _ordinance_case(statute, costs):
+    """A conviction under an unreadable ordinance, owing `costs`."""
+    case = _case(statute, disposition='GUILTY')
+    case['summary_categories'] = [
+        {'label': label,
+         'original': Decimal(costs) if label == 'COSTS' else Decimal('0'),
+         'paid': Decimal('0'),
+         'due': Decimal(costs) if label == 'COSTS' else Decimal('0')}
+        for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')]
+    # ICOS states the balance on every financials page it serves, and the
+    # zero-balance case is the one that decides whether column V stays quiet.
+    case['total_due'] = '$' + costs
+    return case
+
+
+def _note(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
+    row = str(crs.FIRST_CASE_ROW)
+    return sheet['H' + row].value, sheet['V' + row].value or ''
+
+
+def test_a_blank_column_h_says_why_on_a_row_the_sheet_will_speak_about():
+    """A blank is honest and invisible, which is the problem with leaving it.
+
+    LICENSE-REGIS reads a blank exactly as it reads "NO" and prints
+    "Registration only", so the row that gets that sentence printed about it
+    carries the reason nobody could check it.
+    """
+    vehicular, note = _note(_ordinance_case('SY/62.01(120)-0198', '65.75'))
+    assert vehicular is None
+    assert 'SY/62.01(120)-0198' in note
+    assert 'Registration only' in note
+
+
+def test_a_case_that_owes_nothing_stays_quiet():
+    """LICENSE-REGIS prints "Z - no debt" and never looks at column H.
+
+    Seven of the nine captured ordinance cases are paid off. A caveat about a
+    sentence the sheet is not going to print is the same noise column V was
+    cleared of once already.
+    """
+    vehicular, note = _note(_ordinance_case('SY/62.01(120)-0198', '0'))
+    assert vehicular is None
+    assert 'Column H is blank' not in note, note
+
+
+def test_a_dismissed_ordinance_case_stays_quiet():
+    """No conviction, so the sheet says neither licence nor registration."""
+    case = _ordinance_case('SY/62.01(120)-0198', '65.75')
+    case['charges'][0]['disposition'] = ['DISMISSED']
+    vehicular, note = _note(case)
+    assert vehicular is None
+    assert 'Column H is blank' not in note, note
+
+
+def test_an_ordinance_napier_can_read_needs_no_caveat():
+    """It answered the question, so there is nothing to warn about."""
+    vehicular, note = _note(_ordinance_case('SY/32-321.285(d)(3)', '65.75'))
+    assert vehicular == 'YES'
+    assert 'Column H is blank' not in note, note
+
+
+def test_the_caveat_does_not_displace_what_the_money_left_in_column_v():
+    """Column V belongs to process_financials first. This joins, never replaces."""
+    case = _ordinance_case('SY/62.01(120)-0198', '65.75')
+    case['financials'] = [
+        {'detail': 'SYNTHETIC UNCATEGORISED LINE', 'amount': Decimal('10.00'),
+         'paid': None},
+    ]
+    _, note = _note(case)
+    assert 'MISCELLANEOUS' in note, note
+    assert 'SY/62.01(120)-0198' in note, note


### PR DESCRIPTION
## What the replay found

Nine of 90 captured ICOS cases are prosecuted by a city or county under its own ordinance rather than the state section. Iowa Courts prints the ordinance citation in the adjudicated code, and the chapter 321 test was anchored at the start of the string, so all nine answered **column H = NO**.

Every one of the nine is a motor vehicle offence: speeding, seat belts, a parking meter, driving an unregistered vehicle.

## Why the column matters

LICENSE-REGIS turns column H into a sentence, on any case that owes money and was disposed GTR, GPL or DEF:

```
IF('CASE DATA'!H6="YES", "License & registration", "Registration only")
```

A wrong NO is the workbook telling an attorney the client's driving licence is not at stake, on a speeding case. Of the 27 rows in the corpus where that formula actually reaches column H, one is ordinance-coded.

## Two shapes, one of them answerable

| shape | example | what Napier can tell |
|---|---|---|
| ordinance that cites the state section | `DU/32-321.285(d)(3)` | the chapter is in the code, so read it |
| bare municipal code section | `MA/62.01(120)-0198` | nothing. 62.01 in one city's code has no relation to 62.01 in another's, or to the state chapters |

Two of the nine are the first shape and now answer YES. Reading them needs no legal call, because the state section is printed right there.

The other seven are the second shape. Napier stops answering and leaves column H blank rather than guessing.

## The blank is honest and invisible

LICENSE-REGIS reads a blank exactly as it reads "NO" and prints "Registration only" regardless. So the row now says why: it names the ordinance, says what the sheet is going to print, and says the licence may be at stake too if the ordinance mirrors a chapter 321 offence.

That last part is deliberately not answered here. Whether an Iowa city ordinance conviction that mirrors a chapter 321 offence puts the licence at risk is a question about Iowa law, and it belongs to whoever is advising the client. The code withholds an answer and says so on the row.

The caveat is held until the fees are written and fires only on a row that is a conviction and owes something, since that is the only row LICENSE-REGIS prints a verdict about. Across the corpus that is one row out of 90.

## Evidence

Replayed against all 90 captured cases:

| | before | after |
|---|---|---|
| H = YES | 33 | 35 |
| H = NO | 24 | 15 |
| H = blank | 33 | 40 |

Exactly nine rows move (2 NO→YES, 7 NO→blank), nothing else changes, exactly one note is emitted.

Rollback proof: 11 of the 13 new tests fail against `main`'s `crs.py` with real assertion failures, not import or attribute errors. The 2 that pass both ways are deliberate regression guards (an ordinance alongside a real state statute still answers YES; a non-vehicular state statute is still a confident NO).

Full suite: **758 pass**, up from 745.

## PII

Test fixtures use the synthetic `SY/` prefix throughout. The two real strings in the diff are municipal ordinance numbers in code comments explaining the two shapes. Those are published law, carry no case number, name or date, and offer no path to a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
