### PR TITLE
Scan every header line for credentials, not the six that were listed

### DIFF
--- a/tests/test_workbook_receipt.py
+++ b/tests/test_workbook_receipt.py
@@ -178,9 +178,26 @@ class TestWhatItMustNotCarry:
     def test_no_credential_reaches_the_file(self):
         """Workbooks get emailed by staff, which puts them outside the ESA
         agreement's reach. Case numbers are public record and may travel. The
-        account they were pulled with is half a credential and may not."""
+        account they were pulled with is half a credential and may not.
+
+        Every line the header writes, taken from the sheet's own row map rather
+        than listed here. The list version covered six of the eight rows, and
+        the two it missed were the two added after it was written, which is how
+        a scan like this stops covering the thing it is for.
+        """
         sheet = built(failed=MISSING)
-        line = " ".join(str(sheet[cell].value) for cell in
-                        ('B2', 'B3', 'B5', 'B6', MISSING_LINE, CAVEAT_LINE))
+        cells = [prefix + str(row) for row in actions.SUMMARY_ROWS.values()
+                 for prefix in ('A', 'B')]
+        assert len(cells) == 2 * len(actions.SUMMARY_ROWS)
+        line = " ".join(str(sheet[cell].value) for cell in cells)
         for smell in ('ILA', 'drakelegalclinic', 'password', 'user ID'):
             assert smell not in line
+
+    def test_the_scan_covers_every_line_the_header_writes(self):
+        """The scan above is only worth its runtime if it reads the whole
+        header. A line added to SUMMARY_ROWS and not written is the other way
+        this goes quiet."""
+        sheet = built(failed=MISSING)
+        for name, row in actions.SUMMARY_ROWS.items():
+            assert sheet.cell(row, 1).value, \
+                '%s (row %d) writes no label' % (name, row)


### PR DESCRIPTION
The credential scan on the ACTION LIST header named its cells by hand. It covered six of the eight lines the header writes, and the two it missed were `Total owed` and `Judgments`. Both were added after the list was written, and the judgments line is the one PR #93 added, so the scan shipped already blind to the newest thing on the sheet.

It reads `actions.SUMMARY_ROWS` now, so a line the header gains is a line the scan gains.

A second test asserts every row in that map writes a label. That catches the other way this goes quiet: a row added to the map and never written would make the scan read an empty cell and pass on it.

## Why this matters

Workbooks get emailed by staff, which puts them outside the reach of the ESA agreement. Case numbers are court public record and may travel. The ESA account they were pulled with is half a credential and may not. The scan is the only thing standing between those two facts, and it had quietly stopped covering the sheet it was written for.

## Proof

Rollback, not just a green run.

With `"none on these cases, pulled by ILA04"` injected at the judgments write site in `actions.py`:

- the derived scan fails by assertion
- the hand-listed version passes

Both files restored afterwards. Full suite 833 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t