### PR TITLE
Stop counting a bond as money the client paid

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -83,6 +83,13 @@ one the sheets want is a question about the sheets.
 Column I, "Under supervison?", is blank on all 210 cases. ICOS does not print
 it anywhere Napier can reach.
 
+Bond principal is kept out of the payment history by matching two whole
+wordings, `APPEARANCE BOND REFUND` and `BONDS - ESCROW`, which are the only two
+seen across 300 cases. A third wording for the same thing would go back to
+being counted as a payment. The match is deliberately not on the word `BOND`,
+because a bond assignment fee is court debt and a forfeited bond is money the
+county keeps.
+
 The workbook recognises a `TNSF` disposition code that the parser never
 produces. Either ICOS has a wording for it that has not been seen in 210
 cases, or the code is dead.

--- a/crs.py
+++ b/crs.py
@@ -271,6 +271,25 @@ def is_judgment(detail):
     return (detail or '').strip().upper() == JUDGMENT_LINE
 
 
+# Bond principal moving through the clerk's account. A defendant, or more often
+# somebody standing behind them, puts up an appearance bond, and the clerk holds
+# it and later gives it back or applies it. Either way the line records the
+# money moving, not the defendant paying down what they owe. Where a bond is
+# applied to the debt, ICOS bills the fees it covered on their own lines and
+# marks those paid, so counting the bond line as well counts the same money
+# twice.
+#
+# Whole lines again, for the reason JUDGMENT_LINE is. A bond assignment fee or a
+# forfeiture is court debt and carries the word, and forfeited bond money is
+# money the county keeps rather than money that comes back.
+BOND_LINES = ('APPEARANCE BOND REFUND', 'BONDS - ESCROW')
+
+
+def is_bond_principal(detail):
+    """Whether an itemization line is bond money rather than a payment."""
+    return (detail or '').strip().upper() in BOND_LINES
+
+
 def payments(case):
     """Every payment ICOS records on a case, oldest first.
 
@@ -291,6 +310,15 @@ def payments(case):
     single judgment listed six times, once per debtor. What is left after
     taking them out is $21,422.11 across 488 payments, which is a person paying
     the clerk.
+
+    Bond principal is excluded for the third time on the same grounds. It is the
+    one that reaches criminal cases, which is what most of this workbook is for,
+    and it is the one that lands on a single client rather than washing out
+    across a pooled figure. One captured case owes nothing and has a $4,000
+    escrowed bond as its only line, and this reported it as $4,000 paid and
+    $333.33 a month. Another had $100 in fees and reported $2,100 paid at $350 a
+    month. Those monthly figures are what an ability-to-pay argument is built
+    out of, so the error runs against the client every time.
     """
     history = []
     last_detail = None
@@ -299,7 +327,8 @@ def payments(case):
         if detail:
             last_detail = detail
         line = detail or last_detail or ''
-        if is_excluded_fee(line) or is_judgment(line):
+        if (is_excluded_fee(line) or is_judgment(line)
+                or is_bond_principal(line)):
             continue
         paid = _money(row.get('paid'))
         when = parse_us_date(row.get('paidDate'))

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -149,6 +149,85 @@ class TestJudgmentsAreNotPayments:
         assert not crs.is_judgment(None)
 
 
+class TestBondMoneyIsNotAPayment:
+    """An appearance bond is money put up so somebody can go home, usually by a
+    relative, and the clerk holds it and later gives it back or applies it to
+    the debt. Counting the line as a payment says the client paid it, and where
+    it was applied it says so twice, because ICOS bills the fees it covered on
+    their own lines and marks those paid.
+
+    Judgments were the version of this that lands on civil cases. This is the
+    version that lands on criminal ones, which is most of what the workbook is
+    for, and it does not wash out across a client with several cases. One
+    captured case owes nothing, has an escrowed bond as its only line, and was
+    reported as $4,000 paid at $333.33 a month.
+    """
+
+    def test_an_escrowed_bond_is_not_money_paid_on_the_case(self):
+        history = crs.payments(_case([
+            _row('BONDS - ESCROW', '4000.00', '01/01/1900', amount='4000.00'),
+        ]))
+        assert history == []
+
+    def test_a_refunded_bond_is_not_money_paid_either(self):
+        # It is the clerk paying the client, which is the opposite direction.
+        history = crs.payments(_case([
+            _row('APPEARANCE BOND REFUND', '2000.00', '01/01/1900',
+                 amount='2000.00'),
+            _row('FILING AND DOCKETING FEES CRIMINAL', '67.00', '02/01/1900'),
+        ]))
+        assert [payment['detail'] for payment in history] == [
+            'FILING AND DOCKETING FEES CRIMINAL']
+
+    def test_the_fees_a_bond_covered_are_still_the_client_paying(self):
+        """The bond going onto the debt is real, and it is already on the
+        sheet: the fees it settled are itemized and marked paid. Dropping the
+        bond line keeps that and drops only the second count of it."""
+        history = crs.payments(_case([
+            _row('APPEARANCE BOND REFUND', '2000.00', '01/01/1900',
+                 amount='2000.00'),
+            _row('CRIME SERVICES SURCHARGE', '128.25', '02/01/1900'),
+            _row('RESTITUTIONS', '83.12', '02/01/1900'),
+        ]))
+        assert sum(payment['amount'] for payment in history) == \
+            Decimal('211.37')
+
+    def test_a_continuation_of_a_bond_line_is_left_out_too(self):
+        history = crs.payments(_case([
+            _row('BONDS - ESCROW', '2000.00', '01/01/1900', amount='4000.00'),
+            _row('', '2000.00', '02/01/1900', amount='4000.00'),
+        ]))
+        assert history == []
+
+    def test_the_monthly_figure_a_court_reads_no_longer_carries_it(self):
+        """The reason this matters. recent_monthly is what gets typed into the
+        ability-to-pay calculator, and a one-off bond divided over twelve
+        months is a claim about what the client can pay every month."""
+        history = crs.payment_history(_case([
+            _row('BONDS - ESCROW', '4000.00', '01/01/2026', amount='4000.00'),
+            _row('FINE', '20.00', '02/01/2026'),
+        ]), date(2026, 7, 31))
+        assert history['total'] == Decimal('20.00')
+        assert history['recent_monthly'] == Decimal('1.67')
+
+    def test_a_bond_only_case_reports_no_record_rather_than_a_payment(self):
+        # None and zero are different answers, and either is better than a
+        # $4,000 payment the client never made.
+        assert crs.payment_history(_case([
+            _row('BONDS - ESCROW', '4000.00', '01/01/1900', amount='4000.00'),
+        ]), CLINIC) is None
+
+    def test_is_bond_principal_wants_the_whole_line(self):
+        # A bond assignment fee is court debt and a forfeiture is money the
+        # county keeps. Matching the word would have thrown both away.
+        assert crs.is_bond_principal('BONDS - ESCROW')
+        assert crs.is_bond_principal('  appearance bond refund  ')
+        assert not crs.is_bond_principal('BOND ASSIGNMENT FEE')
+        assert not crs.is_bond_principal('BOND FORFEITURE')
+        assert not crs.is_bond_principal('')
+        assert not crs.is_bond_principal(None)
+
+
 class TestJudgmentsAreStillReported:
     """Taking them out of the payment history must not throw them away. A
     client being garnished on a judgment has less money for court debt, which


### PR DESCRIPTION
An appearance bond is money put up so somebody can go home, usually by a relative. The clerk holds it and later gives it back or applies it to the debt. Napier read the line as a payment on the case.

## What it did to real cases

Single captured cases, not a pooled figure:

| what ICOS shows | what the PAYMENTS sheet said |
|---|---|
| $0.00 due, one `BONDS - ESCROW` line of $4,000 | $4,000 paid, $333.33 a month |
| $100 in fees ever due, plus a $2,000 bond refund | $2,100 paid, $350 a month |
| $100 owed, $1,066.37 in real fees, plus a $2,000 bond refund | $3,066.37 paid, $1,022.12 a month |

`recent_monthly` is the number that gets typed into the ability-to-pay calculator and read by a court as what the client can pay every month. A one-off bond divided over twelve months is a claim about recurring capacity that nobody made. The error runs against the client every time it happens, which is the same direction as the judgment bug in #93.

Where the bond did go onto the debt it was counted twice, because ICOS bills the fees it covered on their own lines and marks those paid. Dropping the bond line keeps those and drops only the second count.

## Why whole lines

`APPEARANCE BOND REFUND` and `BONDS - ESCROW`, matched as whole lines the way `JUDGMENTS` is and for the same reason. A bond assignment fee is court debt and a forfeited bond is money the county keeps, and both carry the word. Those two are the only bond wordings across 300 captured cases; `OPEN_QUESTIONS.md` now records that a third would go back to being counted.

## The fee columns do not move

This is what separates it from the refundables question already in `OPEN_QUESTIONS.md`, where the reason for leaving it alone is that changing it would put Napier's arithmetic at odds with the court's.

Every bond line in the corpus is assessed and paid at the same amount, so it contributes nothing to what is owed. Across 300 cases the fee columns total **$46,147.49 either way**, with MISCELLANEOUS at **$15,881.21 either way**.

## Measured on 300 real cases

| | before | after |
|---|---|---|
| payment total | $93,539.48 | $83,989.48 |
| ability-to-pay monthly | $624.75 | $124.75 |
| cases reporting a payment history | 202 | 199 |

The three cases that stop reporting a history had a bond as their only line. `None` and zero are different answers, and either is better than a $4,000 payment the client never made.

## How it was found

Replay, again. The corpus had 20 criminal cases and this defect only reaches criminal ones, so a capture sweep biased toward FECR, AGCR and SRCR took it to 110 across 28 counties. The defect showed up on the fourth case that had a bond on it.

## Proof

Rollback. With the filter reverted, all six behavioural tests fail by `AssertionError` rather than by error:

- escrowed bond still in the history
- refunded bond still in the history
- the fees a bond covered summing to $2,211.37 instead of $211.37
- a continuation row of a bond line still counted
- `recent_monthly` at $4,020.00 instead of $20.00
- a bond-only case reporting a payment history instead of none

Full suite 839 passed, up from 832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t