### PR TITLE
Read the probation wordings ICOS actually writes

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -80,8 +80,18 @@ disposed under a different code. Pairing the code with its own date and
 reporting the case as finished on its last day cannot both be true, and which
 one the sheets want is a question about the sheets.
 
-Column I, "Under supervison?", is blank on all 210 cases. ICOS does not print
-it anywhere Napier can reach.
+Column I, "Under supervison?", is answered off the sentence table on the
+charges page, and comes out YES on 4 of the 300 captured cases. It is blank on
+the rest, and blank covers two different things: a term that has run out, and a
+term nobody can put an end date on. Three cases are the second sort, where ICOS
+shows probation with a date and no duration.
+
+The expungement sheet reads that column in `=IF('CASE DATA'!I4="YES",
+SUM('CASE DATA'!J4:P4),"n/a")`, so a blank and a NO reach it identically and
+"Amount of debt subject to 910.7?" says n/a either way. On the three cases with
+an undated term that n/a is Napier not knowing rather than the answer being
+none, and nothing on the sheet distinguishes the two. Whether that column should
+be able to say so is a question about the sheet.
 
 Bond principal is kept out of the payment history by matching two whole
 wordings, `APPEARANCE BOND REFUND` and `BONDS - ESCROW`, which are the only two

--- a/crs.py
+++ b/crs.py
@@ -423,14 +423,33 @@ def _months_between(start, end):
 
 
 # Sentence types ICOS uses that put somebody under supervision in the community.
-# All three are court-ordered, run for a stated term, and appear in the sentence
-# table with that term, which is what makes them answerable from ICOS at all.
+# All of them are court-ordered, run for a stated term, and appear in the
+# sentence table with that term, which is what makes them answerable from ICOS
+# at all.
 #
 # PRISON, JAIL and the suspended variants are deliberately not here. Somebody in
 # custody is not what the expungement sheet's 910.7 column is asking about, and
 # the day they get out is not on this page.
+#
+# The two probation wordings after the first are the ones this set was missing.
+# ICOS writes PROBATION - OTHER THAN DCS when somebody other than the Department
+# of Correctional Services holds the supervision, and 910.7 turns on the period
+# of probation rather than on who administers it. PROBATION EXTENDED is the
+# wording for an extension, which is the thing is_under_supervision says below
+# that ICOS records inconsistently: inconsistently is not never, and where ICOS
+# does record one it is the row that decides whether the term is still running.
+#
+# Between them they are 6 rows across 300 captured cases, and two of those are
+# people on probation today whose column I was blank. Both come off the same
+# page Napier already has.
+#
+# NO SUPERVISION is a real ICOS wording too and is deliberately absent. It is
+# the court saying the opposite, and is_under_supervision has nothing to do with
+# it, since it never writes a NO.
 SUPERVISION_SENTENCES = frozenset({
     'PROBATION',
+    'PROBATION - OTHER THAN DCS',
+    'PROBATION EXTENDED',
     'DRUG COURT',
     'RESIDENTIAL FACILITY',
 })
@@ -446,6 +465,19 @@ SUPERVISION_NOTE = (
     "discharged early, a term extended, or anyone on parole, so confirm this "
     "before relying on it."
 )
+
+# The note reads "a probation term of 2 Year(s)", so the ICOS wording is
+# lowercased to sit inside the sentence. DCS is the Department of Correctional
+# Services, and "other than dcs" in a workbook somebody files off is a typo
+# rather than a house style.
+TERM_ACRONYMS = frozenset({'DCS'})
+
+
+def term_wording(kind):
+    """The ICOS sentence type as it reads in the middle of a sentence."""
+    return ' '.join(
+        word.upper() if word.upper() in TERM_ACRONYMS else word
+        for word in (kind or '').lower().split(' '))
 
 
 def _add_term(start, count, unit):
@@ -1200,7 +1232,7 @@ def process_case(case, worksheet, row, as_of=None):
     if supervised is not None:
         worksheet['I' + i] = supervised
         supervision_note = SUPERVISION_NOTE % (
-            term[0].lower(), term[1], term[2].strftime('%m/%d/%Y'),
+            term_wording(term[0]), term[1], term[2].strftime('%m/%d/%Y'),
             term[3].strftime('%m/%d/%Y'))
     else:
         supervision_note = None

--- a/tests/test_supervision.py
+++ b/tests/test_supervision.py
@@ -116,12 +116,43 @@ def test_the_other_real_sentence_types_are_not_supervision(kind):
     assert answer is None
 
 
-@pytest.mark.parametrize('kind', ['PROBATION', 'DRUG COURT',
+@pytest.mark.parametrize('kind', ['PROBATION', 'PROBATION - OTHER THAN DCS',
+                                  'PROBATION EXTENDED', 'DRUG COURT',
                                   'RESIDENTIAL FACILITY'])
 def test_every_community_supervision_type_counts(kind):
     answer, _ = crs.is_under_supervision(
         [_sentence(kind, '01/01/2025', '3 Year(s)')], CLINIC)
     assert answer == "YES"
+
+
+def test_probation_someone_other_than_dcs_holds_is_still_probation():
+    """Two of the 300 captured cases are people on probation right now, and
+    both of them are this wording. 910.7 is petitionable during the period of
+    probation, and it does not ask who administers it."""
+    answer, term = crs.is_under_supervision(
+        [_sentence('PROBATION - OTHER THAN DCS', '12/22/2025', '2 Year(s)')],
+        CLINIC)
+    assert answer == "YES"
+    assert term[3] == date(2027, 12, 22)
+
+
+def test_an_extension_can_be_the_row_that_keeps_the_term_running():
+    """The one place the wording matters on its own. The original term is spent
+    and the extension is not, so reading only PROBATION says the person is off
+    supervision on the day they are not."""
+    sentences = [_sentence('PROBATION', '01/01/2023', '2 Year(s)'),
+                 _sentence('PROBATION EXTENDED', '01/01/2025', '3 Year(s)')]
+    answer, term = crs.is_under_supervision(sentences, CLINIC)
+    assert answer == "YES"
+    assert term[0] == 'PROBATION EXTENDED'
+    assert term[3] == date(2028, 1, 1)
+
+
+def test_icos_saying_there_is_no_supervision_is_not_supervision():
+    """A real wording, and the one type in the table that means the opposite."""
+    answer, _ = crs.is_under_supervision(
+        [_sentence('NO SUPERVISION', '01/01/2025', '12 Month(s)')], CLINIC)
+    assert answer is None
 
 
 def test_the_longest_running_term_is_the_one_reported():
@@ -264,6 +295,23 @@ def test_the_row_says_what_the_yes_rests_on():
     assert '3 Year(s)' in note
     assert '01/01/2025' in note
     assert '01/01/2028' in note
+
+
+def test_the_agency_keeps_its_capitals_in_the_note():
+    """The note lowercases the ICOS wording so it reads as a sentence, which
+    turned the Department of Correctional Services into "dcs" on a workbook
+    somebody files off."""
+    _, note = _row(_case([
+        _sentence('PROBATION - OTHER THAN DCS', '01/01/2025', '3 Year(s)')]))
+    assert 'probation - other than DCS term' in note
+
+
+def test_term_wording_only_shouts_where_icos_meant_to():
+    assert crs.term_wording('PROBATION') == 'probation'
+    assert crs.term_wording('DRUG COURT') == 'drug court'
+    assert crs.term_wording('PROBATION - OTHER THAN DCS') == \
+        'probation - other than DCS'
+    assert crs.term_wording('') == ''
 
 
 def test_the_note_admits_what_napier_cannot_see():


### PR DESCRIPTION
Found by sweeping the EXPUNGEMENT & 910.7 sheet on the 97 case criminal workbook, which the criminal-heavy corpus exercises properly for the first time.

## What the column is for

CASE DATA column I is "Under supervison?" and the expungement sheet reads it in `=IF('CASE DATA'!I4="YES",SUM('CASE DATA'!J4:P4),"n/a")`. Column I is the only thing standing between a client and the one column on that sheet that says how much restitution they can petition to have modified. On the 97 case criminal workbook that column was `n/a` on all 97 rows.

## What was missing

`SUPERVISION_SENTENCES` matched three exact wordings. ICOS writes five.

| wording | rows in 300 cases | in the set before |
|---|---|---|
| `PROBATION` | 41 | yes |
| `RESIDENTIAL FACILITY` | 8 | yes |
| `PROBATION - OTHER THAN DCS` | 5 | **no** |
| `DRUG COURT` | 2 | yes |
| `PROBATION EXTENDED` | 1 | **no** |

`PROBATION - OTHER THAN DCS` is probation the Department of Correctional Services does not hold, and Iowa Code 910.7 turns on the period of probation rather than on who administers it. `PROBATION EXTENDED` is the wording for an extension, which is the thing `is_under_supervision`'s own docstring says ICOS records inconsistently. Inconsistently is not never, and where ICOS does record one it is the row that decides whether the term is still running.

## Two real clients

| case | term | runs to | 910.7 column before | after |
|---|---|---|---|---|
| AGCR | probation other than DCS, 2 years from 12/22/2025 | 12/22/2027 | `n/a` | $1,031.20 |
| SRCR | probation other than DCS, 1 year from 12/22/2025 | 12/22/2026 | `n/a` | $347.04 |

Both are on probation today. Verified end to end: built a workbook of every case with a running term, recalculated it through LibreOffice, and the two that used to say `n/a` now carry those figures.

Across the corpus, column I goes from YES on 2 of 300 cases to YES on 4, and cases with a term Napier can date go from 27 to 32.

`NO SUPERVISION` is a real ICOS wording too and stays out, because it is the court saying the opposite and this function never writes a NO.

## Two smaller things

The note Napier writes on the row lowercases the ICOS wording so it reads as a sentence, which turned the agency into "other than dcs" on a workbook somebody files off. It keeps its capitals now.

`OPEN_QUESTIONS.md` still said column I "is blank on all 210 cases. ICOS does not print it anywhere Napier can reach." That has not been true since the supervision work shipped, and it is a public document Iowa Legal Aid reads. Replaced with what the column actually does, plus the question that is genuinely still open: blank covers both an expired term and a term nobody can date, three captured cases are the second sort, and the sheet's `n/a` cannot tell a reader which one it means.

## Proof

With the two wordings taken back out, 4 tests fail by `AssertionError`. 847 pass with them in, up from 845.

No client data, names or case numbers in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t