### PR TITLE
Stop dropping the array-formula columns off every row the grid adds

### DIFF
--- a/grid.py
+++ b/grid.py
@@ -36,6 +36,7 @@ import re
 from copy import copy
 
 from openpyxl.formula.translate import Translator
+from openpyxl.worksheet.formula import ArrayFormula
 
 # The sheets that hold the case list itself, the clinic header and the static
 # statute lookup. None of them is a per-case analysis of CASE DATA.
@@ -61,9 +62,48 @@ CASE_RANGE = re.compile(
     r"('CASE DATA'!)(\$?[A-Z]{1,3}\$)(\d+):(\$?[A-Z]{1,3}\$)(\d+)")
 
 
+# A cell entered with ctrl-shift-enter is not a string. openpyxl hands it back
+# as an ArrayFormula object carrying the text and the range it was entered over,
+# and a formula read as a string is silently not one of these. The expungement
+# sheet keeps three of its columns this way, including the one that asks whether
+# there is a subsequent conviction, so treating them as blank drops those
+# columns off every row this module adds and leaves their ranges unwidened on
+# the rows that were already there.
+ARRAY_REF = re.compile(r'^([A-Z]{1,3})(\d+)(?::([A-Z]{1,3})(\d+))?$')
+
+
 def _formula(cell):
     value = cell.value
+    if isinstance(value, ArrayFormula):
+        return value.text
     return value if isinstance(value, str) and value.startswith('=') else None
+
+
+def _shift_ref(ref, row_delta):
+    """The range a copied array formula is entered over, moved down with it."""
+    match = ARRAY_REF.match(str(ref or ''))
+    if not match:
+        return ref
+    start_col, start_row, end_col, end_row = match.groups()
+    moved = '%s%d' % (start_col, int(start_row) + row_delta)
+    if end_col:
+        moved += ':%s%d' % (end_col, int(end_row) + row_delta)
+    return moved
+
+
+def _write(cell, formula, source=None, row_delta=0):
+    """Put a formula back the way it was entered.
+
+    An array formula written back as a plain string loses its ctrl-shift-enter
+    marking, and the ones here are all SUM(COUNTIF(range, range)) over a range,
+    which without that marking stops summing and answers about one cell.
+    """
+    original = (source or cell).value
+    if isinstance(original, ArrayFormula):
+        cell.value = ArrayFormula(
+            ref=_shift_ref(original.ref, row_delta), text=formula)
+    else:
+        cell.value = formula
 
 
 def _case_rows(formula):
@@ -165,9 +205,11 @@ def _extend_sheet(sheet, last_case_row):
     for step in range(1, added + 1):
         for cell in template:
             target = sheet.cell(row=deepest + step, column=cell.column)
-            target.value = Translator(
-                _formula(cell), origin=cell.coordinate).translate_formula(
-                    row_delta=step, col_delta=0)
+            _write(target,
+                   Translator(_formula(cell),
+                              origin=cell.coordinate).translate_formula(
+                                  row_delta=step, col_delta=0),
+                   source=cell, row_delta=step)
             # Without this the new rows lose the currency and date formats the
             # filled-down ones carry, and a dollar figure printed as a bare
             # number reads as a different kind of number.
@@ -214,7 +256,7 @@ def extend_formula_grid(workbook, case_count):
                     widened = _widen_local_ranges(
                         widened, first_case_row, deepest)
                 if widened != formula:
-                    cell.value = widened
+                    _write(cell, widened)
                     touched = touched or 1
         if touched:
             changed[sheet.title] = added

--- a/tests/test_formula_grid.py
+++ b/tests/test_formula_grid.py
@@ -29,6 +29,7 @@ import sys
 from decimal import Decimal
 
 from openpyxl import load_workbook
+from openpyxl.worksheet.formula import ArrayFormula
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -43,6 +44,12 @@ LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
 # The shallowest per-row grid in either template, so a list longer than this
 # has cases the SOL sheet cannot see.
 SOL_LAST_ROW = 150
+
+# Where the expungement sheet's own per-row formulas stop, and the columns it
+# keeps as ctrl-shift-enter array formulas rather than plain ones.
+EXPUNGEMENT_LAST_ROW = 200
+ARRAY_COLUMNS = {'CRS 3.5.5.xlsx': ('F', 'M', 'N'),
+                 'CRS Lite 3.5.5.xlsx': ('F', 'L', 'M')}
 
 CASE_REF = re.compile(r"'CASE DATA'!(\$?)[A-Z]{1,3}(\$?)(\d+)")
 
@@ -237,6 +244,106 @@ def test_the_lite_template_grows_too():
 def test_it_reports_which_sheets_it_had_to_touch():
     _, grown = extended(SOL_LAST_ROW + 20)
     assert 'SOL' in grown and grown['SOL'] > 0, grown
+
+
+# -- the columns that were entered with ctrl-shift-enter ---------------------
+
+def array_columns(template=FULL):
+    return ARRAY_COLUMNS[os.path.basename(template)]
+
+
+def test_an_array_formula_column_reaches_the_new_rows_too():
+    """openpyxl hands a ctrl-shift-enter cell back as an object rather than a
+    string, so a formula read as a string is silently not one of these. Three
+    columns of the expungement sheet are that kind, and one of them is whether
+    there is a subsequent conviction, which is what decides a juvenile record
+    under 232.150. Dropping them leaves a row that is present and blank, which
+    reads as nothing to report."""
+    count = EXPUNGEMENT_LAST_ROW + 20
+    workbook, grown = extended(count)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    assert grown.get('EXPUNGEMENT & 910.7'), 'the sheet did not grow'
+    for column in array_columns():
+        source = sheet['%s%d' % (column, EXPUNGEMENT_LAST_ROW)]
+        assert isinstance(source.value, ArrayFormula), \
+            '%s is no longer an array formula, so nothing is being tested' % column
+        for row in (EXPUNGEMENT_LAST_ROW + 1, EXPUNGEMENT_LAST_ROW + 10):
+            assert sheet['%s%d' % (column, row)].value is not None, \
+                '%s%d is blank' % (column, row)
+
+
+def test_a_copied_array_formula_is_still_an_array_formula():
+    """Written back as a plain string it loses the marking, and every one of
+    these is a SUM(COUNTIF(range, range)) that stops summing without it and
+    answers about a single cell instead."""
+    workbook, _ = extended(EXPUNGEMENT_LAST_ROW + 20)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    for column in array_columns():
+        cell = sheet['%s%d' % (column, EXPUNGEMENT_LAST_ROW + 5)]
+        assert isinstance(cell.value, ArrayFormula), (column, cell.value)
+
+
+def test_a_copied_array_formula_is_entered_over_its_own_cell():
+    """The ref travels with the formula. Left pointing at the row it came from,
+    the copy is entered over a cell it is not in."""
+    workbook, _ = extended(EXPUNGEMENT_LAST_ROW + 20)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    for column in array_columns():
+        for row in (EXPUNGEMENT_LAST_ROW + 1, EXPUNGEMENT_LAST_ROW + 12):
+            cell = sheet['%s%d' % (column, row)]
+            assert isinstance(cell.value, ArrayFormula), (column, row,
+                                                          cell.value)
+            assert cell.value.ref == '%s%d' % (column, row), \
+                (column, row, cell.value.ref)
+
+
+def test_a_copied_array_formula_reads_its_own_case():
+    """Filling down has to move the case reference with the row, or every new
+    row answers about the last case that fitted."""
+    count = EXPUNGEMENT_LAST_ROW + 20
+    workbook, _ = extended(count)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    row = EXPUNGEMENT_LAST_ROW + 10
+    cell = sheet['M%d' % row]
+    assert isinstance(cell.value, ArrayFormula), cell.value
+    assert "'CASE DATA'!G%d" % (row + 1) in cell.value.text, cell.value.text
+
+
+def test_an_array_formula_counting_every_case_is_widened_too():
+    """SUBSEQUENT CONVICTION counts convictions over 'CASE DATA'!$G$4:$G$200.
+    On a longer list that answers "no subsequent conviction" from a partial
+    reading of the case list, which is the direction that says a juvenile
+    record is clear to expunge when it is not."""
+    count = 260
+    workbook, _ = extended(count)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    last_case_row = 3 + count
+    for row in (3, EXPUNGEMENT_LAST_ROW, EXPUNGEMENT_LAST_ROW + 20):
+        cell = sheet['F%d' % row]
+        assert isinstance(cell.value, ArrayFormula), (row, cell.value)
+        end = int(re.search(r"\$G\$4:\$G\$(\d+)", cell.value.text).group(1))
+        assert end >= last_case_row, 'row %d counts only to %d' % (row, end)
+
+
+def test_the_lite_template_keeps_its_array_formulas_too():
+    workbook, _ = extended(EXPUNGEMENT_LAST_ROW + 20, template=LITE)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    for column in array_columns(LITE):
+        cell = sheet['%s%d' % (column, EXPUNGEMENT_LAST_ROW + 5)]
+        assert isinstance(cell.value, ArrayFormula), (column, cell.value)
+
+
+def test_a_short_case_list_leaves_the_array_formulas_alone():
+    plain = load_workbook(FULL)['EXPUNGEMENT & 910.7']
+    workbook, _ = extended(40)
+    sheet = workbook['EXPUNGEMENT & 910.7']
+    for column in array_columns():
+        for row in (3, 100, EXPUNGEMENT_LAST_ROW):
+            was = plain['%s%d' % (column, row)].value
+            now = sheet['%s%d' % (column, row)].value
+            assert now.text == was.text, (column, row)
+            assert now.ref == was.ref, (column, row)
+        assert sheet['%s%d' % (column, EXPUNGEMENT_LAST_ROW + 1)].value is None
 
 
 # -- through the real build ---------------------------------------------------


### PR DESCRIPTION
`grid.py` decided what was a formula with `isinstance(value, str) and value.startswith('=')`. A cell entered with ctrl-shift-enter is not a string: openpyxl returns an `ArrayFormula` object carrying `.text` and the range it was entered over. So the module read every one of those as blank.

The expungement sheet keeps three columns that way. On the full template they are F, M and N; on Lite, F, L and M.

**Rows past the template grid lose those columns.** Starting at 198 cases, every row the extension adds has a case number and three empty analysis cells. A blank answer reads as nothing to report, not as a question nobody asked.

**Column F never got widened.** `SUBSEQUENT CONVICTION?` counts over `'CASE DATA'!$G$4:$G$200`. Because it was unreadable, `_widen_case_ranges` skipped it, so on a 210 case workbook *every* row on the sheet, including the rows that were always in the grid, answered from only the first 197 cases. That column is the 232.150 test for whether a later conviction blocks expunging a juvenile record. A conviction it cannot see makes it answer `NO`, which reads as clear to expunge.

A copy also has to go back as an array formula. All three are `SUM(COUNTIF(range, range))`, which without the marking stops summing and answers about one cell, and the `ref` has to move down with the row, which `Translator` does not touch.

### Checked

Against the 210 captured cases, computed by LibreOffice:

- column F counts `G4:G213` on rows 3, 100, 200, 201 and 212
- rows 201 to 212 carry F, M and N
- column M on the added rows is `n/a` on 11 and `YES` on 1, the same shape as the in-grid rows (`n/a` on 181, `YES` on 17)
- a 40 case control workbook has no computed cell that differs

Suite 788 to 795. Reverting `_formula` to the string-only test fails six of the seven new tests on their own assertions; the seventh is the small-workbook control and passes either way, which is the point of it.

Independent of #91 and branched off the same commit, so the two do not conflict. The single `#VALUE!` still visible in the proof run is the one #91 fixes.