### PR TITLE
Stop counting the clerk's escrow as money the client paid

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -52,10 +52,18 @@ county attorney fee is rather than about what the page says.
 
 `REFUNDABLES DUE TO PREPAID EXPENSES` shows up on 14 lines worth $681.69, and
 Napier counts every one of them as money the client paid toward court debt.
-A prepaid expense being refunded is probably not that. It is left alone because
-the wording does not say clearly enough which way it runs, and because ICOS's
-own totals treat it as a payment, so changing it would put Napier's arithmetic
-at odds with the court's.
+A prepaid expense being refunded is probably not that.
+
+The original reason for leaving it alone was that ICOS's own totals treat it as
+a payment, so changing it would put Napier's arithmetic at odds with the
+court's. That has been measured since and is not true: taking these lines out
+of the payment history moves no fee column on the 300 case corpus, which totals
+$46,147.49 either way. What is left is weaker but still enough to hold. The
+wording does not say which direction the money ran. It sits on civil cases
+rather than the criminal ones the workbook is mostly for. It is $299.44 on the
+cases that own it, against $9,274.25 for the bare `REFUNDABLE` that was
+excluded. And three of its lines are part paid, where every held-money wording
+that was excluded is assessed and paid at the same amount on every line.
 
 ## ICOS case statuses with no CRS code
 
@@ -83,12 +91,14 @@ one the sheets want is a question about the sheets.
 Column I, "Under supervison?", is blank on all 210 cases. ICOS does not print
 it anywhere Napier can reach.
 
-Bond principal is kept out of the payment history by matching two whole
-wordings, `APPEARANCE BOND REFUND` and `BONDS - ESCROW`, which are the only two
-seen across 300 cases. A third wording for the same thing would go back to
-being counted as a payment. The match is deliberately not on the word `BOND`,
-because a bond assignment fee is court debt and a forfeited bond is money the
-county keeps.
+Money the clerk is holding on somebody's behalf is kept out of the payment
+history by matching three whole wordings, `APPEARANCE BOND REFUND`,
+`BONDS - ESCROW` and `REFUNDABLE`, which are the only three of their kind seen
+across 300 cases. A fourth wording for the same thing would go back to being
+counted as a payment. The match is deliberately not on the word `BOND`, because
+a bond assignment fee is court debt and a forfeited bond is money the county
+keeps, and deliberately not on the word `REFUNDABLE`, for the reason in the
+prepaid expenses section above.
 
 The workbook recognises a `TNSF` disposition code that the parser never
 produces. Either ICOS has a wording for it that has not been seen in 210

--- a/crs.py
+++ b/crs.py
@@ -271,23 +271,31 @@ def is_judgment(detail):
     return (detail or '').strip().upper() == JUDGMENT_LINE
 
 
-# Bond principal moving through the clerk's account. A defendant, or more often
-# somebody standing behind them, puts up an appearance bond, and the clerk holds
-# it and later gives it back or applies it. Either way the line records the
-# money moving, not the defendant paying down what they owe. Where a bond is
-# applied to the debt, ICOS bills the fees it covered on their own lines and
-# marks those paid, so counting the bond line as well counts the same money
-# twice.
+# Money sitting with the clerk on somebody's behalf, rather than money applied
+# to what the client owes. A defendant, or more often somebody standing behind
+# them, puts up an appearance bond, and the clerk holds it and later gives it
+# back or applies it. Either way the line records the money moving, not the
+# defendant paying down their debt. Where it is applied, ICOS bills the fees it
+# covered on their own lines and marks those paid, so counting the deposit as
+# well counts the same money twice.
+#
+# Every one of these in the captured corpus is assessed and paid at the same
+# amount, so none of them contributes anything to what ICOS says is owed, and
+# taking them out of the payment history cannot put Napier's arithmetic at odds
+# with the court's. That is the test to apply to any wording added here.
 #
 # Whole lines again, for the reason JUDGMENT_LINE is. A bond assignment fee or a
 # forfeiture is court debt and carries the word, and forfeited bond money is
-# money the county keeps rather than money that comes back.
-BOND_LINES = ('APPEARANCE BOND REFUND', 'BONDS - ESCROW')
+# money the county keeps rather than money that comes back. REFUNDABLE is a
+# whole line for a second reason: REFUNDABLES DUE TO PREPAID EXPENSES is a
+# different thing on civil cases and is deliberately still counted, for the
+# reasons in OPEN_QUESTIONS.md.
+DEPOSIT_LINES = ('APPEARANCE BOND REFUND', 'BONDS - ESCROW', 'REFUNDABLE')
 
 
-def is_bond_principal(detail):
-    """Whether an itemization line is bond money rather than a payment."""
-    return (detail or '').strip().upper() in BOND_LINES
+def is_clerk_deposit(detail):
+    """Whether a line is money held for the client rather than money paid."""
+    return (detail or '').strip().upper() in DEPOSIT_LINES
 
 
 def payments(case):
@@ -311,14 +319,15 @@ def payments(case):
     taking them out is $21,422.11 across 488 payments, which is a person paying
     the clerk.
 
-    Bond principal is excluded for the third time on the same grounds. It is the
-    one that reaches criminal cases, which is what most of this workbook is for,
-    and it is the one that lands on a single client rather than washing out
-    across a pooled figure. One captured case owes nothing and has a $4,000
+    Money the clerk is holding is excluded for the third time on the same
+    grounds. It is the one that reaches criminal cases, which is what most of
+    this workbook is for, and it lands on a single client rather than washing
+    out across a pooled figure. One captured case owes nothing and has a $4,000
     escrowed bond as its only line, and this reported it as $4,000 paid and
-    $333.33 a month. Another had $100 in fees and reported $2,100 paid at $350 a
-    month. Those monthly figures are what an ability-to-pay argument is built
-    out of, so the error runs against the client every time.
+    $333.33 a month. Another owes nothing, has a $2,490 REFUNDABLE against $155
+    of real fees, and reported $2,645 a month. Those monthly figures are what an
+    ability-to-pay argument is built out of, so the error runs against the
+    client every time.
     """
     history = []
     last_detail = None
@@ -328,7 +337,7 @@ def payments(case):
             last_detail = detail
         line = detail or last_detail or ''
         if (is_excluded_fee(line) or is_judgment(line)
-                or is_bond_principal(line)):
+                or is_clerk_deposit(line)):
             continue
         paid = _money(row.get('paid'))
         when = parse_us_date(row.get('paidDate'))

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -149,18 +149,22 @@ class TestJudgmentsAreNotPayments:
         assert not crs.is_judgment(None)
 
 
-class TestBondMoneyIsNotAPayment:
+class TestMoneyTheClerkIsHoldingIsNotAPayment:
     """An appearance bond is money put up so somebody can go home, usually by a
     relative, and the clerk holds it and later gives it back or applies it to
     the debt. Counting the line as a payment says the client paid it, and where
     it was applied it says so twice, because ICOS bills the fees it covered on
-    their own lines and marks those paid.
+    their own lines and marks those paid. A bare `REFUNDABLE` is the same shape:
+    round, bond-sized, dated apart from the fee payments, and on cases that owe
+    nothing.
 
     Judgments were the version of this that lands on civil cases. This is the
     version that lands on criminal ones, which is most of what the workbook is
     for, and it does not wash out across a client with several cases. One
     captured case owes nothing, has an escrowed bond as its only line, and was
-    reported as $4,000 paid at $333.33 a month.
+    reported as $4,000 paid at $333.33 a month. Another owes nothing, has $2,490
+    of `REFUNDABLE` against $155 of real fees, and was reported at $2,645 a
+    month.
     """
 
     def test_an_escrowed_bond_is_not_money_paid_on_the_case(self):
@@ -217,15 +221,47 @@ class TestBondMoneyIsNotAPayment:
             _row('BONDS - ESCROW', '4000.00', '01/01/1900', amount='4000.00'),
         ]), CLINIC) is None
 
-    def test_is_bond_principal_wants_the_whole_line(self):
+    def test_a_bare_refundable_is_held_money_too(self):
+        """$9,274.25 across 8 lines in the captured corpus, second only to
+        the bonds. Seven of the eight sit on cases that owe nothing."""
+        history = crs.payments(_case([
+            _row('REFUNDABLE', '2490.00', '01/01/1900', amount='2490.00'),
+            _row('COURT COSTS', '155.00', '02/01/1900'),
+        ]))
+        assert [payment['detail'] for payment in history] == ['COURT COSTS']
+
+    def test_the_refundable_case_that_read_as_2645_a_month(self):
+        # The real one, with the amounts kept and the case number thrown away.
+        history = crs.payment_history(_case([
+            _row('REFUNDABLE', '2490.00', '01/01/2026', amount='2490.00'),
+            _row('COURT COSTS', '155.00', '02/01/2026'),
+        ]), date(2026, 7, 31))
+        assert history['total'] == Decimal('155.00')
+        assert history['recent_monthly'] == Decimal('12.92')
+
+    def test_a_prepaid_expense_refund_is_still_counted(self):
+        """The whole-line match is the whole point of the distinction.
+        REFUNDABLES DUE TO PREPAID EXPENSES is a different thing, it sits on
+        civil cases, and three of its lines are part paid, so it is a question
+        for Iowa Legal Aid rather than a fix. Matching on the word would have
+        decided it silently."""
+        assert not crs.is_clerk_deposit('REFUNDABLES DUE TO PREPAID EXPENSES')
+        history = crs.payments(_case([
+            _row('REFUNDABLES DUE TO PREPAID EXPENSES', '48.69', '01/01/1900'),
+        ]))
+        assert [payment['detail'] for payment in history] == [
+            'REFUNDABLES DUE TO PREPAID EXPENSES']
+
+    def test_is_clerk_deposit_wants_the_whole_line(self):
         # A bond assignment fee is court debt and a forfeiture is money the
         # county keeps. Matching the word would have thrown both away.
-        assert crs.is_bond_principal('BONDS - ESCROW')
-        assert crs.is_bond_principal('  appearance bond refund  ')
-        assert not crs.is_bond_principal('BOND ASSIGNMENT FEE')
-        assert not crs.is_bond_principal('BOND FORFEITURE')
-        assert not crs.is_bond_principal('')
-        assert not crs.is_bond_principal(None)
+        assert crs.is_clerk_deposit('BONDS - ESCROW')
+        assert crs.is_clerk_deposit('  appearance bond refund  ')
+        assert crs.is_clerk_deposit('refundable')
+        assert not crs.is_clerk_deposit('BOND ASSIGNMENT FEE')
+        assert not crs.is_clerk_deposit('BOND FORFEITURE')
+        assert not crs.is_clerk_deposit('')
+        assert not crs.is_clerk_deposit(None)
 
 
 class TestJudgmentsAreStillReported:


### PR DESCRIPTION
The bond fix in #96 caught two wordings. It missed the third, and the third turns out to be the second largest payment wording in the captured corpus: `REFUNDABLE` at **$9,274.25 across 8 lines**, against $9,550 for the two bond wordings together.

## Why it is the same thing

A bare `REFUNDABLE` line looks exactly like a bond and behaves like one. Round amounts, bond sized, dated apart from the actual fee payments, and seven of the eight sit on cases that owe nothing at all. It is the clerk holding somebody's money, not the client paying down court debt.

## What it did to real clients

| case | reported paid | reported monthly | of which REFUNDABLE | actually owed |
|---|---|---|---|---|
| AGCR | $5,110.00 | **$1,703.33** | $5,000.00 | $0 |
| SRCR | $2,645.00 | **$2,645.00** | $2,490.00 | $0 |

`recent_monthly` is the figure that gets typed into abilitytopay.org and read by a court as what the client can afford every month. Both of these run against the client.

## Measured on the 300 case corpus

- payment total $83,989.48 to $74,715.23
- fee columns **$46,147.49 either way**, not one column moves
- all 8 lines are assessed and paid at the same amount, so they were never contributing to what ICOS says is owed

That last point is the test. It is what makes taking these out safe, and it is now written into the comment above `DEPOSIT_LINES` as the bar any future wording has to clear.

## The rename

`is_bond_principal` becomes `is_clerk_deposit`. A function called `is_bond_principal` that also matches `REFUNDABLE` is a lie about what it does. Same whole-line matching for the same reason as before: a bond assignment fee is court debt, a forfeiture is money the county keeps, and `REFUNDABLES DUE TO PREPAID EXPENSES` is a different thing on civil cases that is deliberately still counted.

## OPEN_QUESTIONS sharpened

The prepaid expenses entry said Napier leaves it alone because excluding it would put the arithmetic at odds with the court's. That was never measured and is not true, the fee columns do not move for it either. What actually remains: the wording is ambiguous about direction, it is $299.44 and sits on civil cases, and three of its lines are part paid where every excluded wording is paid in full on every line. Still a question for Iowa Legal Aid, but now for reasons that hold up.

## Proof

With the filter reverted, 8 of the 10 tests in the class fail by `AssertionError`. The 2 that pass are the two that test the predicate rather than the filter, which is what they are supposed to do. 843 pass with the filter in.

No client data, names or case numbers in the diff. Every fixture is the synthetic `00000  FECR000000` family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t