### PR TITLE
Write down what Napier will not guess at, and what each guess is worth

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -1,0 +1,92 @@
+# Open questions
+
+Things Napier does deliberately that need someone who knows Iowa practice to
+confirm or overrule. None of these are bugs as far as the code is concerned.
+They are places where the right answer is a legal judgement rather than a
+parsing one, so the code takes the conservative reading and says so.
+
+Numbers here come from replaying 210 real ICOS cases through the shipping
+path. No client data, names or case numbers appear in this repository.
+
+## The SOL sheet does not account for all the debt
+
+On the 210 case workbook the SOL sheet totals $8,720.48 against $16,602.57
+owed. The missing $7,882.09 sits on 17 time-barred rows.
+
+The formulas are the reason. A row past twenty years claims columns J and K in
+"STRANGE-BARRED" and column L in "20 year old Jail / Room & Board", and the
+"NO ARGUMENT" column only fires on rows that are not barred. So on a barred
+case everything from sheriff fees through restitution appears in no column at
+all. What falls out:
+
+| falls outside every SOL column | amount |
+|---|---|
+| sheriff fees | $794.15 |
+| miscellaneous | $340.93 |
+| unknown | $1,915.76 |
+| surcharges | $660.78 |
+| fines | $442.50 |
+| victim restitution | $3,727.97 |
+
+If the sheet is meant to list only what an attorney can argue away, this is
+correct and the total is not supposed to reconcile. If it is meant to sort all
+the debt into barred and not barred, then "NO ARGUMENT" should be the balance
+after the two barred columns rather than zero on a barred row.
+
+Related: SOL column D is $0.00 across all 210 cases, because jail and room and
+board debt reaches column L only on rows whose itemization reconciled fee by
+fee. Offer to look at this is open and unanswered.
+
+## Fees Napier will not classify
+
+Both of these go to column P, UNKNOWN, rather than being guessed at.
+
+`DNU-DELINQUENT REVOLVING FUND OBLIGATION` appears on 43 lines and is most of
+what UNKNOWN carries. `COLLECTION BY CO ATTY (THRESHOLD MET)` and
+`COLLECTION BY CO ATTY` appear on 8 lines between them. The second reads like a
+collection cost, which would put it in column K where the statute of
+limitations sheet can see it, but calling it that is a decision about what the
+county attorney fee is rather than about what the page says.
+
+## Refundables counted as a payment
+
+`REFUNDABLES DUE TO PREPAID EXPENSES` shows up on 14 lines worth $681.69, and
+Napier counts every one of them as money the client paid toward court debt.
+A prepaid expense being refunded is probably not that. It is left alone because
+the wording does not say clearly enough which way it runs, and because ICOS's
+own totals treat it as a payment, so changing it would put Napier's arithmetic
+at odds with the court's.
+
+## ICOS case statuses with no CRS code
+
+Napier reads the case level status only where it overlaps the per count
+adjudication wordings, which is at DISMISSED and nowhere else. These are left
+uncoded, and the case goes onto the sheet with the wording in column V so it is
+visibly uncoded rather than quietly miscoded:
+
+GUILTY PLEA/DEFAULT, VIOLATIONS HANDLED BY CLERK, BY TRIAL TO COURT, OTHER
+JUDGMENT, TRANSFERRED, SMALL CLAIM-DISPOSED BY CLERK, CHANGE OF VENUE, CLOSED.
+
+Whether VIOLATIONS HANDLED BY CLERK is a guilty plea decides what five sheets
+compute, which is why the code will not guess.
+
+## Smaller ones
+
+A case whose counts were adjudicated on different days is reported under the
+last date that carries the winning disposition code, so the code and the date
+on the row agree with each other. On one of the 210 cases that is 9 days
+before the case's actual last adjudication, because the later count was
+disposed under a different code. Pairing the code with its own date and
+reporting the case as finished on its last day cannot both be true, and which
+one the sheets want is a question about the sheets.
+
+Column I, "Under supervison?", is blank on all 210 cases. ICOS does not print
+it anywhere Napier can reach.
+
+The workbook recognises a `TNSF` disposition code that the parser never
+produces. Either ICOS has a wording for it that has not been seen in 210
+cases, or the code is dead.
+
+An Iowa city ordinance conviction that mirrors a chapter 321 offence: does it
+put the licence at risk the way the state charge would? The LICENSE-REGIS
+sheet's answer depends on it.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ summary is therefore what the CRS reports. If the categories still do not
 reconcile with the ICOS total, the row is flagged and column U (the ICOS total)
 is the figure to trust.
 
+Some fee wordings and some ICOS case statuses are deliberately left uncoded
+rather than guessed at, because what they mean is a question about Iowa
+practice. `OPEN_QUESTIONS.md` lists them with what each one is worth across
+210 real cases.
+
 ## What may leave the building
 
 The client's name and date of birth are privileged and never leave the machine


### PR DESCRIPTION
Eleven replay rounds against real ICOS pages have turned up a set of places where Napier takes the conservative reading because the right answer is a question about Iowa practice rather than about parsing. Until now those lived in PR bodies and in scratch notes. This puts them in one file with what each one is worth across 210 real cases.

No code changes. Suite is 832, unchanged.

## The new one

The SOL sheet totals $8,720.48 against $16,602.57 owed on the 210 case workbook. The missing $7,882.09 sits on 17 time-barred rows, and it is the formulas rather than the data: a row past twenty years claims J and K in "STRANGE-BARRED" and L in "20 year old Jail / Room & Board", and "NO ARGUMENT" only fires on rows that are *not* barred. So on a barred case everything from sheriff fees through restitution appears in no column.

| falls outside every SOL column | amount |
|---|---|
| sheriff fees | $794.15 |
| miscellaneous | $340.93 |
| unknown | $1,915.76 |
| surcharges | $660.78 |
| fines | $442.50 |
| victim restitution | $3,727.97 |

If the sheet lists only what can be argued away, this is correct and it is not supposed to reconcile. If it sorts all the debt, "NO ARGUMENT" should be the balance after the two barred columns. One question for Ari, answerable in a reading.

## Already known, now quantified

- `DNU-DELINQUENT REVOLVING FUND OBLIGATION`, 43 lines, most of what column P carries
- `COLLECTION BY CO ATTY (THRESHOLD MET)`, 8 lines, reads like a collection cost, which would put it in K where the SOL sheet can see it
- `REFUNDABLES DUE TO PREPAID EXPENSES`, 14 lines and $681.69 counted as money paid toward court debt
- eight ICOS case statuses with no CRS code, which travel to column V uncoded
- column I blank on all 210, and a `TNSF` code the parser never produces

## Checked this round and cleared

These were chased and came back clean, which is why they are not in the file as defects: the 22 money-carrying cases with no action row (correctly barred as traffic), the case-id format census (the type code is at [7:9] on all 210), a formula-error sweep across all 11 sheets (0 error cells), the LICENSE-REGIS row map (a benign permutation, every case appears exactly once), and the ACTION LIST registration-hold line against the LICENSE-REGIS sheet (28 cases and $13,174.92, matching to the cent).

The disposition date one is worth naming because it looked like a defect and is not. `case_parser` keeps whichever adjudication ICOS printed first with no comparison, which on 3 of 210 cases is up to 773 days early. `crs.py` already overrides it with the last date carrying the winning code, and at the shipping layer 2 of those 3 come out right. The third is 9 days early because the later count carries a different code, which is the documented tradeoff between pairing the code with its own date and reporting the case as finished on its last day. Recorded rather than changed.

No client data, names or case numbers. The fee wordings are ICOS's own vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t