### PR TITLE
Keep a collection fee ICOS counted in the column it belongs to

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -1012,9 +1012,13 @@ def reconcile_financials(case):
     buckets = {name: [] for name in ICOS_BUCKETS}
     last_detail = None
     current = None
+    # A third party collection fee is normally ICOS listing a debt it does not
+    # count, so it is dropped before the buckets are checked. When this case's
+    # summary does count it, dropping it would break the bucket it belongs to.
+    keep_third_party = summary_counts_third_party(case)
     for row in rows:
         detail = row.get('detail') or ''
-        if is_excluded_fee(detail):
+        if is_excluded_fee(detail) and not keep_third_party:
             last_detail = None
             current = None
             continue
@@ -1179,8 +1183,51 @@ def is_excluded_fee(detail):
     leaves it out of the case totals entirely -- summing the itemization at face
     value put money in the collection-costs column that the defendant is not
     shown as owing.
+
+    Usually. summary_counts_third_party is the case-by-case check, because on
+    four of the nine captured cases carrying one of these fees ICOS did count it.
     """
     return "THIRD PARTY" in (detail or "").upper()
+
+
+def summary_counts_third_party(case):
+    """Whether this case's ICOS summary already includes its third party fees.
+
+    Of the nine captured cases carrying a third party collection fee, five leave
+    it out of the five bucket summary, which is what is_excluded_fee describes.
+    On the other four the itemization and the summary agree to the cent, and
+    that is ICOS saying it did count the fee.
+
+    Excluding the line on one of those four costs the fee breakdown rather than
+    the money. The bucket then falls short of its summary original, so it stops
+    reconciling and the balance comes back as a category total, spread over
+    whatever columns the rest of the bucket uses. That takes collection costs
+    out of column K, which is one of the two columns Iowa Legal Aid treats as
+    surely dischargeable in a bankruptcy.
+
+    All four of those captured cases are paid off, so nothing on the corpus
+    moves either way. This is here so that the first one that is not paid off
+    keeps its collection costs in column K.
+    """
+    categories = case.get('summary_categories') or []
+    rows = case.get('financials') or []
+    if not categories or not rows:
+        return False
+    if not any(is_excluded_fee(row.get('detail')) for row in rows):
+        return False
+
+    assessed = Decimal(0)
+    for row in rows:
+        # Rows with no amount are continuation payments against the line above,
+        # which the summary counts under that line rather than separately.
+        if row.get('amount') is not None:
+            assessed += Decimal(str(row['amount']))
+    summarised = Decimal(0)
+    for category in categories:
+        if category.get('original') is None:
+            return False
+        summarised += category['original']
+    return abs(assessed - summarised) <= Decimal('0.01')
 
 
 def summary_financials(case):

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -366,6 +366,86 @@ def test_third_party_fee_stays_out_of_the_partition(felony_case):
     assert Decimal('304.75') not in columns.values()
 
 
+def _third_party_case(other_original, other_paid):
+    """A case owing one ordinary OTHER fee and one third party collection fee.
+
+    other_original is what the ICOS summary says the OTHER bucket was assessed.
+    Set it to 40 and the summary has left the collection fee out, which is the
+    common shape. Set it to 100 and the summary has counted it.
+    """
+    def zero(label):
+        return {'label': label, 'original': Decimal('0'),
+                'paid': Decimal('0'), 'due': Decimal('0')}
+
+    original = Decimal(other_original)
+    paid = Decimal(other_paid)
+    return {
+        'total_due': '$%s' % (original - paid),
+        'summary_categories': [
+            zero('COSTS'), zero('FINE'), zero('SURCHARGE'), zero('RESTITUTION'),
+            {'label': 'OTHER', 'original': original, 'paid': paid,
+             'due': original - paid},
+        ],
+        'financials': [
+            {'detail': 'DELINQUENT REVOLVING FUND OBLIGATION',
+             'amount': '40.00', 'paid': None, 'paidDate': None},
+            {'detail': 'THIRD PARTY DEBT COLLECTION FEE',
+             'amount': '60.00', 'paid': None, 'paidDate': None},
+        ],
+    }
+
+
+def test_a_summary_that_leaves_the_third_party_fee_out_still_drops_it():
+    """The five captured cases of this shape, and the reason the rule exists.
+
+    The itemisation assesses 100 and the summary only 40, which is ICOS saying
+    the collection agency's 60 is not part of what it will collect. Column K
+    stays empty and the row reports the 40 ICOS stands behind.
+    """
+    columns, _ = crs.reconcile_financials(_third_party_case('40.00', '0'))
+    assert columns == {'P': Decimal('40.00')}
+
+
+def test_a_summary_that_counts_the_third_party_fee_keeps_it_in_column_k():
+    """The other four captured cases.
+
+    Here the itemisation and the summary both say 100, so ICOS did count the
+    collection fee. Dropping it would leave the bucket 60 short of its own
+    summary, and the whole balance would come back as a category total in
+    column P instead of splitting into the two fees that make it up.
+
+    Column K is one of the two columns Iowa Legal Aid treats as surely
+    dischargeable, so losing 60 out of it is not cosmetic.
+    """
+    columns, note = crs.reconcile_financials(_third_party_case('100.00', '0'))
+    assert columns == {'P': Decimal('40.00'), 'K': Decimal('60.00')}
+    assert note is None
+
+
+def test_the_check_is_the_summary_total_not_the_wording():
+    crs_case = _third_party_case('100.00', '0')
+    assert crs.summary_counts_third_party(crs_case) is True
+    assert crs.summary_counts_third_party(_third_party_case('40.00', '0')) is False
+
+
+def test_a_case_with_no_third_party_fee_is_not_affected():
+    """The check only ever answers a question about a fee that is there."""
+    case = _third_party_case('40.00', '0')
+    case['financials'] = [case['financials'][0]]
+    assert crs.summary_counts_third_party(case) is False
+
+
+def test_a_counted_third_party_fee_that_was_paid_off_owes_nothing():
+    """All four captured cases of this shape are paid in full.
+
+    The bucket reconciles, the payment is attributed to the lines that account
+    for it, and nothing is owed. This is the corpus today, and it is why the
+    change above moves no captured row.
+    """
+    columns, _ = crs.reconcile_financials(_third_party_case('100.00', '100.00'))
+    assert not columns or sum(columns.values()) == Decimal('0')
+
+
 @pytest.mark.parametrize("detail,bucket", [
     ("SHERIFFS FEES - LOCAL", "COSTS"),
     ("INDIGENT DEFENSE-FELONY-REIMBURSE STATE", "COSTS"),


### PR DESCRIPTION
Stacked on #105.

Napier drops every "THIRD PARTY" line out of the itemization before checking a
bucket against the ICOS summary, because ICOS usually lists the collection
agency's fee and then leaves it out of the case totals.

Nine captured cases carry one of these fees. Five leave it out, which is the
shape the rule was written for. Four count it: the itemization and the five
bucket summary agree to the cent.

On those four, dropping the line loses the fee breakdown rather than the money.
The bucket ends up short of its own summary original, stops reconciling, and the
balance comes back as a category total spread over whatever columns the rest of
the bucket uses. Column K is where it belonged, and column K is one of the two
Iowa Legal Aid treats as surely dischargeable. Taking the guard back out shows
it is worse than that: the whole row falls back to the summary and every fee
column on it goes with it.

The exclusion is now decided per case rather than by wording.

No captured row moves. All four cases ICOS counts are paid off, which is why
this never showed up: the bucket reconciles, the payment is attributed, and
nothing is owed either way.

While measuring this I ran the current build against production v55 over all 300
captured cases. Columns J through S equal the ICOS balance on 294 of 294 rows,
against 281 of 294 for production. Production overstates by $3,342.41 across 13
rows and puts a negative number in a fee column on 3 of them.

933 tests pass. The new tests fail against the code without the guard.
