### PR TITLE
Stop counting civil judgments as court debt the client paid

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -377,7 +377,21 @@ PAYMENT_HEADERS = [
     ("HOW PAID", 11),
 ]
 
-FIRST_ACTION_ROW = 10
+# The block above the ranked list, one line per row, named rather than counted.
+# Adding a line to it used to mean finding every place that had worked out the
+# row numbers by hand, and the row after the last of these is the header.
+SUMMARY_ROWS = {
+    'clinic': 2,
+    'cases': 3,
+    'owed': 4,
+    'payments': 5,
+    'hold': 6,
+    'judgments': 7,
+    'missing': 8,
+    'caveat': 9,
+}
+
+FIRST_ACTION_ROW = max(SUMMARY_ROWS.values()) + 2
 
 # The missing-case line is the one thing on this sheet that has to be read
 # rather than skimmed, so it gets the colour the caveat gets.
@@ -428,6 +442,30 @@ def client_payments(cases, as_of):
     }
 
 
+def client_judgments(cases):
+    """The civil judgments across every case, which are not court debt.
+
+    They are kept off the payment history and out of the balance on purpose,
+    and they still have to be said. A client being garnished on a judgment has
+    less money for court debt than the same client without one, which is the
+    whole of an ability-to-pay argument, and the number is usually an order of
+    magnitude above anything else on the page.
+    """
+    found = []
+    for case in cases:
+        for judgment in crs.judgments(case):
+            found.append(dict(judgment, case=case['id']))
+    if not found:
+        return None
+    return {
+        'count': len(found),
+        'cases': len({judgment['case'] for judgment in found}),
+        'total': sum((judgment['amount'] for judgment in found), Decimal(0)),
+        'satisfied': sum((judgment['satisfied'] for judgment in found),
+                         Decimal(0)),
+    }
+
+
 def build_action_sheet(workbook, cases, written, as_of, def_name, failed=()):
     """Add ACTION LIST to a workbook Napier has finished writing.
 
@@ -448,28 +486,31 @@ def build_action_sheet(workbook, cases, written, as_of, def_name, failed=()):
     worksheet['A1'].font = TITLE_FONT
     worksheet['D1'] = def_name
 
-    worksheet['A2'] = 'Clinic date'
-    worksheet['B2'] = as_of
-    worksheet['B2'].number_format = 'MM/DD/YYYY'
+    def line(name, label):
+        row = SUMMARY_ROWS[name]
+        worksheet.cell(row, 1, label)
+        return 'B%d' % row
 
-    worksheet['A3'] = 'Cases read'
-    worksheet['B3'] = written
+    worksheet[line('clinic', 'Clinic date')] = as_of
+    worksheet['B%d' % SUMMARY_ROWS['clinic']].number_format = 'MM/DD/YYYY'
 
-    worksheet['A4'] = 'Total owed'
+    worksheet[line('cases', 'Cases read')] = written
+
+    line('owed', 'Total owed')
     total_owed = sum(
         (_sum(row_facts(workbook['CASE DATA'], row), FEE_COLUMNS)
          for row in range(crs.FIRST_CASE_ROW, crs.FIRST_CASE_ROW + written)),
         Decimal(0))
-    _money_cell(worksheet, 4, 2, total_owed)
+    _money_cell(worksheet, SUMMARY_ROWS['owed'], 2, total_owed)
 
-    worksheet['A5'] = 'Payments on record'
+    payments_cell = line('payments', 'Payments on record')
     if history is None:
         # Not the same as nothing paid, and the difference decides whether an
         # ability-to-pay argument leans on a payment record or has to be made
         # without one.
-        worksheet['B5'] = "none in the ICOS itemization"
+        worksheet[payments_cell] = "none in the ICOS itemization"
     else:
-        worksheet['B5'] = (
+        worksheet[payments_cell] = (
             "%s across %d payment%s on %d case%s, %s to %s. Last 12 months: "
             "%s, about %s a month."
             % (_dollars(history['total']), history['count'],
@@ -480,26 +521,43 @@ def build_action_sheet(workbook, cases, written, as_of, def_name, failed=()):
                _dollars(history['recent']),
                _dollars(history['recent_monthly'])))
 
-    worksheet['A6'] = 'Registration hold'
+    hold_cell = line('hold', 'Registration hold')
     held, held_owed = registration_hold(workbook['CASE DATA'], written)
     if held:
-        worksheet['B6'] = (
+        worksheet[hold_cell] = (
             "%d convicted case%s carrying %s. The county treasurer can refuse "
             "to renew a registration over any of it (Iowa Code 321.40(6), "
             "602.8107(7))."
             % (held, "" if held == 1 else "s", _dollars(held_owed)))
     else:
-        worksheet['B6'] = "none"
+        worksheet[hold_cell] = "none"
+
+    # Not court debt, and kept out of every figure above on purpose. It is here
+    # because a judgment is the largest number on the page and the one most
+    # likely to be what is actually taking the client's money.
+    judgment_cell = line('judgments', 'Civil judgments')
+    judged = client_judgments(cases)
+    if judged is None:
+        worksheet[judgment_cell] = "none on these cases"
+    else:
+        worksheet[judgment_cell] = (
+            "%d judgment%s on %d case%s, %s, %s of it shown satisfied. Not "
+            "court debt, so none of it is in the figures above. A judgment "
+            "being collected on is money the client does not have for court "
+            "debt."
+            % (judged['count'], "" if judged['count'] == 1 else "s",
+               judged['cases'], "" if judged['cases'] == 1 else "s",
+               _dollars(judged['total']), _dollars(judged['satisfied'])))
 
     # A workbook gets emailed to a colleague, saved to a shared drive and opened
     # three weeks later by somebody who never watched it being built. Up to now
     # the only place that said a run came back short was the finish page and the
     # progress log, both of which are gone within two hours, so the file itself
     # read as a complete criminal record when it was two cases shy of one.
-    worksheet['A7'] = 'Not in this file'
+    missing_cell = line('missing', 'Not in this file')
     failed = list(failed)
     if failed:
-        worksheet['B7'] = (
+        worksheet[missing_cell] = (
             "%d case%s Iowa Courts would not give up: %s. %s on no sheet in "
             "this workbook. Look %s up on Iowa Courts before relying on this "
             "being the whole record."
@@ -507,12 +565,13 @@ def build_action_sheet(workbook, cases, written, as_of, def_name, failed=()):
                ", ".join(failed),
                "It is" if len(failed) == 1 else "They are",
                "it" if len(failed) == 1 else "them"))
-        worksheet['B7'].font = MISSING_FONT
+        worksheet[missing_cell].font = MISSING_FONT
     else:
-        worksheet['B7'] = "none. Every case the search turned up is here."
+        worksheet[missing_cell] = \
+            "none. Every case the search turned up is here."
 
-    worksheet['A8'] = CAVEAT
-    worksheet['A8'].font = CAVEAT_FONT
+    caveat = worksheet.cell(SUMMARY_ROWS['caveat'], 1, CAVEAT)
+    caveat.font = CAVEAT_FONT
 
     _headers(worksheet, FIRST_ACTION_ROW - 1, ACTION_HEADERS)
     row = FIRST_ACTION_ROW

--- a/crs.py
+++ b/crs.py
@@ -253,6 +253,24 @@ def _money(text):
         return None
 
 
+# The line a civil money judgment sits on in the same itemization table as the
+# court fees. It is what one private party owes another, not a fee owed to the
+# clerk, and it is settled by whatever the parties do rather than by the client
+# paying the court. ICOS records it satisfied with a journal entry, so it looks
+# from the table exactly like a fee that has been paid.
+#
+# The match has to be the whole line and not the word. CONFESSION OF JUDGMENT -
+# $5000 OR MORE A-R is the fee for filing one, and DEFERRED JUDGMENT CIVIL
+# PENALTY is a fine that get_finance_column already sends to column R. Both are
+# court debt and both carry the word.
+JUDGMENT_LINE = 'JUDGMENTS'
+
+
+def is_judgment(detail):
+    """Whether an itemization line is the judgment itself rather than a fee."""
+    return (detail or '').strip().upper() == JUDGMENT_LINE
+
+
 def payments(case):
     """Every payment ICOS records on a case, oldest first.
 
@@ -265,6 +283,14 @@ def payments(case):
     from the fee columns: ICOS lists them and does not count them in the case
     total, so counting a payment against one as money paid on the case would
     overstate what the client has actually put in.
+
+    A satisfied civil judgment is excluded for the same reason and at a very
+    different scale. Across the 210 captured cases ten judgment lines accounted
+    for $4,024,095.44 of the $4,045,517.55 this function reported, which is
+    99.5% of it, against $16,602.57 of actual court debt. One of them was a
+    single judgment listed six times, once per debtor. What is left after
+    taking them out is $21,422.11 across 488 payments, which is a person paying
+    the clerk.
     """
     history = []
     last_detail = None
@@ -272,7 +298,8 @@ def payments(case):
         detail = (row.get('detail') or '').strip()
         if detail:
             last_detail = detail
-        if is_excluded_fee(detail or last_detail or ''):
+        line = detail or last_detail or ''
+        if is_excluded_fee(line) or is_judgment(line):
             continue
         paid = _money(row.get('paid'))
         when = parse_us_date(row.get('paidDate'))
@@ -287,6 +314,42 @@ def payments(case):
         })
     history.sort(key=lambda payment: payment['date'])
     return history
+
+
+def judgments(case):
+    """The civil judgments on a case, so taking them out of the payment history
+    does not throw them away.
+
+    A judgment against the client is the largest number anywhere near them and
+    it decides whether they are being garnished, which is the first thing an
+    ability-to-pay argument runs into. It is not court debt and it does not
+    belong in the court debt figures, but it does belong on the page.
+
+    ICOS lists the same judgment once per debtor, so a judgment against six
+    people is six rows with six receipt numbers and one amount between them.
+    The captured corpus has exactly that: one judgment a little over $650,000
+    listed six times on one case, all on the same day. Rows agreeing on both
+    the amount and the date are treated as one judgment, because adding them up
+    is how that judgment came out six times its own size.
+    """
+    found = []
+    for row in case.get('financials') or []:
+        if not is_judgment(row.get('detail')):
+            continue
+        amount = _money(row.get('amount'))
+        if amount is None or amount <= 0:
+            continue
+        when = parse_us_date(row.get('paidDate'))
+        if any(seen['amount'] == amount and seen['date'] == when
+               for seen in found):
+            continue
+        found.append({
+            'amount': amount,
+            'satisfied': _money(row.get('paid')) or Decimal(0),
+            'date': when,
+            'receipt': row.get('receipt'),
+        })
+    return found
 
 
 def payment_history(case, as_of):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -329,8 +329,9 @@ class TestCollect:
 
 # -- the sheets themselves ---------------------------------------------------
 
-def payment_row(detail, paid, when, receipt='000001', tender='CSH'):
-    return {'detail': detail, 'amount': '100.00', 'paid': paid,
+def payment_row(detail, paid, when, receipt='000001', tender='CSH',
+                amount='100.00'):
+    return {'detail': detail, 'amount': amount, 'paid': paid,
             'paidDate': when, 'receipt': receipt, 'tender': tender}
 
 
@@ -383,6 +384,85 @@ class TestClientPayments:
         assert history['payments'][0]['case'] == '00000  FECR000007'
 
 
+def judgment_row(amount, paid='', when='01/01/1900', receipt='000001'):
+    return payment_row('JUDGMENTS', paid, when, receipt=receipt,
+                       tender='JRN', amount=amount)
+
+
+class TestClientJudgments:
+    def test_judgments_are_pooled_across_every_case(self):
+        judged = actions.client_judgments([
+            synthetic_case('00000  FECR000001', [judgment_row('5000.00')]),
+            synthetic_case('00000  FECR000002', [judgment_row('2500.00')]),
+        ])
+        assert judged['count'] == 2
+        assert judged['cases'] == 2
+        assert judged['total'] == Decimal('7500.00')
+
+    def test_no_judgment_anywhere_is_none(self):
+        assert actions.client_judgments([synthetic_case()]) is None
+
+    def test_what_has_been_satisfied_is_counted_separately(self):
+        judged = actions.client_judgments([
+            synthetic_case(rows=[judgment_row('5000.00', paid='1200.00')])])
+        assert judged['total'] == Decimal('5000.00')
+        assert judged['satisfied'] == Decimal('1200.00')
+
+    def test_a_judgment_listed_once_per_debtor_is_counted_once(self):
+        judged = actions.client_judgments([
+            synthetic_case(rows=[judgment_row('5000.00', receipt='8480%d' % n)
+                                 for n in range(1, 7)])])
+        assert judged['count'] == 1
+        assert judged['total'] == Decimal('5000.00')
+
+
+class TestJudgmentsOnTheSheet:
+    def test_a_client_with_none_is_told_which_kind_of_nothing(self):
+        workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
+        cell = 'B%d' % actions.SUMMARY_ROWS['judgments']
+        assert workbook['ACTION LIST'][cell].value == 'none on these cases'
+
+    def test_the_judgment_line_names_the_money_and_says_it_is_not_court_debt(
+            self):
+        workbook = written_workbook(
+            FULL, [{'G': 'DISM', 'R': 100}],
+            [synthetic_case(rows=[judgment_row('5000.00', paid='1200.00')])])
+        line = workbook['ACTION LIST'][
+            'B%d' % actions.SUMMARY_ROWS['judgments']].value
+        assert '1 judgment on 1 case' in line
+        assert '$5,000.00' in line
+        assert '$1,200.00' in line
+        assert 'Not court debt' in line
+
+    def test_the_judgment_stays_out_of_the_payment_line(self):
+        # This is the defect. A $5,000 judgment settled between two private
+        # parties was reported as the client's record of paying the clerk,
+        # next to $25.00 of actual court debt.
+        workbook = written_workbook(
+            FULL, [{'G': 'DISM', 'R': 100}],
+            [synthetic_case(rows=[
+                judgment_row('5000.00', paid='5000.00'),
+                payment_row('FINE', '25.00', '01/02/1900')])])
+        line = workbook['ACTION LIST']['B%d' % actions.SUMMARY_ROWS[
+            'payments']].value
+        assert '$25.00 across 1 payment on 1 case' in line
+        assert '5,000' not in line
+
+    def test_it_stays_out_of_what_the_client_is_told_they_can_pay(self):
+        # ability_to_pay hands a monthly figure to the abilitytopay.org
+        # calculator. On the captured corpus a garnished civil judgment took a
+        # true $0.00 a month to $269.89, in the direction that says the client
+        # can afford it.
+        rows = [judgment_row('5000.00', paid='5000.00', when='01/15/2026')]
+        history = actions.client_payments([synthetic_case(rows=rows)], CLINIC)
+        assert history is None
+        assert actions.ability_to_pay(Decimal(100), history)['monthly'] is None
+
+        both = actions.client_payments([synthetic_case(rows=rows + [
+            payment_row('FINE', '24.00', '01/15/2026')])], CLINIC)
+        assert actions.ability_to_pay(Decimal(100), both)['monthly'] == '$2.00'
+
+
 class TestActionSheet:
     def test_the_action_list_is_the_first_sheet_staff_see(self):
         workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
@@ -397,7 +477,9 @@ class TestActionSheet:
 
     def test_the_caveat_is_on_the_sheet_not_in_a_manual(self):
         workbook = written_workbook(FULL, [{'G': 'DISM', 'R': 100}])
-        assert 'has been read by a lawyer' in workbook['ACTION LIST']['A8'].value
+        caveat = workbook['ACTION LIST'].cell(
+            actions.SUMMARY_ROWS['caveat'], 1).value
+        assert 'has been read by a lawyer' in caveat
 
     def test_the_total_owed_adds_up_every_fee_column(self):
         workbook = written_workbook(

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -103,6 +103,101 @@ class TestPayments:
         assert history == []
 
 
+class TestJudgmentsAreNotPayments:
+    """A civil money judgment sits in the same itemization table as the court
+    fees, and ICOS marks it satisfied with a journal entry, so it read to
+    Napier exactly like a fee somebody had paid off. On the captured corpus
+    that was 99.5% of the payment history: money one private party owed
+    another, reported as the client's record of paying the clerk."""
+
+    def test_the_judgment_line_is_not_money_paid_on_the_case(self):
+        history = crs.payments(_case([
+            _row('JUDGMENTS', '5000.00', '01/01/1900', amount='5000.00'),
+            _row('FINE', '10.00', '02/01/1900'),
+        ]))
+        assert [payment['detail'] for payment in history] == ['FINE']
+
+    def test_a_continuation_of_a_judgment_is_left_out_too(self):
+        history = crs.payments(_case([
+            _row('JUDGMENTS', '2500.00', '01/01/1900', amount='5000.00'),
+            _row('', '2500.00', '02/01/1900', amount='5000.00'),
+        ]))
+        assert history == []
+
+    def test_the_filing_fee_for_one_is_still_a_fee(self):
+        # CONFESSION OF JUDGMENT - $5000 OR MORE A-R is what the clerk charges
+        # to file it. Matching the word rather than the line would have thrown
+        # away real court debt.
+        history = crs.payments(_case([
+            _row('CONFESSION OF JUDGMENT - $5000 OR MORE A-R', '185.00',
+                 '01/01/1900'),
+        ]))
+        assert len(history) == 1
+
+    def test_the_civil_penalty_is_still_a_fine(self):
+        history = crs.payments(_case([
+            _row('DEFERRED JUDGMENT CIVIL PENALTY', '65.00', '01/01/1900'),
+        ]))
+        assert len(history) == 1
+
+    def test_is_judgment_wants_the_whole_line(self):
+        assert crs.is_judgment('JUDGMENTS')
+        assert crs.is_judgment('  judgments  ')
+        assert not crs.is_judgment('CONFESSION OF JUDGMENT - $5000 OR MORE A-R')
+        assert not crs.is_judgment('DEFERRED JUDGMENT CIVIL PENALTY')
+        assert not crs.is_judgment('')
+        assert not crs.is_judgment(None)
+
+
+class TestJudgmentsAreStillReported:
+    """Taking them out of the payment history must not throw them away. A
+    client being garnished on a judgment has less money for court debt, which
+    is the whole of an ability-to-pay argument."""
+
+    def test_it_finds_the_judgment(self):
+        found = crs.judgments(_case([
+            _row('JUDGMENTS', '5000.00', '01/01/1900', amount='5000.00'),
+            _row('FINE', '10.00', '02/01/1900'),
+        ]))
+        assert len(found) == 1
+        assert found[0]['amount'] == Decimal('5000.00')
+        assert found[0]['satisfied'] == Decimal('5000.00')
+        assert found[0]['date'] == date(1900, 1, 1)
+
+    def test_the_amount_is_the_judgment_not_what_was_paid_on_it(self):
+        found = crs.judgments(_case([
+            _row('JUDGMENTS', '100.00', '01/01/1900', amount='5000.00')]))
+        assert found[0]['amount'] == Decimal('5000.00')
+        assert found[0]['satisfied'] == Decimal('100.00')
+
+    def test_one_judgment_against_six_people_is_one_judgment(self):
+        # ICOS lists it once per debtor: six rows, six receipt numbers, one
+        # amount between them. Adding them up is how a real $656,285.88
+        # judgment in the corpus became $3,937,715.28.
+        rows = [_row('JUDGMENTS', '', '01/01/1900', receipt='84800%d' % n,
+                     amount='5000.00')
+                for n in range(1, 7)]
+        found = crs.judgments(_case(rows))
+        assert len(found) == 1
+        assert found[0]['amount'] == Decimal('5000.00')
+
+    def test_two_judgments_on_different_days_are_two_judgments(self):
+        found = crs.judgments(_case([
+            _row('JUDGMENTS', '', '01/01/1900', amount='5000.00'),
+            _row('JUDGMENTS', '', '02/01/1900', amount='5000.00'),
+        ]))
+        assert len(found) == 2
+
+    def test_an_unsatisfied_judgment_still_counts(self):
+        found = crs.judgments(_case([
+            _row('JUDGMENTS', '', '01/01/1900', amount='5000.00')]))
+        assert len(found) == 1
+        assert found[0]['satisfied'] == Decimal(0)
+
+    def test_a_case_with_no_judgment_has_none(self):
+        assert crs.judgments(_case([_row('FINE', '10.00', '01/01/1900')])) == []
+
+
 class TestPaymentHistory:
     def test_no_itemization_is_none_not_zero(self):
         # A case ICOS publishes no itemization for cannot tell us the client

--- a/tests/test_workbook_receipt.py
+++ b/tests/test_workbook_receipt.py
@@ -39,6 +39,12 @@ FRESH = '01/01/2020'
 
 MISSING = ['00000  FECR000001', '00000  SRCR000002']
 
+# Ask the sheet where its own lines are. Hard-coding the rows here meant that
+# adding one line to the header broke nine tests that were not about the header.
+MISSING_LABEL = 'A%d' % actions.SUMMARY_ROWS['missing']
+MISSING_LINE = 'B%d' % actions.SUMMARY_ROWS['missing']
+CAVEAT_LINE = 'A%d' % actions.SUMMARY_ROWS['caveat']
+
 
 def built(failed=(), rows=({'J': 250},)):
     """A real CRS workbook, built knowing what would not come off ICOS."""
@@ -61,18 +67,18 @@ class TestWhatTheLineSays:
         never filled in, and the whole point is a reader who can tell the
         difference without asking whoever ran it."""
         sheet = built()
-        assert sheet['A7'].value == 'Not in this file'
-        assert sheet['B7'].value == "none. Every case the search turned up is here."
+        assert sheet[MISSING_LABEL].value == 'Not in this file'
+        assert sheet[MISSING_LINE].value == "none. Every case the search turned up is here."
 
     def test_a_short_run_names_every_case_it_could_not_get(self):
         sheet = built(failed=MISSING)
-        line = sheet['B7'].value
+        line = sheet[MISSING_LINE].value
         for case_id in MISSING:
             assert case_id in line
         assert line.startswith("2 cases")
 
     def test_one_missing_case_is_not_described_in_the_plural(self):
-        line = built(failed=MISSING[:1])['B7'].value
+        line = built(failed=MISSING[:1])[MISSING_LINE].value
         assert line.startswith("1 case Iowa Courts")
         assert "It is on no sheet" in line
         assert "Look it up" in line
@@ -81,7 +87,7 @@ class TestWhatTheLineSays:
         """Naming a case number without saying it has to be looked up leaves
         the reader to work out whether it matters, and the answer is that it
         always matters."""
-        line = built(failed=MISSING)['B7'].value
+        line = built(failed=MISSING)[MISSING_LINE].value
         assert "on no sheet in this workbook" in line
         assert "Look them up on Iowa Courts" in line
         assert "the whole record" in line
@@ -89,8 +95,8 @@ class TestWhatTheLineSays:
     def test_the_missing_line_is_not_set_in_the_same_type_as_the_rest(self):
         """A reader skimming a summary sheet reads the values, not the labels.
         This one has to stop them."""
-        quiet = built()['B7'].font
-        loud = built(failed=MISSING)['B7'].font
+        quiet = built()[MISSING_LINE].font
+        loud = built(failed=MISSING)[MISSING_LINE].font
         assert loud.bold and not quiet.bold
 
 
@@ -111,7 +117,7 @@ class TestWhereItSits:
         or the sheet writes the header over the caveat and the first action
         over the header."""
         sheet = built(failed=MISSING)
-        assert 'has been read by a lawyer' in sheet['A8'].value
+        assert 'has been read by a lawyer' in sheet[CAVEAT_LINE].value
         header = sheet.cell(actions.FIRST_ACTION_ROW - 1, 1)
         assert header.value == actions.ACTION_HEADERS[0][0]
         assert header.font.bold
@@ -145,8 +151,8 @@ class TestItSurvivesTheBuild:
             sheet = load_workbook(path)['ACTION LIST']
         finally:
             os.unlink(path)
-        assert MISSING[0] in sheet['B7'].value
-        assert MISSING[1] in sheet['B7'].value
+        assert MISSING[0] in sheet[MISSING_LINE].value
+        assert MISSING[1] in sheet[MISSING_LINE].value
 
     def test_the_lite_workbook_gets_it_too(self, tmp_path):
         """Lite is what most clinics actually hand out, and it is the one where
@@ -165,7 +171,7 @@ class TestItSurvivesTheBuild:
             sheet = load_workbook(path)['ACTION LIST']
         finally:
             os.unlink(path)
-        assert MISSING[0] in sheet['B7'].value
+        assert MISSING[0] in sheet[MISSING_LINE].value
 
 
 class TestWhatItMustNotCarry:
@@ -175,6 +181,6 @@ class TestWhatItMustNotCarry:
         account they were pulled with is half a credential and may not."""
         sheet = built(failed=MISSING)
         line = " ".join(str(sheet[cell].value) for cell in
-                        ('B2', 'B3', 'B5', 'B6', 'B7', 'A8'))
+                        ('B2', 'B3', 'B5', 'B6', MISSING_LINE, CAVEAT_LINE))
         for smell in ('ILA', 'drakelegalclinic', 'password', 'user ID'):
             assert smell not in line


### PR DESCRIPTION
Defect #11 from the replay methodology: 210 real ICOS cases captured outside the repo, run through the shipping code.

## What it said

The ACTION LIST reported **$4,045,517.55** paid toward court debt. The real figure is **$21,422.11**.

Civil money judgments sit in the same ICOS itemization table as the court fees, and ICOS marks them satisfied with a journal entry, so `crs.payments()` read one exactly like a fee somebody had paid off. Ten judgment lines accounted for **$4,024,095.44**, or 99.5% of the reported total, against **$16,602.57** of actual court debt on the same workbook.

A judgment is what one private party owes another. It is settled by whatever the parties do, not by the client paying the clerk.

## What reaches a client

`actions.ability_to_pay` hands a court debt balance and a monthly payment figure to the abilitytopay.org calculator. Those are the two numbers a person sitting in a clinic cannot answer from memory, which is why the interview stalls on them.

| | before | after |
|---|---|---|
| payments | 498 | 488 |
| total | $4,045,517.55 | $21,422.11 |
| monthly handed to the calculator | **$269.89** | **$5.83** |

Forty-six times too high, in the direction that says the client can afford to pay. The last twelve months of "payments" were almost entirely one garnished judgment on one civil case.

## Scoping

The match is the whole line, not the word:

- `CONFESSION OF JUDGMENT - $5000 OR MORE A-R` is the clerk's fee for filing one. Court debt.
- `DEFERRED JUDGMENT CIVIL PENALTY` is a fine that `get_finance_column` already routes to FINES. Court debt.

Both carry the word. Matching on the substring would have thrown away real court debt, so `is_judgment` is exact equality on `JUDGMENTS`.

Tender code was the other candidate discriminator and it does not work: JRN appears on a $656k judgment and on real $3 and $10 scheduled-violation satisfactions in the same corpus.

## It is still reported

A judgment against the client is the largest number anywhere near them and it decides whether they are being garnished. A client being garnished has less money for court debt, which is the whole of an ability-to-pay argument. So `crs.judgments()` collects them and the ACTION LIST gets a line saying what they are and saying they are not in the figures above.

ICOS lists one judgment once per debtor, so a judgment against six people is six rows with six receipt numbers and one amount between them. The corpus has exactly that, and adding them up was how one judgment came out six times its own size. Rows agreeing on amount and date are one judgment.

## Header rows are named now

`SUMMARY_ROWS` maps a name to a row and `FIRST_ACTION_ROW` derives from it. Adding one line to the header used to break nine tests that were not about the header.

## Verification

- Suite 795 to 814.
- Rollback proof: putting the exclusion back fails four new tests on genuine assertions; removing the per-debtor dedupe fails two more.
- Replayed the 210 captured cases through the shipping pipeline before and after.

## Left alone deliberately

`REFUNDABLES DUE TO PREPAID EXPENSES` (14 payments, $681.69) is arguably not a payment toward court debt either, but its semantics are less certain. Flagging rather than changing it.

All case numbers and dates in the tests are the synthetic `00000 FECR000000` family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t