### PR TITLE
Stop a category that will not add up from erasing the fee breakdown

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -2,7 +2,7 @@ import re
 
 from calendar import monthrange
 from datetime import date, datetime, timedelta
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from openpyxl.styles import Alignment # Added import
 from openpyxl.styles import Font, PatternFill
 from zoneinfo import ZoneInfo
@@ -801,6 +801,41 @@ FINE_MARKERS = (
     'NONSCHEDULED CHAPTER 321', 'SCHEDULED VIOLATION/NON-SCHEDULED',
 )
 
+# Fees whose wording says one bucket and whose own ICOS summary says another.
+# The markers above are a reading of the fee name; these are what the clerk
+# actually filed the fee under, which is the only thing the reconciliation
+# cares about, so they are checked first and they win.
+#
+# Every one of these was measured across 259 captured cases carrying both a
+# summary and an itemization. Each was applied on its own and none of them cost
+# a single bucket that was adding up before; together they take the buckets
+# that reconcile from 555 of 674 to 600 of 655, and the rows where the whole
+# itemization reconciles from 201 to 228 of 259.
+#
+# The stakes are not cosmetic. A bucket that does not add up used to surrender
+# the fee breakdown for everything in it, so two $100 probation revocation fees
+# filed under OTHER took a $60 indigent defense fee in the same case out of
+# INDIGENT DEFENSE and into MISCELLANEOUS, which is the difference between
+# having a 910.7 analysis and not having one.
+SUMMARY_BUCKET_OVERRIDES = (
+    # Filed under COSTS by the clerk, whatever the wording suggests.
+    ('PARKING VIOLATION PER COMPLAINT', 'COSTS'),
+    ('PROBATION REVOCATION FEE', 'COSTS'),
+    ('REFUNDABLES DUE TO PREPAID EXPENSES', 'COSTS'),
+    ('TITLE CHANGE REAL ESTATE', 'COSTS'),
+    ('PROBATE ENTERING ORDER', 'COSTS'),
+    ('CERTIFICATE AND SEAL (PROBATE)', 'COSTS'),
+    ('PROBATE FEES PAID TO PRIVATE REFEREE', 'COSTS'),
+    # These two carry fine wording and the clerk files them under COSTS. Only
+    # the reconciliation moves; the column the client reads is still FINES,
+    # which is a separate question this does not touch.
+    ('SCHEDULED VIOLATION/NON-SCHEDULED', 'COSTS'),
+    ('NONSCHEDULED CHAPTER 321', 'COSTS'),
+    # The county attorney's collection fee is charged against the fine and the
+    # summary counts it there, not in OTHER where its wording lands it.
+    ('COLLECTION BY CO ATTY', 'FINE'),
+)
+
 
 def get_summary_bucket(detail):
     """Which of the five ICOS summary buckets a line item rolls up into.
@@ -812,6 +847,9 @@ def get_summary_bucket(detail):
     nothing else.
     """
     text = (detail or '').upper()
+    for marker, bucket in SUMMARY_BUCKET_OVERRIDES:
+        if marker in text:
+            return bucket
     if 'SURCHARGE' in text:
         return 'SURCHARGE'
     if 'RESTITUTION' in text:
@@ -849,6 +887,88 @@ def _unique_paid_subset(amounts, target):
                 return None  # more than one explanation
             found = frozenset(combo)
     return found
+
+
+def spread_over_fee_columns(due, entries, paid=None):
+    """Split a category balance across the columns its own fees belong to.
+
+    A category whose balance cannot be pinned to particular fees still has a
+    composition the record does show: what each fee was assessed at. Sending the
+    whole balance to one column threw that away, and the column it usually
+    landed in was MISCELLANEOUS, because that is where a category label with no
+    fee name in it falls.
+
+    That is the one thing these sheets cannot survive. Bankruptcy treats columns
+    J and K as the debt that is surely dischargeable and everything else as
+    maybe; the 910.7 sheet reads J through P and no further; the statute of
+    limitations sheet is built on old attorney fee and jail debt by name. An
+    indigent defense fee that arrives as MISCELLANEOUS is a fee the hearing
+    cannot ask the court to remit, and nothing on the page says why.
+
+    So the balance is apportioned by assessment instead. It is an estimate and
+    the row says so. Returns None when there is nothing to apportion over, which
+    leaves the caller to fall back the old way. Every cent still comes out: the
+    largest column carries the rounding.
+
+    Apportioning is the last resort, not the first. A fee the record already
+    shows as settled must not draw a share of a balance it is no longer part of,
+    because the column that would collect that share is often K, and reporting
+    collection costs a client does not owe is the specific defect this module
+    was rewritten to stop. So anything the record can pin down is pinned down
+    first, and only what is genuinely unattributable gets spread.
+    """
+    if not entries:
+        return None
+    # What each fee still shows as owed on its own line, where ICOS bothered to
+    # fill the Paid column in. Most itemizations leave Paid blank, in which case
+    # this is the assessment and nothing is lost.
+    owed = [[get_finance_column(detail), max(amount - line_paid, Decimal(0))]
+            for detail, amount, line_paid in entries]
+
+    # A bucket paid down by more than its own lines admit to is the usual case,
+    # because ICOS records the payment against the category and leaves the lines
+    # alone. Where exactly one combination of those lines accounts for the
+    # difference, that combination is not a guess: no other set of fees can add
+    # up to what was paid. Those fees are settled and drop out of the split.
+    if paid is not None:
+        remainder = paid - sum((entry[2] for entry in entries), Decimal(0))
+        if remainder > 0:
+            settled = _unique_paid_subset([line[1] for line in owed], remainder)
+            for index in settled or ():
+                owed[index][1] = Decimal(0)
+
+    weights = {}
+    for column, amount in owed:
+        if amount > 0:
+            weights[column] = weights.get(column, Decimal(0)) + amount
+    if not weights:
+        # Every line reads as paid off and yet the category still owes. The
+        # lines are the only account of what this money is, so fall back to
+        # what each fee was assessed and let the note carry the doubt.
+        for detail, amount, _line_paid in entries:
+            if amount > 0:
+                column = get_finance_column(detail)
+                weights[column] = weights.get(column, Decimal(0)) + amount
+    if not weights:
+        return None
+    if len(weights) == 1:
+        return {next(iter(weights)): due}
+    total = sum(weights.values(), Decimal(0))
+    if total <= 0:
+        return None
+
+    # Largest first, so the column carrying the rounding is the one where a
+    # cent is least likely to be noticed.
+    order = sorted(weights, key=lambda column: (-weights[column], column))
+    shares = {}
+    running = Decimal(0)
+    for column in order[1:]:
+        share = (due * weights[column] / total).quantize(Decimal('0.01'),
+                                                         rounding=ROUND_HALF_UP)
+        shares[column] = share
+        running += share
+    shares[order[0]] = due - running
+    return shares
 
 
 def reconcile_financials(case):
@@ -930,6 +1050,7 @@ def reconcile_financials(case):
     columns = {}
     unresolved = []
     unreconciled = []
+    apportioned = []
     carrying = []
     for name in ICOS_BUCKETS:
         entries = buckets[name]
@@ -944,8 +1065,19 @@ def reconcile_financials(case):
             if due is None:
                 due = category['original'] - (category.get('paid') or Decimal(0))
             if due:
-                column = get_finance_column(category['label'])
-                columns[column] = columns.get(column, Decimal(0)) + due
+                # The total is the summary's, because the itemization did not
+                # agree with it and the summary is the side ICOS stands behind.
+                # Which columns it belongs in is still the itemization's to say.
+                shares = spread_over_fee_columns(due, entries,
+                                                 category.get('paid'))
+                if shares is None:
+                    shares = {get_finance_column(category['label']): due}
+                elif len(shares) > 1:
+                    # One column is not an estimate. The category total went
+                    # somewhere exact and the note has nothing to add.
+                    apportioned.append(name)
+                for column, share in shares.items():
+                    columns[column] = columns.get(column, Decimal(0)) + share
             continue
 
         if not entries:
@@ -980,9 +1112,13 @@ def reconcile_financials(case):
             due = summary[name].get('due')
             if due is None:
                 due = sum(amounts, Decimal(0)) - paid
-            shared = {get_finance_column(entry[0]) for entry in entries}
-            column = shared.pop() if len(shared) == 1 else 'O'
-            columns[column] = columns.get(column, Decimal(0)) + due
+            shares = spread_over_fee_columns(due, entries, paid)
+            if shares is None:
+                shares = {get_finance_column(summary[name]['label']): due}
+            elif len(shares) > 1:
+                apportioned.append(name)
+            for column, share in shares.items():
+                columns[column] = columns.get(column, Decimal(0)) + share
             continue
         for index, (detail, amount, _line_paid) in enumerate(entries):
             owed = Decimal(0) if index in settled else amount
@@ -1004,18 +1140,28 @@ def reconcile_financials(case):
                 % (_and_list(unreconciled),
                    "those balances are" if len(unreconciled) > 1
                    else "that balance is"))
-        if any(get_finance_column(summary[name]['label']) == 'O'
-               for name in unreconciled):
-            text += (", and those fees are in MISCELLANEOUS rather than in "
-                     "their own columns")
+        stranded = [name for name in unreconciled
+                    if name not in apportioned
+                    and get_finance_column(summary[name]['label']) == 'O']
+        if stranded:
+            text += (", and %s is in MISCELLANEOUS rather than in its own "
+                     "columns" % _and_list(stranded))
         notes.append(text + ". The rest of the row is fee by fee and the ICOS "
                             "total is still right.")
     if unresolved:
         notes.append(
             "ICOS records payments per category, not per fee. The payment "
-            "in %s could not be tied to a specific line, so that balance "
-            "is reported as a category total rather than per fee."
-            % ", ".join(unresolved))
+            "in %s could not be tied to a specific line, so that balance is "
+            "ICOS's category total." % _and_list(unresolved))
+    if apportioned:
+        # Named separately from the reason, because this is the part that
+        # changes how the number should be read. The column is right and the
+        # split inside it is an estimate.
+        notes.append(
+            "The %s balance is divided across its fee columns in proportion "
+            "to what those fees were assessed, so the column totals are "
+            "estimates. Request an accounting before relying on the split."
+            % _and_list(sorted(set(apportioned))))
     return columns, " ".join(notes) or None
 
 

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -123,7 +123,14 @@ def test_one_broken_category_does_not_cost_the_others(felony_case):
     felony_case['financials'][0]['amount'] = '31.00'   # an OTHER line
     sheet = FakeSheet()
     crs.process_financials(felony_case, sheet, 4)
-    assert sheet.value_of('O4') == Decimal('90.00')    # OTHER, as a total
+    # The category total is ICOS's, because the itemization disagreed with it.
+    # Which column it belongs in is still the itemization's to say, and every
+    # fee in this bucket is a revolving fund fee, so it is column P and not
+    # MISCELLANEOUS. Iowa Legal Aid asked for this in August 2026 after a
+    # workbook moved a $60 attorney fee out of INDIGENT DEFENSE over a
+    # discrepancy in a different category.
+    assert sheet.value_of('P4') == Decimal('90.00')    # OTHER, as a total
+    assert sheet.value_of('O4') is None
     assert sheet.value_of('M4') == Decimal('579.00')   # sheriff fees survive
     assert sheet.value_of('J4') == Decimal('50.00')    # indigent defense too
     assert sheet.value_of('S4') == Decimal('500.00')
@@ -138,12 +145,17 @@ def test_a_collapsed_row_says_it_is_collapsed(felony_case):
     Folded into MISCELLANEOUS looks exactly like never charged. The row that
     cannot be reconciled has to say so on its face, since nothing else about it
     is different.
+
+    The word MISCELLANEOUS is no longer what says it, because the balance no
+    longer goes there when the itemization can name a better column. What has
+    to survive is the row admitting that this category came off the summary.
     """
     felony_case['financials'][0]['amount'] = '31.00'
     sheet = FakeSheet()
     crs.process_financials(felony_case, sheet, 4)
     note = sheet.value_of('V4')
-    assert 'MISCELLANEOUS' in note
+    assert 'OTHER did not add up' in note
+    assert 'category total' in note
     assert 'ICOS total is still right' in note
 
 
@@ -282,16 +294,19 @@ def test_reconciliation_needs_both_halves(felony_case):
 
 def test_reconciliation_refuses_a_partition_that_does_not_add_up(felony_case):
     # If a fee lands in the wrong bucket the bucket stops matching its summary
-    # original. That must cost us that bucket's split, not produce a wrong one.
+    # original. That must cost us the per-fee split inside that bucket, not the
+    # knowledge of which columns the bucket's fees belong to. Here every fee in
+    # the broken bucket is a revolving fund fee, so there is one column and the
+    # answer is exact even though the split is given up.
     felony_case['financials'][0]['amount'] = '31.00'
     columns, note = crs.reconcile_financials(felony_case)
     assert columns == {
         'M': Decimal('579.00'),
         'J': Decimal('50.00'),
-        'O': Decimal('90.00'),    # OTHER, off the summary rather than by fee
+        'P': Decimal('90.00'),    # OTHER, off the summary rather than by fee
         'S': Decimal('500.00'),
     }
-    assert 'P' not in columns     # no guessed split of the broken bucket
+    assert 'O' not in columns
     assert 'OTHER' in note
 
 
@@ -310,7 +325,9 @@ def test_a_row_where_nothing_reconciles_falls_back_whole(felony_case):
 
 def test_ambiguous_payment_is_flagged_not_guessed():
     # Two lines of the same amount in one bucket, one of them paid. Nothing on
-    # the page says which, so the balance goes to MISC and the row gets a note.
+    # the page says which, so the balance is apportioned across the two columns
+    # those fees belong to and the row says the split is an estimate. It used to
+    # go to MISCELLANEOUS whole, which reads as neither fee having been charged.
     case = {
         'total_due': '$25.00',
         'summary_categories': [
@@ -333,8 +350,10 @@ def test_ambiguous_payment_is_flagged_not_guessed():
         ],
     }
     columns, note = crs.reconcile_financials(case)
-    assert columns == {'O': Decimal('25.00')}
+    assert columns == {'P': Decimal('12.50'), 'K': Decimal('12.50')}
+    assert sum(columns.values()) == Decimal('25.00')
     assert note is not None and 'OTHER' in note
+    assert 'estimates' in note
 
 
 def test_third_party_fee_stays_out_of_the_partition(felony_case):
@@ -353,7 +372,23 @@ def test_third_party_fee_stays_out_of_the_partition(felony_case):
     ("RESTITUTIONS", "RESTITUTION"),
     ("CRIMINAL PENALTY SURCHARGE", "SURCHARGE"),
     ("FINE", "FINE"),
-    ("NONSCHEDULED CHAPTER 321", "FINE"),
+    # Fine wording, filed under COSTS by the clerk. Measured across 259
+    # captured cases carrying both halves: moving it gained two buckets and
+    # cost none, and there is no case in the corpus where the summary counts it
+    # as a fine. Thin evidence, so it is worth revisiting, but it is one sided,
+    # and this decides only the reconciliation. The column the client reads is
+    # still FINES.
+    ("NONSCHEDULED CHAPTER 321", "COSTS"),
+    ("SCHEDULED VIOLATION/NON-SCHEDULED", "COSTS"),
+    # The county attorney's collection fee is charged against the fine and the
+    # summary counts it there. Six buckets and three whole rows, no losses.
+    ("COLLECTION BY CO ATTY (THRESHOLD MET)", "FINE"),
+    # Filed under COSTS despite the wording. Probation revocation was the
+    # single biggest cause of a broken partition in the corpus, at thirteen
+    # buckets, and it broke the bucket that holds indigent defense fees.
+    ("PROBATION REVOCATION FEE", "COSTS"),
+    ("PARKING VIOLATION PER COMPLAINT", "COSTS"),
+    ("REFUNDABLES DUE TO PREPAID EXPENSES", "COSTS"),
     ("DNU-DELINQUENT REVOLVING FUND OBLIGATION", "OTHER"),
     ("IOWA DEPT OF REVENUE COLLECTIONS FEE", "OTHER"),
     ("", "OTHER"),
@@ -503,7 +538,8 @@ def test_old_fee_debt_survives_a_broken_category_elsewhere():
     columns, note = crs.reconcile_financials(case)
     assert columns['J'] == Decimal('150.00')
     assert columns['L'] == Decimal('250.00')
-    assert columns['O'] == Decimal('25.00')
+    assert columns['P'] == Decimal('25.00')   # the revolving fund's own column
+    assert 'O' not in columns
     assert 'OTHER' in note
 
 
@@ -525,11 +561,19 @@ def test_the_wording_icos_actually_uses_for_room_and_board_reaches_column_l():
     assert crs.get_finance_column('SHERIFFS FEES - LOCAL') == 'M'
 
 
-def test_an_unattributable_payment_across_different_fees_still_falls_to_misc():
-    """The old behaviour, kept for the case that actually warrants it.
+def test_an_unattributable_payment_is_apportioned_not_dumped():
+    """What happens when the lines in an unsplittable bucket disagree.
 
-    When the lines in an unsplittable bucket map to different columns there is
-    no honest column to put the balance in, so MISC it is.
+    This used to be the case that went to MISCELLANEOUS whole, on the reasoning
+    that no single column was honest. Iowa Legal Aid's answer in August 2026 was
+    that MISCELLANEOUS is the least honest column of the lot: the bankruptcy
+    sheet treats J and K as surely dischargeable and everything else as maybe,
+    and the 910.7 sheet stops reading at P, so a fee that arrives in
+    MISCELLANEOUS is a fee no sheet can reason about.
+
+    So the balance is split by what the fees were assessed at, and the row says
+    the split is an estimate. Half of a $50 bucket was paid, and each of the two
+    $25 fees carries half the remainder.
     """
     case = {
         'total_due': '$25.00',
@@ -543,5 +587,5 @@ def test_an_unattributable_payment_across_different_fees_still_falls_to_misc():
         ],
     }
     columns, note = crs.reconcile_financials(case)
-    assert columns == {'O': Decimal('25.00')}
-    assert note is not None
+    assert columns == {'P': Decimal('12.50'), 'K': Decimal('12.50')}
+    assert note is not None and 'estimates' in note


### PR DESCRIPTION
Iowa Legal Aid ran the new build against the current one on a real client and
sent back a regression: $60 of attorney fees had moved out of column J into
MISCELLANEOUS. Their words, on why that matters:

> we cannot do a 910.7 analysis, or SOL "strange barred" analysis. It will be
> a problem for bankruptcy as well because only Columns J and K (attorney fees
> and collection costs) are for sure dischargeable.

## What was happening

Reconciliation checks each of the five ICOS summary categories against the
itemization before it trusts the fee detail. A category that does not match is
reported as its summary total instead, which is right. It was reported into a
single column, which is not: the column came from running the category's own
label through `get_finance_column`, and no branch there matches the bare word
`COSTS`, so a COSTS category that failed to reconcile emptied everything it held
into MISCELLANEOUS. The attorney fee, the jail debt, the sheriff fee, together.

Across the 300 captured cases that was $15,881 sitting in MISCELLANEOUS, where
the 910.7 sheet (reads J through P) and the SOL sheet (old attorney fee and jail
debt by name) cannot see any of it.

## Fix, part one: fewer categories break

Fees are sorted into categories by reading the fee name, and for ten fees that
reading disagrees with what the clerk actually filed. `PROBATION REVOCATION FEE`
is filed under COSTS, not OTHER. `COLLECTION BY CO ATTY` is charged against the
fine. Those ten are now named, and the clerk's filing wins over the wording.

Measured individually and together over the 259 captured cases carrying both a
summary and an itemization. No override cost a category that already reconciled.

| | before | after |
|---|---|---|
| categories that add up | 555 / 674 | 600 / 655 |
| cases where the whole itemization reconciles | 201 / 259 | 228 / 259 |

The reported case is exactly this shape: its COSTS category was $200 short
because two $100 probation revocation fees had been read into OTHER, and the $60
attorney fee was in that same broken category.

## Fix, part two: a category that still breaks keeps its shape

Some categories will never reconcile. Instead of dumping the balance in one
column, it is apportioned across the columns its own fees belong to, weighted by
what each fee still shows as owed. Column V says the split is an estimate and to
request an accounting before relying on it. The total stays ICOS's; only the
split inside it is inferred.

Apportioning is the last resort. Line-level Paid is used where ICOS fills it in.
Where it is blank but exactly one combination of the category's fees adds up to
what the summary says was paid, those fees are settled and cannot draw a share
of the remainder.

That last guard is load-bearing. Remove it and the felony fixture, which exists
because Napier once reported $487.60 of collection costs on a case that did not
owe them, puts $60.09 into collection costs for a revenue fee its own summary
shows as paid in full. Both tests pinning it fail with exactly that number.

## Effect on 300 real cases

| column | before | after |
|---|---|---|
| J indigent defense | 5,152.77 | 5,821.09 |
| K collection costs | 0.00 | 0.00 |
| L jail / room & board | 3,060.00 | 11,387.56 |
| M sheriff fees | 1,087.18 | 1,514.73 |
| N probation | 0.00 | 800.00 |
| **O miscellaneous** | **15,881.21** | **5,134.35** |
| P unknown | 3,599.14 | 4,582.92 |

Rows where reconciliation gave up entirely: 18 to 9. Rows carrying a caveat in
column V: 9 to 5. Collection costs are $0.00 on both sides, so none of this
invents the debt the fixture guards against.

## Tests

926 pass. Seven changed; each pinned the old collapse and now pins a strictly
better answer, with the reasoning in a comment beside it. Both apportionment
guards were verified by removal.

Stacked on #102, so review that one first. Base is
`work/no-conviction-dischargeable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
