### PR TITLE
Reach the cases the derived sheets were never dragged down to

### DIFF
--- a/grid.py
+++ b/grid.py
@@ -1,0 +1,221 @@
+"""Make the workbook's derived sheets reach as far as its case list.
+
+CASE DATA takes one row per case and build_workbook has nothing stopping it.
+The sheets that read CASE DATA do stop, each at a different row, because each
+was filled down by hand to whatever depth looked like enough:
+
+    SOL              rows to 150   covers 147 cases
+    EXPUNGEMENT      rows to 200   covers 198 cases
+    EXEMPTIONS       rows to 200   covers 197 cases
+    BANKRUPTCY       rows to 201   covers 198 cases
+    LICENSE-REGIS    rows to 300   covers 299 cases
+    POLK R&B APPEAL  rows to 300   covers 299 cases
+
+and the totals at the top of SOL, BANKRUPTCY and EXEMPTIONS are shorter still,
+=SUM(C4:C100), which covers 97.
+
+Past those the workbook does not complain. The case is on CASE DATA with its
+money in columns J to S, and it is absent from the analysis: not time barred,
+not "NO ARGUMENT", not a pending charge blocking expungement, nowhere. Built
+from the captured corpus at 210 cases, 63 of them are missing from the SOL
+sheet entirely and its NO ARGUMENT total reads $6,727.91 against $6,895.38 of
+rows the sheet itself computed.
+
+A staffer has already pulled 70 cases in one run in production, so the totals
+threshold of 98 is the one that matters. A client with decades of traffic and
+scheduled-violation cases reaches it.
+
+Nothing here decides anything. Every formula written is the sheet author's own
+last row, translated down, and every range widened keeps its start and its
+function and only stops later. The analysis is unchanged; it just reaches the
+rows that were already there. A workbook small enough for the grid it shipped
+with comes out exactly as before.
+"""
+
+import re
+from copy import copy
+
+from openpyxl.formula.translate import Translator
+
+# The sheets that hold the case list itself, the clinic header and the static
+# statute lookup. None of them is a per-case analysis of CASE DATA.
+NOT_DERIVED = ('CASE DATA', 'BASIC INFO', 'CODE SECTIONS')
+
+# Far past any case list, and there to stop a sheet whose styled region runs to
+# the bottom of the spreadsheet from being walked cell by cell.
+ROW_CAP = 5000
+
+# 'CASE DATA'!A6 and 'CASE DATA'!$D$4 both name a row. The dollar matters: a
+# relative reference moves when the formula is translated down and an absolute
+# one does not, which is exactly the difference between a per-row lookup and a
+# count over the whole column.
+CASE_REF = re.compile(r"'CASE DATA'!(\$?)([A-Z]{1,3})(\$?)(\d+)")
+
+# A range on this same sheet, so not one preceded by a sheet name. Only the end
+# row is ever touched.
+LOCAL_RANGE = re.compile(r"(?<!!)\b([A-Z]{1,3})(\d+):([A-Z]{1,3})(\d+)\b")
+
+# A range over CASE DATA with an absolute row, which is the shape a count over
+# every case takes. A relative one is a per-row lookup and is left alone.
+CASE_RANGE = re.compile(
+    r"('CASE DATA'!)(\$?[A-Z]{1,3}\$)(\d+):(\$?[A-Z]{1,3}\$)(\d+)")
+
+
+def _formula(cell):
+    value = cell.value
+    return value if isinstance(value, str) and value.startswith('=') else None
+
+
+def _case_rows(formula):
+    """The CASE DATA rows a formula names relatively, so the ones that move."""
+    return {int(m.group(4)) for m in CASE_REF.finditer(formula)
+            if not m.group(3)}
+
+
+def _survey(sheet):
+    """Every row of this sheet that reads a case row, and which row it reads.
+
+    Returns (rows, deepest, furthest) where rows maps a sheet row to the
+    highest case row it reads, deepest is the last such sheet row and furthest
+    is the highest case row the sheet reads anywhere.
+    """
+    rows = {}
+    for row in sheet.iter_rows(min_row=1, max_row=min(sheet.max_row, ROW_CAP)):
+        best = None
+        for cell in row:
+            formula = _formula(cell)
+            if not formula:
+                continue
+            named = _case_rows(formula)
+            if named:
+                best = max(named) if best is None else max(best, max(named))
+        if best is not None:
+            rows[row[0].row] = best
+    if not rows:
+        return rows, None, None
+    return rows, max(rows), max(rows.values())
+
+
+def _widen_local_ranges(formula, first_case_row, last_row):
+    """Push a range down the case rows to last_row, never up.
+
+    SUM(C4:C100) on a sheet now carrying 210 cases has to become SUM(C4:C213).
+    A range that already reaches far enough is left exactly as written, so a
+    workbook that fits its grid keeps the formula it shipped with.
+
+    Only a range that starts in the case rows is one of these. SOL's grand
+    total is =SUM(C1:E1), three cells of the totals row itself, and stretching
+    that to E150 adds every per-row figure to the totals that already contain
+    them and doubles the sheet's headline number.
+    """
+    def replace(match):
+        start_col, start_row, end_col, end_row = match.groups()
+        if int(start_row) < first_case_row or int(end_row) >= last_row:
+            return match.group(0)
+        return '%s%s:%s%d' % (start_col, start_row, end_col, last_row)
+    return LOCAL_RANGE.sub(replace, formula)
+
+
+def _widen_case_ranges(formula, last_case_row):
+    """The same for a count over every case row.
+
+    The expungement sheet finds pending charges with
+    COUNTIF('CASE DATA'!$D$4:$D$200,"") and a case at row 201 is a pending
+    charge it cannot see. That count is what says whether anything is still
+    hanging over the client under 901C.2, so it has to cover the whole list.
+    """
+    def replace(match):
+        prefix, start, start_row, end, end_row = match.groups()
+        if int(end_row) >= last_case_row:
+            return match.group(0)
+        return '%s%s%s:%s%d' % (prefix, start, start_row, end, last_case_row)
+    return CASE_RANGE.sub(replace, formula)
+
+
+def _extend_sheet(sheet, last_case_row):
+    """Fill this sheet's last row of formulas down to cover last_case_row.
+
+    Returns (rows added, the sheet's last formula row afterwards, and the
+    first row of it that reads a case, which is where the header ends).
+
+    The sheets do not agree on where a case lands. SOL row 4 reads case row 4;
+    the expungement sheet starts a row higher, its row 3 reading case row 4;
+    LICENSE-REGIS reads them out of order, its row 2 pointing at case row 6
+    while case row 4 sits down at row 57. So the offset is measured from the
+    sheet's own last row rather than assumed. Order does not matter to any of
+    these sheets, because nothing on them reads a neighbouring row.
+    """
+    rows, deepest, furthest = _survey(sheet)
+    if deepest is None:
+        return 0, None, None
+
+    first = min(rows)
+    reached = rows[deepest]
+    if reached < furthest:
+        # The sheet reads a higher case row somewhere above its last row, so
+        # filling down from that last row would leave a gap or a repeat. None
+        # of the shipped templates is shaped this way, and guessing at one that
+        # is would be worse than leaving it alone.
+        return 0, deepest, first
+    if reached >= last_case_row:
+        return 0, deepest, first
+
+    template = [cell for cell in sheet[deepest] if _formula(cell)]
+    added = last_case_row - reached
+    for step in range(1, added + 1):
+        for cell in template:
+            target = sheet.cell(row=deepest + step, column=cell.column)
+            target.value = Translator(
+                _formula(cell), origin=cell.coordinate).translate_formula(
+                    row_delta=step, col_delta=0)
+            # Without this the new rows lose the currency and date formats the
+            # filled-down ones carry, and a dollar figure printed as a bare
+            # number reads as a different kind of number.
+            target._style = copy(cell._style)
+    return added, deepest + added, first
+
+
+def extend_formula_grid(workbook, case_count):
+    """Widen every derived sheet to the number of cases actually written.
+
+    Call once the CASE DATA rows are in and before the workbook is saved.
+    Returns the sheets that had to change, which is empty for any workbook that
+    already fits the grid the templates ship with.
+    """
+    if case_count <= 0:
+        return {}
+
+    last_case_row = 3 + case_count
+    changed = {}
+    for sheet in workbook.worksheets:
+        if sheet.title in NOT_DERIVED:
+            continue
+
+        added, deepest, first_case_row = _extend_sheet(sheet, last_case_row)
+        if deepest is None:
+            continue
+        touched = added
+
+        # Ranges come after the fill so the totals can see the rows just added.
+        # This runs whether or not the sheet grew: the totals on SOL, BANKRUPTCY
+        # and EXEMPTIONS stop at row 100 while their per-row formulas run to 150
+        # and beyond, so a workbook can sit inside the grid and still be
+        # under-totalled. Widening a range on a per-case row would be a
+        # different thing entirely, so only the header rows above the case rows
+        # are eligible for it.
+        for row in sheet.iter_rows(min_row=1,
+                                   max_row=min(sheet.max_row, ROW_CAP)):
+            for cell in row:
+                formula = _formula(cell)
+                if not formula:
+                    continue
+                widened = _widen_case_ranges(formula, last_case_row)
+                if cell.row < first_case_row:
+                    widened = _widen_local_ranges(
+                        widened, first_case_row, deepest)
+                if widened != formula:
+                    cell.value = widened
+                    touched = touched or 1
+        if touched:
+            changed[sheet.title] = added
+    return changed

--- a/tasks.py
+++ b/tasks.py
@@ -17,6 +17,7 @@ import actions
 import alerts
 import case_parser
 import crs
+import grid
 import icos_sessions
 import roster
 from icos import IcosClient, IcosError, IcosStopped, STOPPED_MESSAGE
@@ -924,6 +925,15 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
         for disposition in crs.process_case(case, sheet, row, clinic_date) or []:
             unknown.setdefault(disposition, []).append(case['id'])
         row += 1
+
+    # The templates were filled down by hand, each to a different depth, and
+    # nothing above stops the case list before it runs past them. A case on a
+    # row no derived sheet reaches is not reported as time barred, not reported
+    # as having no argument and not counted as a pending charge: it is simply
+    # absent, and the workbook says nothing. This fills the author's own last
+    # row down to the case list and widens the totals to match. It changes no
+    # formula's meaning, and does nothing at all to a workbook that fits.
+    grid.extend_formula_grid(workbook, row - 4)
 
     sheet = workbook['BASIC INFO']
     # Every date test in the workbook compares against B3, the clinic date: the

--- a/tests/test_formula_grid.py
+++ b/tests/test_formula_grid.py
@@ -1,0 +1,260 @@
+"""A case list longer than the grid the templates were filled down to.
+
+CASE DATA takes one row per case and nothing stops it. The sheets that read
+CASE DATA stop, each at a different row, because each was dragged down by hand
+to whatever looked like enough: SOL at 150, expungement and exemptions at 200,
+bankruptcy at 201, licence and Polk room and board at 300. The totals at the
+top of SOL, bankruptcy and exemptions are shorter still, =SUM(C4:C100).
+
+Past those the workbook says nothing. The case sits on CASE DATA with its money
+in columns J to S and it is simply absent from the analysis: not time barred,
+not "NO ARGUMENT", not counted as a pending charge under 901C.2.
+
+Measured on the 210 captured cases, built into the real workbook and computed
+by LibreOffice. Before, 63 of them had no row at all on the SOL sheet and its
+NO ARGUMENT total read $6,727.91. After, every case has a row and the total
+reads $7,539.73. The same corpus cut to 40 cases comes out cell for cell
+identical either way.
+
+A staffer has already pulled 70 cases in one run in production, and the totals
+give way at 98.
+
+The cases here are synthetic. This repo is public and a real charges page is
+one person's unredacted criminal record.
+"""
+
+import os
+import re
+import sys
+from decimal import Decimal
+
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import grid
+import tasks
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
+
+# The shallowest per-row grid in either template, so a list longer than this
+# has cases the SOL sheet cannot see.
+SOL_LAST_ROW = 150
+
+CASE_REF = re.compile(r"'CASE DATA'!(\$?)[A-Z]{1,3}(\$?)(\d+)")
+
+
+def _cells(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page():
+    """One count, convicted, so the row carries a code and a date."""
+    return ''.join([
+        '<html><body><table>',
+        _cells('Count 01', 'Original Charge'),
+        _cells('Charge:', '321.285', 'Description:', 'SYNTHETIC SPEEDING'),
+        _cells('Offense Date:', '01/01/1900', 'Arrest Date:', ''),
+        _cells('Adjudication'),
+        _cells('Charge:', '321.285', 'Description:', 'SYNTHETIC SPEEDING'),
+        _cells('Adjudication:', 'GUILTY', 'Adjudication Date:', '02/02/1901'),
+        '</table></body></html>']).encode('utf-8')
+
+
+def synthetic_cases(count):
+    """A case list of a given length, every case owing the same small sum."""
+    page = charges_page()
+    cases = []
+    for n in range(count):
+        case = {'id': '00000  FECR%06d' % n, 'county': 'SYNTHETIC',
+                'financials': [], 'sentences': [],
+                'summary_created_date': '01/01/1900',
+                'summary_disposition_date': '', 'summary_dispo_status': ''}
+        case_parser.parse_case_charges(page, case)
+        case['summary_categories'] = [
+            {'label': label, 'original': Decimal('10.00' if label == 'FINE' else '0'),
+             'paid': Decimal('0'),
+             'due': Decimal('10.00' if label == 'FINE' else '0')}
+            for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')]
+        case['total_due'] = '$10.00'
+        cases.append(case)
+    return cases
+
+
+def extended(count, template=FULL):
+    """A template with the case rows filled in and the grid widened to match."""
+    workbook = load_workbook(template)
+    sheet = workbook['CASE DATA']
+    for n in range(count):
+        sheet['A%d' % (4 + n)] = '00000  FECR%06d' % n
+    grown = grid.extend_formula_grid(workbook, count)
+    return workbook, grown
+
+
+def formulas(sheet, limit):
+    return {cell.coordinate: cell.value
+            for row in sheet.iter_rows(min_row=1, max_row=limit)
+            for cell in row
+            if isinstance(cell.value, str) and cell.value.startswith('=')}
+
+
+# -- the end of the case list reaches every sheet ----------------------------
+
+def test_a_case_past_the_sol_grid_gets_a_row_on_it():
+    count = SOL_LAST_ROW + 20
+    workbook, grown = extended(count)
+    last = 3 + count
+    assert grown, 'nothing grew, so nothing below is being tested'
+    formula = workbook['SOL']['A%d' % last].value
+    assert formula, 'the last case has no row on the SOL sheet'
+    assert "'CASE DATA'!A%d" % last in formula, formula
+
+
+def test_every_case_row_is_read_exactly_once_afterwards():
+    """LICENSE-REGIS reads the case rows out of order, case row 4 sitting at
+    sheet row 57. Filling down must not repeat one or drop one."""
+    count = 320
+    workbook, _ = extended(count)
+    last = 3 + count
+    for name in ('SOL', 'LICENSE-REGIS', 'BANKRUPTCY', 'EXEMPTIONS'):
+        sheet = workbook[name]
+        seen = []
+        for row in sheet.iter_rows(min_row=1, max_row=last + 4):
+            for cell in row:
+                value = cell.value
+                if not (isinstance(value, str) and value.startswith('=')):
+                    continue
+                if cell.column_letter != 'A':
+                    continue
+                # Once per cell. The formula is
+                # =IF('CASE DATA'!A4="","",'CASE DATA'!A4) and names its case
+                # row twice, which is one row read once.
+                seen.extend({int(match.group(3))
+                             for match in CASE_REF.finditer(value)
+                             if not match.group(2)})
+        wanted = set(range(4, last + 1))
+        assert wanted <= set(seen), (
+            '%s misses case rows %s' % (name, sorted(wanted - set(seen))[:10]))
+        repeats = [r for r in wanted if seen.count(r) > 1]
+        assert not repeats, '%s reads case rows twice: %s' % (name, repeats[:10])
+
+
+def test_the_totals_cover_the_whole_case_list():
+    """SOL, bankruptcy and exemptions all total =SUM(C4:C100), which gives way
+    at 98 cases while their own rows run to 150 and beyond."""
+    count = 120
+    workbook, _ = extended(count)
+    for name in ('SOL', 'BANKRUPTCY', 'EXEMPTIONS'):
+        total = workbook[name]['C1'].value
+        end = int(re.search(r'C4:C(\d+)', total).group(1))
+        assert end >= 3 + count, '%s totals stop at row %d' % (name, end)
+
+
+def test_the_pending_charge_count_covers_the_whole_case_list():
+    """The expungement sheet finds pending charges with
+    COUNTIF('CASE DATA'!$D$4:$D$200,""), and a blank D past row 200 is a
+    pending charge it cannot see. That count is the 901C.2 blocker."""
+    count = 260
+    workbook, _ = extended(count)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    found = False
+    for row in sheet.iter_rows(min_row=1, max_row=3 + count + 4):
+        for cell in row:
+            value = cell.value
+            if not (isinstance(value, str) and 'COUNTIF' in value):
+                continue
+            for end in re.findall(r"'CASE DATA'!\$[A-Z]+\$\d+:\$[A-Z]+\$(\d+)",
+                                  value):
+                found = True
+                assert int(end) >= 3 + count, (
+                    '%s counts only to row %s' % (cell.coordinate, end))
+    assert found, 'no COUNTIF over CASE DATA was checked'
+
+
+# -- and a workbook that fits is left exactly as it was ----------------------
+
+def test_a_short_case_list_changes_no_formula():
+    """Most clinics are well inside the grid, and those workbooks have to come
+    out of this unchanged."""
+    plain = load_workbook(FULL)
+    workbook, grown = extended(40)
+    assert not any(grown.values()), 'a 40 case list needs no new rows'
+    for name in ('SOL', 'EXPUNGEMENT & 910.7', 'BANKRUPTCY', 'EXEMPTIONS',
+                 'LICENSE-REGIS', 'POLK R&B APPEAL'):
+        before = formulas(plain[name], 320)
+        after = formulas(workbook[name], 320)
+        assert before, 'no formulas read off %s, so nothing was compared' % name
+        moved = {k: (before[k], after.get(k))
+                 for k in before if before[k] != after.get(k)}
+        # The totals are allowed to reach the sheet's own last row; nothing
+        # else may move, and no total may reach past what the sheet computes.
+        for coordinate, (was, now) in moved.items():
+            assert coordinate in ('C1', 'D1', 'E1', 'F1'), \
+                '%s!%s changed: %r -> %r' % (name, coordinate, was, now)
+
+
+def test_the_grand_total_is_not_stretched_down_the_sheet():
+    """SOL's F1 is =SUM(C1:E1), three cells of the totals row itself. Widening
+    it to E150 adds every per-row figure to the totals that already hold them
+    and doubles the sheet's headline number."""
+    workbook, _ = extended(210)
+    assert workbook['SOL']['F1'].value == '=SUM(C1:E1)'
+    assert workbook['BANKRUPTCY']['G1'].value == '=SUM(C1:F1)'
+    assert workbook['EXEMPTIONS']['E1'].value == '=SUM(C1:D1)'
+
+
+def test_nothing_happens_to_an_empty_case_list():
+    workbook, grown = extended(0)
+    assert grown == {}
+    assert workbook['SOL']['A%d' % (SOL_LAST_ROW + 1)].value is None
+
+
+# -- the rows that get added look like the ones above them -------------------
+
+def test_the_new_rows_keep_the_formats_of_the_row_they_came_from():
+    """A dollar figure printed as a bare number reads as a different number."""
+    workbook, _ = extended(SOL_LAST_ROW + 20)
+    sheet = workbook['SOL']
+    for column in ('C', 'D', 'E'):
+        source = sheet['%s%d' % (column, SOL_LAST_ROW)].number_format
+        added = sheet['%s%d' % (column, SOL_LAST_ROW + 5)].number_format
+        assert added == source, column
+
+
+def test_the_lite_template_grows_too():
+    """Lite has no SOL sheet but its licence and expungement sheets stop too."""
+    workbook, grown = extended(260, template=LITE)
+    assert grown, 'the lite template did not grow'
+    last = 3 + 260
+    formula = workbook['EXPUNGEMENT & 910.7']['A%d' % (last - 1)].value
+    assert formula and "'CASE DATA'!A%d" % last in formula, formula
+
+
+def test_it_reports_which_sheets_it_had_to_touch():
+    _, grown = extended(SOL_LAST_ROW + 20)
+    assert 'SOL' in grown and grown['SOL'] > 0, grown
+
+
+# -- through the real build ---------------------------------------------------
+
+def test_a_built_workbook_covers_all_of_its_own_cases():
+    """The whole point, through the path a clinic actually takes."""
+    count = SOL_LAST_ROW + 10
+    path, _, _ = tasks.build_workbook(
+        synthetic_cases(count), 'TEST CLIENT', '01/01/1980', False)
+    try:
+        workbook = load_workbook(path)
+        last = 3 + count
+        assert workbook['CASE DATA']['A%d' % last].value, \
+            'the case list did not reach that row, so nothing is proved'
+        formula = workbook['SOL']['A%d' % last].value
+        assert formula, 'the last case has no row on the SOL sheet'
+        assert "'CASE DATA'!A%d" % last in formula, formula
+        end = int(re.search(r'C4:C(\d+)', workbook['SOL']['C1'].value).group(1))
+        assert end >= last, 'the SOL totals stop at row %d of %d' % (end, last)
+    finally:
+        os.remove(path)


### PR DESCRIPTION
## What breaks

`build_workbook` writes one CASE DATA row per case and has no cap. The sheets that read CASE DATA all have one, and they disagree:

| sheet | last row | cases it can see |
|---|---|---|
| SOL | 150 | 147 |
| EXPUNGEMENT & 910.7 | 200 | 198 |
| EXEMPTIONS | 200 | 197 |
| BANKRUPTCY | 201 | 198 |
| LICENSE-REGIS | 300 | 299 |
| POLK R&B APPEAL | 300 | 299 |

and the totals at the top of SOL, BANKRUPTCY and EXEMPTIONS are `=SUM(C4:C100)`, which covers 97.

Past those rows the workbook says nothing. The case is on CASE DATA with its money in columns J through S, and it is absent from the analysis: not time barred, not "NO ARGUMENT", not counted as a pending charge blocking expungement under 901C.2. No warning anywhere. A client with decades of traffic and scheduled violation cases gets a shorter answer than the one the workbook computed for them.

The totals threshold of 98 is the one that bites first, and a staffer has already pulled 70 cases in a single production run.

## Measured, not argued

The 210 captured real cases, built into the real template and computed by LibreOffice because openpyxl drops cached formula results:

| | before | after |
|---|---|---|
| SOL NO ARGUMENT total | $6,727.91 | $7,539.73 |
| SOL rows with no case number | 63 | 0 |
| BANKRUPTCY rows with no case number | 12 | 0 |
| EXEMPTIONS rows with no case number | 13 | 0 |
| sheets extended | | `{'EXPUNGEMENT & 910.7': 12, 'BANKRUPTCY': 12, 'EXEMPTIONS': 13, 'SOL': 63}` |

63 of 210 cases carrying $738.35 of ICOS debt were not on the SOL sheet at all.

The same corpus cut to 40 cases, well inside every grid: **every computed cell identical**, both sides through LibreOffice.

## What it does not do

It does not touch the analysis. Every formula written is the sheet author's own last row put through `openpyxl.formula.translate.Translator`, and every range widened keeps its start, its function and its meaning and only stops later. A workbook small enough for the grid it shipped with comes out exactly as before. CASE DATA, BASIC INFO and CODE SECTIONS are never touched.

That distinction is the point. This changes the emitted workbook without changing anything Ari's copyright covers.

## Two things easy to get wrong, both tested

SOL's grand total is `=SUM(C1:E1)`, three cells of the totals row itself. Widening that down the sheet adds every per-row figure to totals that already contain them and doubles the headline number. My first draft did exactly this and the 40-case control caught it. Only a range whose start is in the case rows is eligible now, and `test_the_grand_total_is_not_stretched_down_the_sheet` guards it.

The sheets disagree about where a case lands. SOL row 4 reads case row 4, expungement row 3 reads case row 4, and LICENSE-REGIS reads them out of order with case row 4 down at sheet row 57. So the offset is measured off each sheet's own last formula row rather than assumed, and `test_every_case_row_is_read_exactly_once_afterwards` checks nothing is dropped or doubled at 320 cases.

## Tests

11 new, suite goes 777 to 788, all passing.

Rollback proof: with the `grid.extend_formula_grid` call removed from `build_workbook`, `test_a_built_workbook_covers_all_of_its_own_cases` fails by assertion, `the last case has no row on the SOL sheet`, not by import error.

Every case in the tests is synthetic. This repo is public and a real charges page is one person's unredacted criminal record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
