### PR TITLE
Pair the disposition date with the count the disposition came from

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -375,6 +375,12 @@ def parse_case_charges(html, case):
     case['sentences'] = parse_sentences(soup)
     charges = []
     charge_list = list()
+    # The adjudication date of each count, in step with charge_list, so the one
+    # date the sheet has room for can be the date of the count it names. Built
+    # the same way charge_list is, newest first, because the two are read
+    # together and a list that is sorted differently from its partner is a
+    # subtle way to pair the wrong count with the wrong date.
+    charge_date_list = list()
     cur_charge = None
     prev_od_dd = prev_od_mm = prev_od_yyyy = None
     new_od_dd = new_od_mm = new_od_yyyy = None
@@ -450,6 +456,8 @@ def parse_case_charges(html, case):
             if len(texts) >= 4 and texts[0].startswith("Adjudication:"):
                 charge_list.insert(0, texts[1])
                 cur_charge['disposition'] = charge_list
+                charge_date_list.insert(0, texts[3])
+                cur_charge['disposition_dates'] = charge_date_list
                 prior_description = prior_description + "[" + disposition_code(texts[1]) + "];"
                 cur_charge['description'] = cur_charge['description'] + "[" + disposition_code(texts[1]) + "]"
                 if 'prior_dispositionDate' not in vars():

--- a/crs.py
+++ b/crs.py
@@ -173,6 +173,18 @@ ORDINANCE_VEHICULAR_NOTE = (
     "it."
 )
 
+# The row has one disposition date and the case had several. Column D now holds
+# the one that goes with the code in column G, which is the pairing the sheets
+# assume, but the SOL sheet runs its twenty year test off that single date and
+# will apply it to every dollar on the row including debt from a count disposed
+# years earlier.
+DISPOSITION_SPREAD_NOTE = (
+    "Counts on this case were disposed on different dates (%s). Column D holds "
+    "%s, the date of the disposition in column G. The SOL sheet applies its "
+    "20 year test to that one date for the whole row, so if this case is near "
+    "the 20 year line check the counts separately."
+)
+
 
 def is_vehicular(statutes):
     """"YES", "NO", or None when there is nothing to judge from.
@@ -419,9 +431,13 @@ def get_dominant_charge(charges):
         return None
     delisted = dict(charges[0])
     raw_charge = delisted['disposition']
+    raw_dates = delisted.get('disposition_dates') or []
     charge_dict = {}
+    # Which counts produced each code, by date, so the winning code can be
+    # paired with the date of the count that actually produced it.
+    dates_by_code = {}
     unknown = set()
-    for disposition in raw_charge:
+    for index, disposition in enumerate(raw_charge):
         disposition = disposition.replace("DNU-", "")
         if not disposition:
             # ICOS printed no adjudication for this count. That is the absence
@@ -440,13 +456,44 @@ def get_dominant_charge(charges):
         elif disposition not in charge_code_map:
             charge_dict["OTH"] = OTH_RANK
             unknown.add(disposition)
+            charge_key = "OTH"
         else:
             charge_key, rank = next(iter(charge_code_map[disposition].items()))
             charge_dict[charge_key] = rank
+        if index < len(raw_dates) and raw_dates[index]:
+            dates_by_code.setdefault(charge_key, []).append(raw_dates[index])
     sorted_tuples = sorted(charge_dict.items(), reverse=True,
                            key=lambda item: item[1] if item[1] is not None else float('inf'))
     delisted['disposition'] = sorted_tuples[0][0] if sorted_tuples else ''
     delisted['unknown_dispositions'] = sorted(unknown)
+
+    # Column D is the date of the disposition column G names, and on a case
+    # where the counts were disposed on different days those two used to come
+    # from different counts. The parser handed over whichever date came first on
+    # the page and column G is chosen by rank, so a case pleaded out on one
+    # count and adjudicated on another more than a year later reported the later
+    # code against the earlier date.
+    #
+    # That pairing is not cosmetic. The SOL sheet asks IF(D+7300 < today) on
+    # every row, the twenty year limit on enforcing an Iowa judgment, and it
+    # sorts the row's debt into time barred or "NO ARGUMENT" on the answer.
+    # Taking the earliest date available makes a judgment look older than it is,
+    # so the error ran toward telling an attorney a debt had aged out when it
+    # had not.
+    #
+    # Where several counts share the winning code, the last of them is the day
+    # the case finished reaching that disposition, and it is also the reading
+    # that will not retire a debt early.
+    winning_dates = dates_by_code.get(delisted['disposition']) or []
+    if winning_dates:
+        delisted['dispositionDate'] = max(
+            winning_dates, key=lambda d: parse_us_date(d) or date.min)
+
+    # A row that compresses counts disposed on different days is saying less
+    # than the case does, and the sheet that reads the date cannot see the
+    # spread. Recorded here, said in column V by the caller.
+    spread = sorted({d for d in raw_dates if d})
+    delisted['disposition_date_spread'] = spread if len(spread) > 1 else []
     return delisted
 
 
@@ -1068,6 +1115,10 @@ def process_case(case, worksheet, row, as_of=None):
         append_note(worksheet, i, supervision_note)
     if ordinance_note and owes_money(worksheet, i):
         append_note(worksheet, i, ordinance_note)
+    spread = charge.get('disposition_date_spread') or []
+    if spread and owes_money(worksheet, i):
+        append_note(worksheet, i, DISPOSITION_SPREAD_NOTE
+                    % (", ".join(spread), disposition_date))
     unknown = charge.get('unknown_dispositions') or []
     if unknown:
         append_note(worksheet, i,

--- a/tests/test_multi_count.py
+++ b/tests/test_multi_count.py
@@ -1,0 +1,255 @@
+"""A case whose counts were disposed on different days, and the one date column D has.
+
+ICOS gives every count its own adjudication and its own adjudication date. The
+CRS has one row per case, so column G is chosen by rank across the counts and
+column D holds a single date. Those two used to come from different counts:
+column G from whichever count outranked the rest, column D from whichever count
+ICOS printed first.
+
+On three of the nine captured multi-count cases the counts really were disposed
+on different days, and one of them shows the pairing coming apart. A count
+pleaded out, a second count dismissed some months later, and last of all an
+adjudication that outranks both. The row reported that adjudication's code
+against the date of the plea, more than a year earlier.
+
+The date is the part that costs something. The SOL sheet asks
+
+  IF('CASE DATA'!D4 + 7300 < today, ...)
+
+on every row, which is the twenty year limit on enforcing an Iowa judgment, and
+sorts the row's debt into time barred or "NO ARGUMENT" on the answer. Reaching
+for the earliest date on the page makes a judgment look older than it is, so
+the error ran in the direction of telling an attorney a debt had aged out when
+it had not.
+
+The pages here are synthetic. This repo is public and a real charges page is one
+person's unredacted criminal record.
+"""
+
+import os
+import sys
+from decimal import Decimal
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+
+def _cells(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page(counts):
+    """ICOS's real shape for a multi-count case.
+
+    Each count is (statute, description, adjudication, adjudication date). An
+    adjudication of None is a count no court has ruled on yet, which ICOS prints
+    with the block present and its cells empty.
+    """
+    html = ['<html><body><table>']
+    for number, (statute, description, outcome, when) in enumerate(counts, 1):
+        html.append(_cells('Count %02d' % number, 'Original Charge'))
+        html.append(_cells('Charge:', statute, 'Description:', description))
+        html.append(_cells('Offense Date:', '01/01/1900', 'Arrest Date:', ''))
+        html.append(_cells('Adjudication'))
+        if outcome is None:
+            html.append(_cells('Charge:', '', 'Description:', ''))
+            html.append(_cells('Adjudication:', '', 'Adjudication Date:', ''))
+        else:
+            html.append(_cells('Charge:', statute, 'Description:', description))
+            html.append(_cells('Adjudication:', outcome,
+                               'Adjudication Date:', when))
+    html.append('</table></body></html>')
+    return ''.join(html).encode('utf-8')
+
+
+def _case(counts, costs='65.75'):
+    case = {'id': '00000  FECR000000', 'county': 'SYNTHETIC',
+            'financials': [], 'sentences': [],
+            'summary_created_date': '01/01/1900',
+            'summary_disposition_date': '', 'summary_dispo_status': ''}
+    case_parser.parse_case_charges(charges_page(counts), case)
+    case['summary_categories'] = [
+        {'label': label,
+         'original': Decimal(costs) if label == 'COSTS' else Decimal('0'),
+         'paid': Decimal('0'),
+         'due': Decimal(costs) if label == 'COSTS' else Decimal('0')}
+        for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')]
+    case['total_due'] = '$' + costs
+    return case
+
+
+def _row(counts, costs='65.75'):
+    sheet = load_workbook(FULL)['CASE DATA']
+    case = _case(counts, costs)
+    crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
+    row = str(crs.FIRST_CASE_ROW)
+    return {column: sheet[column + row].value
+            for column in ('D', 'F', 'G', 'V')}
+
+
+# -- the parser keeps a date per count ---------------------------------------
+
+def test_every_count_keeps_its_own_adjudication_date():
+    """Nothing recorded them before, so nothing could pair them up."""
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(charges_page([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ]), case)
+    charge = case['charges'][0]
+    assert charge['disposition_dates'] == ['02/02/1901', '01/01/1900']
+
+
+def test_the_dates_line_up_with_the_dispositions_they_belong_to():
+    """They are read as a pair, so they have to be sorted the same way.
+
+    Both lists are built newest first. A list sorted differently from its
+    partner is a quiet way to pair the wrong count with the wrong date.
+    """
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(charges_page([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ]), case)
+    charge = case['charges'][0]
+    pairs = list(zip(charge['disposition'], charge['disposition_dates']))
+    assert pairs == [('GUILTY', '02/02/1901'),
+                     ('DISMISSED BY COURT', '01/01/1900')]
+
+
+# -- the date follows the code -----------------------------------------------
+
+def test_column_d_is_the_date_of_the_count_column_g_names():
+    """The captured shape: a plea, then a dismissal, then an adjudication.
+
+    Column G takes the adjudication because it outranks the rest. Column D used
+    to take the first count's date, from well over a year before.
+    """
+    cells = _row([
+        ('715A.2(2)(A)', 'SYNTHETIC FORGERY', 'GUILTY', '01/01/1900'),
+        ('908.11', 'SYNTHETIC VIOLATION', 'DISMISSED BY COURT', '02/02/1901'),
+        ('715A.2(2)(A)', 'SYNTHETIC FORGERY', 'ADJUDICATED', '03/03/1903'),
+    ])
+    assert cells['G'] == 'JUV'
+    assert cells['D'] == '03/03/1903'
+
+
+def test_a_dismissal_printed_first_does_not_date_the_conviction():
+    """The shape that reads worst: the row says guilty as of the dismissal."""
+    cells = _row([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ])
+    assert cells['G'] == 'GTR'
+    assert cells['D'] == '02/02/1901'
+
+
+def test_the_conviction_coming_first_is_left_alone():
+    """The guard. Two of the three captured cases already had it right and
+    a fix that moves those has broken something."""
+    cells = _row([
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '01/01/1900'),
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '02/02/1901'),
+    ])
+    assert cells['G'] == 'GTR'
+    assert cells['D'] == '01/01/1900'
+
+
+def test_two_counts_sharing_the_winning_code_take_the_later_date():
+    """A captured case convicted on two counts two years apart.
+
+    The case finished reaching that disposition on the second date, and it is
+    the reading that will not retire a debt early.
+    """
+    cells = _row([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'GUILTY', '01/01/1900'),
+        ('714.2(3)', 'SYNTHETIC THEFT', 'GUILTY', '02/02/1901'),
+    ])
+    assert cells['G'] == 'GTR'
+    assert cells['D'] == '02/02/1901'
+
+
+def test_a_single_count_case_is_untouched():
+    """81 of the 90 captured cases have exactly one count."""
+    cells = _row([
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ])
+    assert cells['G'] == 'GTR'
+    assert cells['D'] == '02/02/1901'
+
+
+def test_an_unadjudicated_count_contributes_no_date():
+    """It has no adjudication, so it cannot date one.
+
+    Its empty date must not be picked up as the pair for a code that came from
+    a count that really was decided.
+    """
+    cells = _row([
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+        ('714.2(3)', 'SYNTHETIC THEFT', None, ''),
+    ])
+    assert cells['G'] == 'GTR'
+    assert cells['D'] == '02/02/1901'
+
+
+# -- and the row says it is compressing more than one judgment ---------------
+
+def test_a_case_disposed_over_several_days_says_so():
+    """The sheet reads one date and applies it to every dollar on the row."""
+    cells = _row([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ])
+    note = cells['V'] or ''
+    assert '01/01/1900' in note
+    assert '02/02/1901' in note
+    assert '20 year' in note
+
+
+def test_counts_disposed_the_same_day_stay_quiet():
+    """Six of the nine captured multi-count cases were disposed in one hearing.
+
+    There is no spread to warn about and column V is where the notes that
+    matter go.
+    """
+    cells = _row([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '02/02/1901'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ])
+    assert 'different dates' not in (cells['V'] or '')
+
+
+def test_a_case_that_owes_nothing_stays_quiet():
+    """The SOL sheet sorts debt into buckets. With no debt there is none to
+    sort, and the caveat describes a decision nobody is going to make."""
+    cells = _row([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ], costs='0')
+    assert 'different dates' not in (cells['V'] or '')
+
+
+def test_the_caveat_joins_what_the_money_left_in_column_v():
+    """Column V belongs to process_financials first. This joins, never replaces."""
+    sheet = load_workbook(FULL)['CASE DATA']
+    case = _case([
+        ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
+        ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
+    ])
+    case['financials'] = [
+        {'detail': 'SYNTHETIC UNCATEGORISED LINE', 'amount': Decimal('10.00'),
+         'paid': None},
+    ]
+    crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
+    note = sheet['V' + str(crs.FIRST_CASE_ROW)].value or ''
+    assert 'MISCELLANEOUS' in note, note
+    assert 'different dates' in note, note


### PR DESCRIPTION
## What the replay found

ICOS gives every count its own adjudication and its own adjudication date. The CRS has one row per case, so column G is chosen by rank across the counts while column D holds a single date.

Those two came from different counts. Column G from whichever count outranked the rest, column D from whichever count ICOS happened to print first.

Nine of 90 captured cases have more than one count, and on three of them the counts really were disposed on different days. One shows the pairing coming apart cleanly: a count pleaded out, a second dismissed some months later, and last of all an adjudication that outranks both. The row reported that adjudication's code against the date of the plea, more than a year earlier.

## Why the date matters

The SOL sheet asks this on every row:

```
=IFERROR(IF('CASE DATA'!D4+7300 < 'BASIC INFO'!$B$3, 'CASE DATA'!J4+'CASE DATA'!K4, 0), 0)
=IFERROR(IF('CASE DATA'!D4+7300 > 'BASIC INFO'!$B$3, SUM('CASE DATA'!J4:S4), 0), 0)
```

7300 days is the twenty year limit on enforcing an Iowa judgment, and the answer sorts the row's debt into time barred or "NO ARGUMENT".

Reaching for the earliest date on the page makes a judgment look older than it is. So the error ran in the direction of telling an attorney a debt had aged out when it had not, which is the harmful direction: a client told a live debt is dead does not get a second look.

## The change

The parser keeps a date per count, in step with the dispositions it already kept. The dominant pick then carries the date of the count that produced the winning code.

Where several counts share the winning code the last of them wins. That is the day the case finished reaching that disposition, and it is also the reading that will not retire a debt early.

## The row still says what it is compressing

One row, one date, and possibly several judgments. The sheet reading the date cannot see the spread, so on a row that owes something column V now lists the dates, names the one column D holds, and says the 20 year test is being applied to that single date for the whole row.

That caveat is gated the same way the ordinance one in #86 is: only where there is debt for the sheet to sort.

## Evidence

Replayed against all 90 captured cases. Exactly three rows change:

| case | counts | before | after |
|---|---|---|---|
| two guilty counts, two years apart | 2 | earlier date | later date + caveat |
| guilty then dismissed, nine days apart | 2 | unchanged | unchanged + caveat |
| plea, dismissal, adjudication over 13 months | 3 | plea date | adjudication date + caveat |

Nothing else moves.

Rollback proof: 7 of the 12 new tests fail against `main`, 5 of them on real assertions about the date and 2 on the new key not existing. The 5 that pass both ways are deliberate guards (a conviction printed first is left alone, a single-count case is untouched, an unadjudicated count contributes no date, same-day counts stay quiet, a debt-free case stays quiet).

Full suite: **770 pass**, up from 758.

## Known gap this does not close

The corpus is 90 cases and only nine have multiple counts, all drawn from a narrow set of counties. Alex has asked for a wider capture across counties and surnames to shake out more coding shapes, and that is the next piece of work. This PR fixes what the current corpus proves.

## PII

Test fixtures are synthetic throughout. Real years and the juvenile framing were removed from the docstrings before commit: one of the three cases is a juvenile matter, and Iowa juvenile records are confidential, so the code describes the shape rather than the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
