### PR TITLE
Answer the 910.7 questions instead of printing #VALUE!

### DIFF
--- a/statutes.py
+++ b/statutes.py
@@ -1,0 +1,129 @@
+"""Split the statutory references into the helper columns CASE DATA hides.
+
+CASE DATA column F holds every statute a case was adjudicated under, joined
+with semicolons, and Napier writes it. Columns W to AH are twelve unheadered
+columns off the right hand edge that take that string back apart, one code per
+column, because the expungement sheet has to test the codes one at a time.
+
+The template does the split with a CSE array formula, and that formula pads
+every slot it did not fill with #VALUE!. That is its normal output, not a
+failure: a case with one statute leaves eleven #VALUE! cells behind it.
+
+Two columns of the expungement sheet read the range and only one of them
+survives that:
+
+    M   SUM(COUNTIF('CASE DATA'!W9:AH9,'CODE SECTIONS'!$V$2:$V$218&"*"))
+        the ineligible-offence list. COUNTIF steps over errors, so M answers.
+
+    N   OR(LEFT('CASE DATA'!W9:AH9,3)="719", ... )
+        chapters 717C, 719, 720, 724, 726, 728 and 901A, the offences 901C.2
+        will not seal. LEFT does not step over errors, so N is #VALUE!.
+
+N is gated on M being "YES" and Excel stops at the first false test, so N is
+only ever evaluated on a case that cleared the first screen. Which means the
+910.7 half of the sheet fails on exactly the rows it exists to answer, and
+nowhere else. Measured on the 210 captured cases: the 17 rows where M says YES
+are precisely the 17 rows where N says #VALUE!, no exceptions in either
+direction, and all five columns downstream of N go with it. Those 17 are
+forgery, third degree theft, drug possession, assault, harassment, fugitive
+from justice: the reason a client is at the clinic.
+
+So Napier does the split itself and writes plain text, with an empty string in
+the slots it does not fill. COUNTIF cannot tell an empty cell from an error, so
+M keeps every answer it already gave. LEFT can, so N starts answering.
+
+This is a mechanical resplit of a string Napier authored two columns earlier.
+It decides nothing and it reads nothing back. The sheet author's tests are the
+tests that run.
+
+It also lifts a ceiling nobody would have found: both templates had the array
+formula dragged to row 300, so case 298 onwards had no split at all.
+"""
+
+# W through AH. Twelve slots against a worst case of two statutes on one case
+# across the whole captured corpus, so the overflow path below is a backstop
+# rather than something that happens.
+FIRST_COLUMN = 23
+LAST_COLUMN = 34
+SLOTS = LAST_COLUMN - FIRST_COLUMN + 1
+
+FIRST_CASE_ROW = 4
+STATUTE_COLUMN = 6          # F, the joined references
+ROW_CAP = 5000
+
+# Row 9 of both templates was dragged one column too far and carries a
+# thirteenth slot in AI. Nothing reads it, the expungement sheet asks for
+# W9:AH9, but it is the same array formula and it prints the same #VALUE! on a
+# real case row. Anything out here holding the splitter is that mistake, and
+# only the splitter is touched.
+STRAY_COLUMNS = 12
+SPLITTER_MARK = "'CASE DATA'!$F"
+
+OVERFLOW_NOTE = (
+    "This case is adjudicated under more than %d statutes and the expungement "
+    "sheet only screens the first %d. The rest (%%s) have to be checked by "
+    "hand against 901C.2." % (SLOTS, SLOTS))
+
+
+def split_codes(reference):
+    """Column F back into its parts, the same way the array formula split it.
+
+    Empty fields are kept in place, because '715A.2(A);' is one code and a
+    trailing empty slot and the sheet reads them by position.
+    """
+    if reference in (None, ''):
+        return []
+    return [part.strip() for part in str(reference).split(';')]
+
+
+def _is_splitter(value):
+    text = getattr(value, 'text', value)
+    return isinstance(text, str) and text.startswith('=') and \
+        SPLITTER_MARK in text
+
+
+def _clear_strays(sheet, row):
+    """Blank a splitter cell that was dragged past the last slot the sheet reads."""
+    for column in range(LAST_COLUMN + 1, LAST_COLUMN + 1 + STRAY_COLUMNS):
+        cell = sheet.cell(row=row, column=column)
+        if _is_splitter(cell.value):
+            cell.value = ''
+
+
+def _template_depth(sheet):
+    """How far down the template's own splitter was filled.
+
+    Anything it wrote and Napier does not overwrite keeps its #VALUE! padding,
+    which is only cosmetic on a row with no case but is the kind of thing a
+    staffer reasonably reads as a broken workbook.
+    """
+    depth = FIRST_CASE_ROW - 1
+    for row in range(FIRST_CASE_ROW, ROW_CAP + 1):
+        if sheet.cell(row=row, column=FIRST_COLUMN).value is None:
+            break
+        depth = row
+    return depth
+
+
+def write_statute_split(workbook, case_count):
+    """Fill W..AH from column F. Call once the case rows are written.
+
+    Returns the rows whose statutes did not fit, which is empty for every case
+    the corpus has seen.
+    """
+    sheet = workbook['CASE DATA']
+    last_row = max(3 + case_count, _template_depth(sheet))
+    if last_row < FIRST_CASE_ROW:
+        return {}
+
+    overflow = {}
+    for row in range(FIRST_CASE_ROW, last_row + 1):
+        codes = split_codes(sheet.cell(row=row, column=STATUTE_COLUMN).value)
+        if len(codes) > SLOTS:
+            overflow[row] = codes[SLOTS:]
+            codes = codes[:SLOTS]
+        for offset in range(SLOTS):
+            sheet.cell(row=row, column=FIRST_COLUMN + offset).value = (
+                codes[offset] if offset < len(codes) else '')
+        _clear_strays(sheet, row)
+    return overflow

--- a/tasks.py
+++ b/tasks.py
@@ -20,6 +20,7 @@ import crs
 import grid
 import icos_sessions
 import roster
+import statutes
 from icos import IcosClient, IcosError, IcosStopped, STOPPED_MESSAGE
 
 # One case ICOS will not hand over is a bad case: sealed, or a page the parser
@@ -925,6 +926,18 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
         for disposition in crs.process_case(case, sheet, row, clinic_date) or []:
             unknown.setdefault(disposition, []).append(case['id'])
         row += 1
+
+    # Columns W to AH take column F apart one statute per column, and the
+    # expungement sheet's second screen reads them with LEFT(). The template
+    # did the split with an array formula that pads its unused slots with
+    # #VALUE!, which LEFT() will not step over, so the 910.7 columns failed on
+    # exactly the rows that cleared the first screen and nowhere else. Napier
+    # wrote column F, so it can split it too, and an empty slot is an empty
+    # string rather than an error.
+    for case_row, spare in statutes.write_statute_split(workbook,
+                                                        row - 4).items():
+        crs.append_note(sheet, case_row,
+                        statutes.OVERFLOW_NOTE % ", ".join(spare))
 
     # The templates were filled down by hand, each to a different depth, and
     # nothing above stops the case list before it runs past them. A case on a

--- a/tests/test_expungement_codes.py
+++ b/tests/test_expungement_codes.py
@@ -1,0 +1,285 @@
+"""The 910.7 columns computing an error on the rows they exist to answer.
+
+CASE DATA columns W to AH take column F apart, one statute per column, so the
+expungement sheet can test the codes one at a time. The template did it with an
+array formula that pads its unused slots with #VALUE!.
+
+Column M reads that range with COUNTIF, which steps over errors, and answers.
+Column N reads it with LEFT, which does not, and returns #VALUE!. N is gated on
+M being "YES", so it is only ever evaluated on a case that cleared the first
+screen, and columns O to S all read N.
+
+Built from the 210 captured cases and computed by LibreOffice: the 17 rows
+where M says YES are exactly the 17 rows where N says #VALUE!, no exceptions
+either way, and O POSSIBLE PENDING CHARGES, P DISCHARGEABLE DEBT, Q TIME BARRED
+DEBT, R TOTAL DEBT and S TIME ELAPSED are errors on all 17. The offences are
+forgery, third degree theft, drug possession, assault, harassment and fugitive
+from justice. With the split written as text instead, all 17 read "eligible",
+the five columns compute, and column M does not change its mind about anybody.
+
+The cases here are synthetic. This repo is public and a real charges page is
+one person's unredacted criminal record.
+"""
+
+import os
+import sys
+from decimal import Decimal
+
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import statutes
+import tasks
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
+
+# The depth both templates dragged the array formula down to, so the row past
+# which a long case list had no split at all.
+TEMPLATE_DEPTH = 300
+
+COLUMNS = list(range(statutes.FIRST_COLUMN, statutes.LAST_COLUMN + 1))
+
+
+def _cells(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page(charge='321.285'):
+    """One count, convicted, so the row carries a code and a date."""
+    return ''.join([
+        '<html><body><table>',
+        _cells('Count 01', 'Original Charge'),
+        _cells('Charge:', charge, 'Description:', 'SYNTHETIC OFFENSE'),
+        _cells('Offense Date:', '01/01/1900', 'Arrest Date:', ''),
+        _cells('Adjudication'),
+        _cells('Charge:', charge, 'Description:', 'SYNTHETIC OFFENSE'),
+        _cells('Adjudication:', 'GUILTY', 'Adjudication Date:', '02/02/1901'),
+        '</table></body></html>']).encode('utf-8')
+
+
+def synthetic_cases(count, charge='321.285'):
+    cases = []
+    page = charges_page(charge)
+    for n in range(count):
+        case = {'id': '00000  FECR%06d' % n, 'county': 'SYNTHETIC',
+                'financials': [], 'sentences': [],
+                'summary_created_date': '01/01/1900',
+                'summary_disposition_date': '', 'summary_dispo_status': ''}
+        case_parser.parse_case_charges(page, case)
+        case['summary_categories'] = [
+            {'label': label,
+             'original': Decimal('10.00' if label == 'FINE' else '0'),
+             'paid': Decimal('0'),
+             'due': Decimal('10.00' if label == 'FINE' else '0')}
+            for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')]
+        case['total_due'] = '$10.00'
+        cases.append(case)
+    return cases
+
+
+def split_row(sheet, row):
+    return [sheet.cell(row=row, column=column).value for column in COLUMNS]
+
+
+def is_empty(value):
+    """Blank as far as LEFT() is concerned.
+
+    An empty string is not saved as anything: openpyxl writes the cell with no
+    value at all and it reads back as None. Either way LEFT() of it is "" and
+    the comparison in column N is simply false, which is the entire fix.
+    """
+    return value is None or value == ''
+
+
+def with_statutes(references, template=FULL):
+    """A workbook with column F written by hand and the split run over it."""
+    workbook = load_workbook(template)
+    sheet = workbook['CASE DATA']
+    for offset, reference in enumerate(references):
+        sheet.cell(row=4 + offset, column=1).value = '00000  FECR%06d' % offset
+        sheet.cell(row=4 + offset, column=statutes.STATUTE_COLUMN).value = \
+            reference
+    overflow = statutes.write_statute_split(workbook, len(references))
+    return workbook, sheet, overflow
+
+
+# -- the split itself --------------------------------------------------------
+
+def test_one_statute_lands_in_the_first_column():
+    _, sheet, _ = with_statutes(['321.285'])
+    assert split_row(sheet, 4)[0] == '321.285'
+
+
+def test_the_slots_it_did_not_fill_are_blank_and_not_errors():
+    """The whole defect. LEFT() on a #VALUE! is a #VALUE!, and column N is
+    nothing but LEFT() over this range."""
+    _, sheet, _ = with_statutes(['321.285'])
+    rest = split_row(sheet, 4)[1:]
+    assert rest == [''] * (statutes.SLOTS - 1), rest
+
+
+def test_every_slot_is_text_the_sheet_can_take_the_left_of():
+    """Not a formula, not None, on any case row. A formula is what the
+    template left and what LEFT() choked on."""
+    _, sheet, _ = with_statutes(['715A.2(A);', '124.401(5);124.401(5)',
+                                 None, 'n/a', '321.285'])
+    for row in range(4, 9):
+        for value in split_row(sheet, row):
+            assert isinstance(value, str), (row, value)
+
+
+def test_two_statutes_both_get_a_column():
+    _, sheet, _ = with_statutes(['714.2(3);714.2(3)'])
+    assert split_row(sheet, 4)[:2] == ['714.2(3)', '714.2(3)']
+
+
+def test_a_trailing_semicolon_keeps_its_empty_slot():
+    """'715A.2(A);' is what ICOS gave for a real case, and the array formula
+    read it as one code and one empty field. Position is what the sheet reads,
+    so the shape has to survive."""
+    assert statutes.split_codes('715A.2(A);') == ['715A.2(A)', '']
+
+
+def test_a_row_with_no_statute_is_blank_all_the_way_across():
+    _, sheet, _ = with_statutes([None])
+    assert split_row(sheet, 4) == [''] * statutes.SLOTS
+
+
+def test_the_civil_placeholder_is_left_as_it_is():
+    """Column F says "n/a" on a civil case. It is not a statute and nothing on
+    CODE SECTIONS matches it, so it may sit in the first slot unharmed."""
+    _, sheet, _ = with_statutes(['n/a'])
+    assert split_row(sheet, 4)[0] == 'n/a'
+
+
+def test_spaces_around_a_code_are_taken_off():
+    """'AL/ 3.03' is a real ordinance citation and LEFT() compares against
+    unpadded chapter numbers."""
+    _, sheet, _ = with_statutes(['321.285 ; 719.1'])
+    assert split_row(sheet, 4)[:2] == ['321.285', '719.1']
+
+
+# -- the rows the template had already written -------------------------------
+
+def test_the_template_leaves_no_array_formula_behind_it():
+    """Rows past the case list keep the formula and its #VALUE! padding, which
+    reads as a broken workbook to anyone who scrolls right."""
+    plain = load_workbook(FULL)['CASE DATA']
+    assert plain.cell(row=TEMPLATE_DEPTH, column=statutes.FIRST_COLUMN).value \
+        is not None, 'the template splitter did not reach that row'
+
+    _, sheet, _ = with_statutes(['321.285'])
+    for row in (5, 100, TEMPLATE_DEPTH):
+        assert split_row(sheet, row) == [''] * statutes.SLOTS, row
+
+
+def test_the_slot_dragged_one_column_too_far_goes_too():
+    """Row 9 of both templates carries a thirteenth splitter cell in AI. The
+    expungement sheet asks for W9:AH9 and never sees it, so it does nothing but
+    print #VALUE! on a case row for the life of the workbook."""
+    stray = statutes.LAST_COLUMN + 1
+    plain = load_workbook(FULL)['CASE DATA']
+    assert statutes._is_splitter(plain.cell(row=9, column=stray).value), \
+        'the stray slot is not there, so nothing is being tested'
+
+    _, sheet, _ = with_statutes(['321.285'] * 10)
+    assert sheet.cell(row=9, column=stray).value == ''
+
+
+def test_a_column_out_there_that_is_not_the_splitter_is_left_alone():
+    """Only the array formula. Anything else off the right hand edge is
+    somebody's working note and none of Napier's business."""
+    workbook = load_workbook(FULL)
+    sheet = workbook['CASE DATA']
+    sheet.cell(row=9, column=statutes.LAST_COLUMN + 4).value = 'ari was here'
+    sheet.cell(row=4, column=1).value = '00000  FECR000000'
+    statutes.write_statute_split(workbook, 1)
+    assert sheet.cell(row=9, column=statutes.LAST_COLUMN + 4).value == \
+        'ari was here'
+
+
+def test_a_case_list_past_the_template_splitter_is_still_split():
+    """Both templates dragged the array formula to row 300, so case 298 had no
+    split at all and the expungement sheet had nothing to screen."""
+    count = TEMPLATE_DEPTH + 20
+    _, sheet, _ = with_statutes(['719.1'] * count)
+    last = 3 + count
+    assert sheet.cell(row=last, column=1).value, 'no case on that row'
+    assert split_row(sheet, last)[0] == '719.1'
+
+
+def test_the_lite_template_is_split_too():
+    """Lite drops the SOL and bankruptcy sheets but keeps the expungement one,
+    and it carries the same array formula."""
+    _, sheet, _ = with_statutes(['715A.2'], template=LITE)
+    assert split_row(sheet, 4)[0] == '715A.2'
+    assert split_row(sheet, 4)[1:] == [''] * (statutes.SLOTS - 1)
+
+
+def test_an_empty_case_list_still_comes_out_clean():
+    """No cases means no answers, but it may not mean a sheet of #VALUE!."""
+    workbook = load_workbook(FULL)
+    statutes.write_statute_split(workbook, 0)
+    sheet = workbook['CASE DATA']
+    for row in (4, TEMPLATE_DEPTH):
+        assert split_row(sheet, row) == [''] * statutes.SLOTS, row
+
+
+# -- more statutes than there are columns ------------------------------------
+
+def test_a_case_with_more_statutes_than_slots_is_reported():
+    """Twelve slots against a worst case of two across 210 captured cases, so
+    this is a backstop. It still may not be silent."""
+    codes = ['719.%d' % n for n in range(statutes.SLOTS + 3)]
+    _, sheet, overflow = with_statutes([';'.join(codes)])
+    assert list(overflow) == [4], overflow
+    assert overflow[4] == codes[statutes.SLOTS:]
+    assert split_row(sheet, 4) == codes[:statutes.SLOTS]
+
+
+def test_a_case_that_fits_is_reported_as_nothing():
+    _, _, overflow = with_statutes(['321.285', '714.2(3);714.2(3)'])
+    assert overflow == {}
+
+
+# -- through the real build --------------------------------------------------
+
+def test_a_built_workbook_has_no_errors_waiting_in_the_split():
+    """The whole point, through the path a clinic actually takes."""
+    path, _, _ = tasks.build_workbook(
+        synthetic_cases(3, '715A.2'), 'TEST CLIENT', '01/01/1980', False)
+    try:
+        sheet = load_workbook(path)['CASE DATA']
+        assert sheet['F4'].value == '715A.2', \
+            'the statute never reached column F, so nothing is proved'
+        for row in range(4, 7):
+            values = split_row(sheet, row)
+            assert values[0] == '715A.2', (row, values)
+            assert all(is_empty(value) for value in values[1:]), (row, values)
+        # And nothing anywhere in the range is still a formula, which is what
+        # the padding came out of.
+        for row in range(4, TEMPLATE_DEPTH + 1):
+            for value in split_row(sheet, row):
+                assert not (isinstance(value, str) and value.startswith('=')), \
+                    (row, value)
+    finally:
+        os.remove(path)
+
+
+def test_the_overflow_note_reaches_the_staffer():
+    """Column V is the only place the workbook talks to whoever opens it."""
+    charge = ';'.join('719.%d' % n for n in range(statutes.SLOTS + 2))
+    path, _, _ = tasks.build_workbook(
+        synthetic_cases(1, charge), 'TEST CLIENT', '01/01/1980', False)
+    try:
+        sheet = load_workbook(path)['CASE DATA']
+        note = sheet['V4'].value or ''
+        assert 'by hand' in note, note
+        assert '719.13' in note, note
+    finally:
+        os.remove(path)


### PR DESCRIPTION
## What was wrong

CASE DATA columns W to AH are twelve unheadered columns off the right hand edge that take column F apart, one statute per column, so the expungement sheet can test the codes one at a time. The template did the split with a CSE array formula, and that formula pads every slot it does not fill with `#VALUE!`. A case with one statute leaves eleven of them behind.

Two columns of the expungement sheet read that range and only one survives it:

| | formula | result |
|---|---|---|
| M | `SUM(COUNTIF('CASE DATA'!W9:AH9,'CODE SECTIONS'!$V$2:$V$218&"*"))` | COUNTIF steps over errors, so M answers |
| N | `OR(LEFT('CASE DATA'!W9:AH9,3)="719", ...)` | LEFT does not, so N is `#VALUE!` |

N is the second screen: chapters 717C, 719, 720, 724, 726, 728 and 901A, the offences 901C.2 will not seal. It is gated on M being `"YES"` and Excel stops at the first false test, so N is only ever evaluated on a case that cleared the first screen.

So the 910.7 half of the sheet failed on exactly the rows it exists to answer, and nowhere else.

## Measured

Built from the 210 captured cases and computed by LibreOffice. The 17 rows where M says `YES` are **precisely** the 17 rows where N says `#VALUE!`. No exceptions in either direction. All five columns downstream of N go with it: POSSIBLE PENDING CHARGES, DISCHARGEABLE DEBT, TIME BARRED DEBT, TOTAL DEBT, TIME ELAPSED, errors on all 17.

The offences on those 17 rows: forgery (715A.2, 715A.2(A), 715A.2(B)), third degree theft (714.2(3)), drug possession (124.401(5), 124.414), fugitive from justice (820.2), assault (708.2(6)), harassment (BO/40.02), failure to pay parking (FD/934), curfew (AL/ 3.03). The reason somebody is at the clinic. The 193 cases the sheet had nothing to say about printed cleanly.

This is pre-existing and has nothing to do with #90: all 17 sheet rows sit inside the template's original 200 row grid.

## The fix

Napier does the split itself and writes plain text, with an empty string where it has nothing to put. COUNTIF cannot tell an empty cell from an error, so M keeps every answer it already gave. LEFT can, so N starts answering.

Same corpus after: all 17 read `eligible` and all five downstream columns compute. Across the whole workbook, sheet by sheet and cell by cell, **every cell that changed had been `#VALUE!`** and nothing else moved. Same again cut to 40 cases. Column M differs on zero rows.

This is a mechanical resplit of a string Napier wrote two columns earlier. It decides nothing and reads nothing back. The tests that run are the sheet author's own, which is the same boundary that justified #90.

## Two things that came out with it

Both templates dragged the array formula down to row 300, so case 298 onwards had no split at all and the expungement sheet had nothing to screen.

Row 9 of both templates carries a thirteenth slot in AI, one column past anything the sheet asks for, printing `#VALUE!` on a real case row for the life of the workbook. Only a cell actually holding the splitter is cleared, so a working note parked out there stays where it is.

A 210 case workbook now comes out with no error value in it anywhere.

## Verification

- Suite 788 to 806, 18 new tests in `tests/test_expungement_codes.py`
- Rollback proof: with the `write_statute_split` call removed, `test_a_built_workbook_has_no_errors_waiting_in_the_split` fails with `AssertionError` showing the `ArrayFormula` objects still in W..AH, and `test_the_overflow_note_reaches_the_staffer` fails on column V. Both genuine assertion failures, not import or attribute errors.
- Overflow backstop: twelve slots against a worst case of two statutes on one case across all 210. More than twelve is reported in column V rather than silently dropped.
- Fixtures synthetic, no case numbers, names or dates of birth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t