### PR TITLE
Stop a row claiming its money is in MISCELLANEOUS when it is not

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -6,9 +6,11 @@ They are places where the right answer is a legal judgement rather than a
 parsing one, so the code takes the conservative reading and says so.
 
 Numbers here come from replaying real ICOS cases through the shipping path. The
-corpus was 210 cases when the older sections below were measured and is 300 now,
-and each section says which. No client data, names or case numbers appear in
-this repository.
+corpus grows as counties are added to it: 210 cases when the oldest sections
+below were measured, 300 for most of them, 400 now. Each section says which it
+was measured against, and a section still quoting an older count has not been
+re-measured rather than been checked and found unchanged. No client data, names
+or case numbers appear in this repository.
 
 ## The SOL sheet does not account for all the debt
 
@@ -102,32 +104,46 @@ emailed out while the run is happening.
 Worth asking Iowa Legal Aid whether CLOSED means something specific in ICOS
 practice, because if it does, it is one line to map.
 
-## Room and board debt the appeal sheet cannot see
+## Why the appeal sheet is named after one county
 
 ICOS has one wording for jail and room and board,
-`REIMBURSE-SHERIFF-ROOM/BOARD/MEDICAL`, and it appears on 11 lines worth
-$18,907.56 across 10 of the 300 captured cases. Napier sends every one of them
-to CASE DATA column L,
-which is where the SOL sheet's column D reads from and where the whole POLK
-R&B APPEAL sheet reads from. The money only gets that far on cases whose
-itemization reconciled against ICOS's own category totals fee by fee. Where a
-category did not add up, the balance goes in as that category's total, and
-room and board is inside COSTS, so it lands in MISC with everything else.
+`REIMBURSE-SHERIFF-ROOM/BOARD/MEDICAL`. It appears on 12 lines worth
+$18,939.56 across 11 of the 400 captured cases. Napier sends every one of them
+to CASE DATA column L, which is where the SOL sheet's column D reads from and
+where the whole POLK R&B APPEAL sheet reads from.
 
-Five of the ten cases still owe money. Two of them reconcile, and their
-$3,060.00 of unpaid room and board reads off the appeal sheet the way an
-attorney would expect. The other three owe $11,080.66 between them, their
-itemizations show $8,420.23 of room and board unpaid, and the appeal sheet
-reports $0.00 for each.
+The reconciliation part of this is closed. Column L used to go empty whenever
+the surrounding category did not add up against its itemization, because room
+and board sits inside COSTS and the whole COSTS balance went to MISC. Since the
+fee breakdown change, an unreconciled balance is apportioned across the columns
+its own fees point at, and column L now agrees with the balance ICOS reports on
+all 11 cases to the cent. Seven of them have money in play, totalling
+$11,510.23.
 
-Napier does say so. CASE DATA column V carries the note naming which category
-totals did not add up. The appeal sheet has four columns and does not carry
-that note, so what a reader sees there is a zero that means Napier could not
-break the number out, printed identically to a zero that means the case has no
-room and board on it. Whether that sheet should be able to say which one it
-means is a question about the sheet.
+Anyone re-checking that by hand should know that ICOS lists instalment payments
+as continuation rows carrying a payment and no detail, so summing the assessed
+column against the first payment on each line overstates what is owed. Two of
+these cases look short by $92.67 and $98.00 that way and are correct.
 
-Offer to look at the reconciliation itself is open and unanswered.
+What is still open is the sheet. It is four columns wide, it has no county
+filter in any cell, and it reads every row of CASE DATA, so a workbook built
+for a client with no Polk cases in it still renders one line per case with
+Polk's name at the top. Of the 80 Polk cases now captured, one carries room and
+board and it is paid off. Every case in the corpus that does owe room and board
+is in Delaware, Linn or Wapello, which are the counties the sheet's own title
+says it is not about.
+
+So the question for Iowa Legal Aid is what that sheet is for. If the Polk
+county attorney's office is the only one that will hear a room and board
+appeal, the sheet wants a county filter and currently has none. If the name is
+historical and the sheet is really about room and board anywhere in Iowa, it
+wants renaming and nothing else. Nobody should have to guess which, and the
+answer decides whether a client outside Polk gets looked at.
+
+The narrower version of the same problem: the four columns do not carry column
+V's note, so a zero there reads identically whether the case has no jail debt
+or Napier could not break the number out. That matters less now that the
+breakdown holds, and it is still true.
 
 ## An ordinance conviction the expungement sheet cannot rule out
 

--- a/crs.py
+++ b/crs.py
@@ -1080,6 +1080,10 @@ def reconcile_financials(case):
     unreconciled = []
     apportioned = []
     carrying = []
+    # Which columns each category's balance actually reached. The note below
+    # describes where the money went, and the only way to describe that
+    # correctly is to have watched it land.
+    landed = {}
     for name in ICOS_BUCKETS:
         entries = buckets[name]
         category = summary[name]
@@ -1106,6 +1110,8 @@ def reconcile_financials(case):
                     apportioned.append(name)
                 for column, share in shares.items():
                     columns[column] = columns.get(column, Decimal(0)) + share
+                landed[name] = {column for column, share in shares.items()
+                                if share}
             continue
 
         if not entries:
@@ -1168,12 +1174,22 @@ def reconcile_financials(case):
                 % (_and_list(unreconciled),
                    "those balances are" if len(unreconciled) > 1
                    else "that balance is"))
+        # Only the categories whose balance really did end up in MISCELLANEOUS.
+        # Deciding this from the category's label instead said MISCELLANEOUS
+        # about any unreconciled COSTS, including the ones whose fees all
+        # pointed at one real column and were broken out there exactly. On the
+        # captured corpus that put a four figure jail debt in JAIL / ROOM &
+        # BOARD and then told the attorney it was a lump sum, which is the
+        # reading that loses a room-and-board appeal. A category that placed no
+        # money anywhere is not named at all: there is no cell to go look at.
         stranded = [name for name in unreconciled
-                    if name not in apportioned
-                    and get_finance_column(summary[name]['label']) == 'O']
-        if stranded:
-            text += (", and %s is in MISCELLANEOUS rather than in its own "
+                    if name not in apportioned and landed.get(name) == {'O'}]
+        if len(stranded) > 1:
+            text += (", and %s are in MISCELLANEOUS rather than in their own "
                      "columns" % _and_list(stranded))
+        elif stranded:
+            text += (", and %s is in MISCELLANEOUS rather than in its own "
+                     "columns" % stranded[0])
         notes.append(text + ". The rest of the row is fee by fee and the ICOS "
                             "total is still right.")
     if unresolved:

--- a/tests/test_misc_note_accuracy.py
+++ b/tests/test_misc_note_accuracy.py
@@ -1,0 +1,188 @@
+"""A row that broke its balance out correctly, told it did not.
+
+When a category will not reconcile against its own itemization, Napier takes
+the balance from the summary and asks the itemization only which columns it
+belongs in. Usually that is a split and the note says the split is an estimate.
+Sometimes every fee in the category points at one column, and then there is no
+estimate involved: the balance went to that column, exactly, and the note has
+nothing to add.
+
+The caveat that goes out with it was deciding what to say from the category's
+label instead. COSTS and OTHER both fall to MISCELLANEOUS when a label is all
+there is to go on, so any unreconciled COSTS balance was told it had landed in
+MISCELLANEOUS whether it had or not.
+
+Measured on the 300 captured cases, recalculated: five rows carry that claim
+and one of them is false. Its MISCELLANEOUS cell holds $0.00 and the $6,577.56
+the note is about is sitting in JAIL / ROOM & BOARD, broken out per fee. That
+column is the whole basis of the Polk room-and-board appeal sheet and half of
+the twenty year test on SOL, so a note telling an attorney the number is a
+lump sum costs the client the remedy rather than the money.
+
+Two smaller things in the same sentence. A category that placed no money at all
+was named alongside the ones that did, and the list read "COSTS and OTHER is in
+MISCELLANEOUS".
+
+Every case number and amount below is synthetic. The repo is public.
+"""
+
+import os
+import sys
+from decimal import Decimal
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+
+# A fine that reconciles to the cent. Without one category that adds up, the
+# whole row is unreconciled and reconcile_financials hands it back to the
+# caller, which says so in its own sentence and never reaches this note.
+FINE_LINE = {'detail': 'FINE', 'amount': Decimal('65.00'), 'paid': None}
+FINE_TOTAL = Decimal('65.00')
+
+CLAIM = 'MISCELLANEOUS'
+
+
+def _five(**due):
+    """The five bucket summary ICOS prints, everything zero by default."""
+    rows = []
+    for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER'):
+        original, paid = due.get(label, (Decimal('0'), Decimal('0')))
+        rows.append({'label': label, 'original': original, 'paid': paid,
+                     'due': original - paid})
+    return rows
+
+
+def _row(costs_original, lines):
+    """A COSTS balance the itemization will not account for, and its note."""
+    case = {
+        'summary_categories': _five(
+            COSTS=(Decimal(costs_original), Decimal('0')),
+            FINE=(FINE_TOTAL, Decimal('0'))),
+        'financials': [FINE_LINE] + list(lines),
+    }
+    columns, note = crs.reconcile_financials(case)
+    assert columns is not None, 'the row fell back to the summary'
+    return columns, note or ''
+
+
+def _fee(detail, amount):
+    return {'detail': detail, 'amount': Decimal(amount), 'paid': None}
+
+
+# Fees whose column is not in doubt, with the column each one lands in.
+ROOM_AND_BOARD = ('ROOM/BOARD FEES', 'L')
+SHERIFF = ('SHERIFFS FEES - LOCAL', 'M')
+INDIGENT_DEFENSE = ('INDIGENT DEFENSE-MISDM-REIMBURSE STATE', 'J')
+
+# Nothing in this wording names a fee, so it really does fall to MISCELLANEOUS.
+UNCATEGORISED = 'SYNTHETIC UNCATEGORISED LINE'
+
+
+# -- the defect --------------------------------------------------------------
+
+@pytest.mark.parametrize('detail,column',
+                         [ROOM_AND_BOARD, SHERIFF, INDIGENT_DEFENSE])
+def test_a_balance_that_landed_in_one_real_column_is_not_called_miscellaneous(
+        detail, column):
+    """Every fee in the category points at the same column, so the balance went
+    there whole. There is no MISCELLANEOUS in it to warn about."""
+    columns, note = _row('6577.56', [_fee(detail, '1000.00')])
+    assert columns[column] == Decimal('6577.56')
+    assert not columns.get('O')
+    assert CLAIM not in note, note
+
+
+def test_the_note_still_says_the_category_did_not_reconcile():
+    """Only the claim about MISCELLANEOUS is wrong. That the balance is ICOS's
+    category total rather than a per-fee breakdown is true and has to survive,
+    or the fix has thrown away the warning instead of correcting it."""
+    _columns, note = _row('6577.56', [_fee(ROOM_AND_BOARD[0], '1000.00')])
+    assert 'COSTS' in note, note
+    assert 'did not add up' in note, note
+
+
+def test_a_category_that_placed_no_money_is_not_named():
+    """An uncategorised line lands in the OTHER bucket, which the summary
+    reports as $0.00. OTHER fails to reconcile and has no balance to put
+    anywhere, so naming it sends someone to look at an empty cell."""
+    columns, note = _row('100.00', [_fee(UNCATEGORISED, '10.00')])
+    assert columns['O'] == Decimal('100.00'), 'the COSTS balance is in O'
+    # The money in MISCELLANEOUS is the COSTS balance. OTHER contributed none.
+    assert 'OTHER is in' not in note, note
+    assert 'and OTHER' not in note.split('did not add up')[-1], note
+
+
+# -- and the row the warning was written for still gets it -------------------
+
+def test_a_balance_that_really_is_in_miscellaneous_is_still_called_out():
+    """The guard. This is the case the sentence exists for, and it is the one
+    where MISCELLANEOUS means the fee cannot be reasoned about on any sheet."""
+    columns, note = _row('100.00', [_fee(UNCATEGORISED, '10.00')])
+    assert columns['O'] == Decimal('100.00')
+    assert CLAIM in note, note
+    assert 'COSTS is in %s' % CLAIM in note, note
+
+
+def test_an_apportioned_split_says_nothing_about_miscellaneous():
+    """Unchanged behaviour, asserted because it is the other half of the same
+    condition: a balance divided across columns is described by the estimate
+    sentence, not this one."""
+    columns, note = _row('100.00', [_fee(ROOM_AND_BOARD[0], '30.00'),
+                                    _fee(SHERIFF[0], '20.00')])
+    assert columns['L'] and columns['M']
+    assert CLAIM not in note, note
+    assert 'estimates' in note, note
+
+
+def test_a_category_with_no_itemization_at_all_still_falls_to_its_label():
+    """With no fees to read, the label is all there is and the balance really
+    does go to MISCELLANEOUS. The note has to keep saying so."""
+    columns, note = _row('100.00', [_fee('SYNTHETIC RESTITUTION LINE', '5.00')])
+    # The COSTS bucket is empty, so the balance falls back to the label column.
+    assert columns['O'] == Decimal('100.00')
+    assert 'COSTS is in %s' % CLAIM in note, note
+
+
+# -- the sentence itself -----------------------------------------------------
+
+def test_two_stranded_categories_read_as_plural():
+    """Naming two categories and then saying "is" reads as a bug in the row to
+    anyone who notices, which is not what you want on the one line telling an
+    attorney how much of the number to trust."""
+    case = {
+        'summary_categories': _five(COSTS=(Decimal('100.00'), Decimal('0')),
+                                    OTHER=(Decimal('50.00'), Decimal('0')),
+                                    FINE=(FINE_TOTAL, Decimal('0'))),
+        'financials': [FINE_LINE,
+                       _fee(UNCATEGORISED, '10.00'),
+                       _fee('SYNTHETIC COURT COSTS LINE', '7.00')],
+    }
+    columns, note = crs.reconcile_financials(case)
+    note = note or ''
+    assert columns is not None
+    assert CLAIM in note, note
+    assert 'COSTS and OTHER are in' in note, note
+    assert 'their own columns' in note, note
+    assert 'OTHER is in' not in note, note
+
+
+# -- the property the sentence is supposed to have ---------------------------
+
+@pytest.mark.parametrize('lines', [
+    [_fee(ROOM_AND_BOARD[0], '1000.00')],
+    [_fee(SHERIFF[0], '50.00')],
+    [_fee(INDIGENT_DEFENSE[0], '60.00')],
+    [_fee(UNCATEGORISED, '10.00')],
+    [_fee(ROOM_AND_BOARD[0], '30.00'), _fee(SHERIFF[0], '20.00')],
+    [_fee(UNCATEGORISED, '10.00'), _fee(SHERIFF[0], '20.00')],
+])
+def test_the_claim_is_never_made_against_an_empty_miscellaneous_cell(lines):
+    """What the note is allowed to say, stated as the rule rather than case by
+    case: if the row says money is in MISCELLANEOUS then MISCELLANEOUS holds
+    money. Every one of these shapes came off a real captured itemization."""
+    columns, note = _row('100.00', lines)
+    if CLAIM in note:
+        assert columns.get('O'), (columns, note)


### PR DESCRIPTION
## What this is

When a category will not reconcile against its own itemization, Napier takes the balance from the summary and asks the itemization only which columns it belongs in. Often that is a split, and the note says the split is an estimate. Sometimes every fee in the category points at one column, and then nothing is being estimated: the balance went there, exactly.

The caveat that went out with it was decided from the category's **label**. COSTS and OTHER both fall to MISCELLANEOUS when a label is all there is to go on, so any unreconciled COSTS balance was told it had landed in MISCELLANEOUS whether it had or not.

## Measured, not argued

Replaying the 400 captured cases through `reconcile_financials`:

| | rows claiming MISCELLANEOUS | of those, false |
|---|---|---|
| before | 20 | 16 |
| after | 2 | 0 |

Four of the changed rows were opened up and checked against their raw itemizations by hand:

- Two rows: a $100.00 COSTS balance really did land in MISCELLANEOUS. Claim kept.
- One Polk row: the $100.00 in MISCELLANEOUS is a filing fee that reconciled fee by fee. OTHER placed no money at all, so the note pointed at money that was not its own.
- One Linn row: the note said OTHER was in MISCELLANEOUS when its $821.85 is in UNKNOWN. Wrong column entirely.

## Why it matters more than a wording slip

The worst case on the corpus is a row whose note says its balance is a lump sum while $6,577.56 is sitting correctly broken out in JAIL / ROOM & BOARD. That column is the entire basis of the POLK R&B APPEAL sheet and half the twenty year test on SOL. Telling an attorney a correct number cannot be trusted costs the client the remedy rather than the money, and it is the harder error to catch, because the row looks careful about itself.

## Also in the same sentence

- A category that placed no money anywhere is no longer named. There is no cell to go and look at.
- Two names no longer read "COSTS and OTHER **is** in MISCELLANEOUS".

## Tests

15 new tests in `tests/test_misc_note_accuracy.py`, including a property test stating the rule directly: if the row says money is in MISCELLANEOUS, then MISCELLANEOUS holds money. 10 of the 15 fail against the unfixed code, all as assertion failures rather than errors.

Suite: **961 passing**, up from 946.

## Second commit

`OPEN_QUESTIONS.md` has been carrying a room and board section that stopped being true when the fee breakdown change landed. It claimed three cases with $8,420.23 of unpaid jail debt reported $0.00 on the appeal sheet. Re-measured on 400 cases: 11 carry room and board, and column L agrees with ICOS on every one to the cent.

What replaces it is the question the corpus now raises. POLK R&B APPEAL has no county filter in any cell and reads every row of CASE DATA. Of the 80 Polk cases captured, one carries room and board and it is paid off. Every case that owes any is in Delaware, Linn or Wapello. Either that sheet wants a filter or it wants renaming, and which one decides whether a client outside Polk gets looked at. **That one needs Iowa Legal Aid.**

No client data, names or case numbers in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t