### PR TITLE
Bring the corpus measurements up to date, and check them by recalculation

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -12,8 +12,16 @@ this repository.
 
 ## The SOL sheet does not account for all the debt
 
-On the 210 case workbook the SOL sheet totals $8,720.48 against $16,602.57
-owed. The missing $7,882.09 sits on 17 time-barred rows.
+On the 300 case workbook the SOL sheet totals $35,326.37 against $46,785.31
+owed. The missing $11,458.94 sits on 22 time-barred rows.
+
+Measured differently from the sections below, and the method is the point. The
+workbook was built through the shipping path and then recalculated by
+LibreOffice, so these are the numbers the formulas produce rather than numbers
+Python computed from the same inputs. The same run says the workbook carries no
+error value in any cell on any sheet, and that every one of the 300 cases
+reaches all nine sheets. BANKRUPTCY and EXEMPTIONS each total $46,785.31 and
+reconcile to CASE DATA exactly. SOL is the only sheet that does not.
 
 The formulas are the reason. A row past twenty years claims columns J and K in
 "STRANGE-BARRED" and column L in "20 year old Jail / Room & Board", and the
@@ -23,10 +31,10 @@ all. What falls out:
 
 | falls outside every SOL column | amount |
 |---|---|
-| sheriff fees | $794.15 |
-| miscellaneous | $340.93 |
-| unknown | $1,915.76 |
-| surcharges | $660.78 |
+| sheriff fees | $854.15 |
+| miscellaneous | $239.00 |
+| unknown | $4,582.92 |
+| surcharges | $1,612.40 |
 | fines | $442.50 |
 | victim restitution | $3,727.97 |
 
@@ -239,10 +247,24 @@ uncoded, and the case goes onto the sheet with the wording in column V so it is
 visibly uncoded rather than quietly miscoded:
 
 GUILTY PLEA/DEFAULT, VIOLATIONS HANDLED BY CLERK, BY TRIAL TO COURT, OTHER
-JUDGMENT, TRANSFERRED, SMALL CLAIM-DISPOSED BY CLERK, CHANGE OF VENUE, CLOSED.
+JUDGMENT, TRANSFERRED, SMALL CLAIM-DISPOSED BY CLERK, CHANGE OF VENUE, CLOSED,
+DEFAULTED, DEFERRED JUDGEMENT, DISCHARGE, CONVERTED TO SIMPLE MISDEMEANR.
 
 Whether VIOLATIONS HANDLED BY CLERK is a guilty plea decides what five sheets
 compute, which is why the code will not guess.
+
+The last four turned up only once the corpus passed 90 pages, so the list should
+be read as still growing rather than as finished. DEFERRED JUDGEMENT is the one
+worth answering first. It looks like a plain DEF, which is a code the licence and
+expungement sheets both test for, and it is the only wording here that names a
+CRS code outright.
+
+On the 300 case corpus this costs almost nothing, because a case-level status is
+only consulted where no count was adjudicated, and that is 8 cases. Two carry a
+status Napier cannot code, CLOSED with $197.43 and TRANSFERRED with none. The
+other six have no disposition of any kind and are genuinely pending. Both of the
+uncoded rows leave column G empty, which BANKRUPTCY, EXEMPTIONS and SOL all read
+as "open charge", and the row says so in column V.
 
 ## Smaller ones
 

--- a/crs.py
+++ b/crs.py
@@ -730,11 +730,14 @@ def get_dominant_charge(charges, case_id=None):
 def case_level_code(status):
     """The CRS code for ICOS's case-level status, or None if it is not one.
 
-    The status ICOS prints on the case summary is its own vocabulary. Across 90
+    The status ICOS prints on the case summary is its own vocabulary. Across 300
     captured pages it reads GUILTY PLEA/DEFAULT, VIOLATIONS HANDLED BY CLERK,
-    DISMISSED, BY TRIAL TO COURT, OTHER JUDGMENT, CLOSED, TRANSFERRED and SMALL
-    CLAIM-DISPOSED BY CLERK, and it overlaps the per-count adjudication wordings
-    at DISMISSED and nowhere else.
+    DISMISSED, BY TRIAL TO COURT, CLOSED, OTHER JUDGMENT, TRANSFERRED, SMALL
+    CLAIM-DISPOSED BY CLERK, DEFAULTED, DEFERRED JUDGEMENT, DISCHARGE and
+    CONVERTED TO SIMPLE MISDEMEANR, and it overlaps the per-count adjudication
+    wordings at DISMISSED and nowhere else. The last four appeared only after the
+    corpus passed 90 pages, which is the reason for reading it this way: the
+    vocabulary is still growing and a guess made now would be wrong later.
 
     Only the overlap is read. The rest are not translated here, because whether
     VIOLATIONS HANDLED BY CLERK is a guilty plea is a question about Iowa

--- a/tests/test_uncoded_case_status.py
+++ b/tests/test_uncoded_case_status.py
@@ -136,6 +136,36 @@ def test_the_case_status_is_not_reached_when_a_count_was_adjudicated():
     assert not cells['V'] or 'open charge' not in cells['V']
 
 
+# -- the vocabulary the refusal is built on ----------------------------------
+
+# Every case level status the 300 captured pages carry. The four at the end
+# appeared only after the corpus passed 90, which is why case_level_code will
+# not guess: the list is still growing.
+CASE_LEVEL_STATUSES = [
+    'GUILTY PLEA/DEFAULT', 'VIOLATIONS HANDLED BY CLERK', 'DISMISSED',
+    'BY TRIAL TO COURT', 'CLOSED', 'OTHER JUDGMENT', 'TRANSFERRED',
+    'SMALL CLAIM-DISPOSED BY CLERK', 'DEFAULTED', 'DEFERRED JUDGEMENT',
+    'DISCHARGE', 'CONVERTED TO SIMPLE MISDEMEANR',
+]
+
+
+def test_dismissed_is_the_only_wording_that_translates():
+    """The claim case_level_code's docstring makes, enforced rather than
+    asserted. A later change to the code map that starts translating one of
+    these silently changes what five sheets compute."""
+    translated = {s: crs.case_level_code(s) for s in CASE_LEVEL_STATUSES}
+    assert translated.pop('DISMISSED') == 'DISM'
+    assert set(translated.values()) == {None}, translated
+
+
+def test_deferred_judgement_at_case_level_is_still_not_a_code():
+    """The one most likely to be answered first, since it names a CRS code
+    outright and both the licence and expungement sheets test for DEF. Until
+    Iowa Legal Aid says so it stays uncoded, and this fails if that changes
+    without the open question being closed."""
+    assert crs.case_level_code('DEFERRED JUDGEMENT') is None
+
+
 # -- the wording, checked against the template it describes ------------------
 
 def test_the_three_sheets_really_do_read_an_empty_column_g_that_way():


### PR DESCRIPTION
Two numbers Napier reasons from were measured when the captured corpus was 90 or 210 cases. It is 300 now.

## The case-level status vocabulary

`case_level_code`'s docstring listed eight ICOS case-level statuses. There are twelve. `DEFAULTED`, `DEFERRED JUDGEMENT`, `DISCHARGE` and `CONVERTED TO SIMPLE MISDEMEANR` all appeared after the corpus passed 90 cases, which argues for the refusal the docstring defends rather than against it. `DISMISSED` is still the only wording overlapping the per-count vocabulary, and a test now holds that, since a code-map change that quietly starts translating one of these changes what five sheets compute.

`DEFERRED JUDGEMENT` is worth asking Iowa Legal Aid about first. It names a CRS code outright and both the licence and expungement sheets test for `DEF`.

## The SOL shortfall

At 300 cases the SOL sheet totals $35,326.37 against $46,785.31 owed. The missing $11,458.94 sits on 22 time-barred rows, and the per-column breakdown in `OPEN_QUESTIONS.md` is refreshed to match.

## How it was measured

The workbook was built through `build_workbook` and then recalculated by LibreOffice, so these are numbers the formulas produced rather than numbers Python computed from the same inputs. That run also found:

- no error value in any cell on any sheet
- all 300 cases reaching all nine sheets
- BANKRUPTCY and EXEMPTIONS both reconciling to CASE DATA to the cent

SOL is the only sheet that does not reconcile, which is the open question.

## One note for anyone auditing this later

Two things look like defects until the workbook is built the way Napier builds it. Driving `process_case` against the raw template leaves the analysis sheets short (SOL stops at 147 cases) and leaves the array-formula statute split throwing `#VALUE!` on every row. `extend_formula_grid` and `write_statute_split` already handle both, and neither runs if you skip `build_workbook`.

## Verified

946 pass, 2 new. No behaviour change in this PR: it is a docstring, a doc, and two tests that lock a claim the code already relies on.

Stacked on #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
