### PR TITLE
Read a structured fine's parts as the costs they are

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -264,6 +264,39 @@ collection cost, which would put it in column K where the statute of
 limitations sheet can see it, but calling it that is a decision about what the
 county attorney fee is rather than about what the page says.
 
+## What a structured fine is made of
+
+A structured fine is the instalment arrangement, not the debt. A clerk
+itemizing one writes each component fee with the arrangement's name attached,
+so the itemization carries `INDIGENT DEFENSE-STRUC FINES-REIMB STATE`,
+`COURT REPORTER SERVICES STRUC FINE`, `TIME PAYMENT FEES-STRUCTURED FINES` and
+`DOCKET PROC - STRUCT FINE ABOVE SIMP` alongside the fine itself. Napier read
+all four as fines, because it tested for the word FINE before it tested for
+anything more specific.
+
+The clerk settled this rather than us. On two Polk cases the itemization ran
+$79.00 over the summary's FINE and $79.00 under its COSTS, and $79.00 is
+exactly those four fees, twice, to the cent. That is the shortfall and matching
+excess the partition check exists to catch, so it caught it, and both rows told
+the staffer their balances could not be broken down fee by fee. Only
+`FINES AND FORFEITED BAIL-STRUCTURED FINES` matched the summary's FINE on the
+nose. They are court costs collected under a fine arrangement, and they are
+filed that way now.
+
+Worth confirming with Iowa Legal Aid all the same, because two cases from one
+county is thin evidence for a rule, even when both are exact. If some other
+county's clerk files them the other way, the partition check will say so by
+failing rather than by being quietly wrong, which is the reason to leave the
+check alone rather than loosen it.
+
+The same change fixed a surcharge that was missing its category by two letters.
+ICOS abbreviates the word when the wording runs long, and
+`DOMESTIC/SEXUAL ABUSE, STALKING, HUMAN TRAFF VICTIM SURCH` runs long. Napier
+now reads SURCH. Nothing in 400 captured cases contains those letters and is
+not a surcharge, and a test pins the wordings that were checked, but the
+abbreviation is a guess about ICOS's habits rather than something the page
+states.
+
 ## Refundables counted as a payment
 
 `REFUNDABLES DUE TO PREPAID EXPENSES` shows up on 14 lines worth $681.69, and

--- a/crs.py
+++ b/crs.py
@@ -770,7 +770,36 @@ def get_finance_column(detail):
         return "P" # UNKNOWN
     if "DELINQUENT REVOLVING FUND" in detail:
         return "P" # UNKNOWN
-        
+
+    # These four are read before the word FINE is looked for, and that order is
+    # the whole point of them.
+    #
+    # A structured fine is Iowa's instalment arrangement, and a clerk itemizing
+    # one writes each component fee with the arrangement's name attached:
+    # "INDIGENT DEFENSE-STRUC FINES-REIMB STATE", "COURT REPORTER SERVICES
+    # STRUC FINE", "TIME PAYMENT FEES-STRUCTURED FINES", "DOCKET PROC - STRUCT
+    # FINE ABOVE SIMP". The trailing words say how the money is being
+    # collected. The leading words say what it is, and what it is decides the
+    # column. Matching on FINE anywhere in the string read all four as fines,
+    # so a reimbursement to the state public defender came out in FINES, where
+    # the expungement sheet cannot see it at all and the bankruptcy sheet calls
+    # it not dischargeable.
+    #
+    # SURCH rather than SURCHARGE because ICOS abbreviates it when the wording
+    # runs long, and "DOMESTIC/SEXUAL ABUSE, STALKING, HUMAN TRAFF VICTIM
+    # SURCH" runs long. Missing it by those two letters put a victim surcharge
+    # in MISCELLANEOUS, which the bankruptcy sheet calls possibly dischargeable
+    # and the exemption sheet covers with every exemption, when a surcharge is
+    # neither. Nothing in 400 captured cases contains SURCH and is not one.
+    if "INDIGENT DEFENSE" in detail:
+        return "J" # INDIGENT DEFENSE
+    if "SURCH" in detail:
+        return "Q" # SURCHARGE
+    if "COURT REPORTER" in detail:
+        return "O" # MISC, as the fee reads without the qualifier
+    if "TIME PAYMENT" in detail or "DOCKET PROC" in detail:
+        return "O" # MISC, as the fee reads without the qualifier
+
     if "FINE" in detail:
         return "R" # FINE
     if "DEFERRED JUDGMENT CIVIL PENALTY" in detail:
@@ -790,12 +819,6 @@ def get_finance_column(detail):
     #    return "J" # FILING
     #if "OTHER SIMPLE MISDEMEANORS" in detail:
     #    return "J" # FILING
-
-    if "INDIGENT DEFENSE" in detail:
-        return "J" # INDIGENT DEFENSE
-
-    if "SURCHARGE" in detail:
-        return "Q" # SURCHARGE
 
     if "ROOM/BOARD" in detail:
         return "L" # JAIL / ROOM & BOARD
@@ -873,6 +896,18 @@ SUMMARY_BUCKET_OVERRIDES = (
     # The county attorney's collection fee is charged against the fine and the
     # summary counts it there, not in OTHER where its wording lands it.
     ('COLLECTION BY CO ATTY', 'FINE'),
+    # A structured fine is Iowa's instalment arrangement, and a clerk itemizing
+    # one writes each component fee with the arrangement's name attached. These
+    # four are court costs collected under that arrangement, and the word FINE
+    # in their wording describes how they are being collected rather than what
+    # they are. The clerk agrees: on two Polk cases the itemization ran $79.00
+    # over the summary's FINE and $79.00 under its COSTS, and $79.00 is exactly
+    # these four fees, twice, to the cent. Only the fine itself, FINES AND
+    # FORFEITED BAIL-STRUCTURED FINES, matched the summary's FINE on the nose.
+    ('INDIGENT DEFENSE-STRUC FINES', 'COSTS'),
+    ('COURT REPORTER SERVICES STRUC FINE', 'COSTS'),
+    ('TIME PAYMENT FEES-STRUCTURED FINES', 'COSTS'),
+    ('DOCKET PROC - STRUCT FINE', 'COSTS'),
 )
 
 
@@ -889,7 +924,14 @@ def get_summary_bucket(detail):
     for marker, bucket in SUMMARY_BUCKET_OVERRIDES:
         if marker in text:
             return bucket
-    if 'SURCHARGE' in text:
+    # SURCH, not SURCHARGE, for the same reason get_finance_column reads it that
+    # way: ICOS abbreviates the word when the wording runs long. Missing it here
+    # is not a cosmetic miss. A surcharge read into OTHER leaves the SURCHARGE
+    # bucket short by exactly that amount and OTHER over by exactly that amount,
+    # which is the shortfall-and-matching-excess this partition check is built to
+    # catch, so both buckets fail and the row tells the staffer two categories
+    # could not be broken down when the only thing wrong was two missing letters.
+    if 'SURCH' in text:
         return 'SURCHARGE'
     if 'RESTITUTION' in text:
         return 'RESTITUTION'

--- a/tests/test_structured_fine.py
+++ b/tests/test_structured_fine.py
@@ -1,0 +1,225 @@
+"""Fees read by how they are collected instead of by what they are.
+
+A structured fine is Iowa's instalment arrangement for court debt. A clerk
+itemizing one writes each component fee with the arrangement's name attached,
+so the itemization carries lines like "INDIGENT DEFENSE-STRUC FINES-REIMB
+STATE" and "TIME PAYMENT FEES-STRUCTURED FINES". The trailing words say how the
+money is being collected. The leading words say what it is. Napier tested for
+the word FINE anywhere in the wording, before it tested for anything more
+specific, so all four component fees were read as fines.
+
+Two things went wrong at once, and the second is the one that gives the first
+away.
+
+The clerk does not agree. On two Polk cases in the 400 case corpus the
+itemization ran $79.00 over the summary's FINE total and $79.00 under its COSTS
+total, and $79.00 is exactly these four fees, twice, to the cent. That
+shortfall-and-matching-excess is the signature reconcile_financials exists to
+catch, so both categories failed their partition check and both rows told the
+staffer their balances could not be broken down fee by fee. Only the fine
+itself, FINES AND FORFEITED BAIL-STRUCTURED FINES, matched the summary's FINE
+on the nose.
+
+And within a category that does reconcile, the reimbursement to the state
+public defender came out in FINES rather than INDIGENT DEFENSE. The
+expungement sheet reads columns J through P and cannot see FINES at all, the
+bankruptcy sheet calls FINES not dischargeable, and the statute of limitations
+sheet looks for old attorney fee debt in J and K. So $30.00 of indigent defense
+debt was invisible to three sheets and wrongly counted by a fourth.
+
+The same two letters cost a victim surcharge its category. ICOS abbreviates the
+word when the wording runs long, and "DOMESTIC/SEXUAL ABUSE, STALKING, HUMAN
+TRAFF VICTIM SURCH" runs long. Napier tested for SURCHARGE, missed it, and a
+$100.00 surcharge landed in OTHER, which left the SURCHARGE bucket short by
+exactly $100.00 and OTHER over by exactly $100.00 on a third Polk case, failing
+both.
+
+Measured across the corpus, the fix clears three false "did not add up"
+warnings and takes one case from a category total to a real fee breakdown. It
+moves no money there, because those three rows are either paid off or land in
+the same column either way. The money in the first test below is what happens
+when they do not.
+
+Every case number and amount below is synthetic. The repo is public.
+"""
+
+import os
+import sys
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+
+
+def _five(**totals):
+    """The five bucket summary ICOS prints, everything zero by default."""
+    rows = []
+    for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER'):
+        original = Decimal(totals.get(label, '0'))
+        rows.append({'label': label, 'original': original,
+                     'paid': Decimal('0'), 'due': original})
+    return rows
+
+
+def _fee(detail, amount):
+    return {'detail': detail, 'amount': Decimal(amount), 'paid': None}
+
+
+# The shape of the two Polk structured fine cases, with the balance still owed
+# rather than paid off, which is the only difference that matters here.
+STRUCTURED_FINE = {
+    'id': '00000  SRCR000000',
+    'summary_categories': _five(COSTS='85.00', FINE='232.00',
+                                SURCHARGE='69.60'),
+    'financials': [
+        _fee('DNU-DOCKET PROC - STRUCT FINE ABOVE SIMP', '30.00'),
+        _fee('DNU-COURT REPORTER SERVICES STRUC FINE', '15.00'),
+        _fee('DNU-SURCHARGE STRUCTURED FINES', '69.60'),
+        _fee('DNU-FINES AND FORFEITED BAIL-STRUCTURED FINES', '232.00'),
+        _fee('DNU-TIME PAYMENT FEES-STRUCTURED FINES', '10.00'),
+        _fee('INDIGENT DEFENSE-MISDM-REIMBURSE STATE', '6.00'),
+        _fee('DNU-INDIGENT DEFENSE-STRUC FINES-REIMB STATE', '6.00'),
+        _fee('DNU-INDIGENT DEFENSE-STRUC FINES-REIMB STATE', '18.00'),
+    ],
+}
+
+# The shape of the victim surcharge case. The surcharge is the last line, and
+# without it the SURCHARGE category is $100.00 short of what ICOS says.
+VICTIM_SURCHARGE = {
+    'id': '00000  FECR000000',
+    'summary_categories': _five(COSTS='1365.78', FINE='1250.00',
+                                SURCHARGE='537.50'),
+    'financials': [
+        _fee('FILING AND DOCKETING FEES CRIMINAL', '100.00'),
+        _fee('DNU-SURCHARGE ALL STATE CHARGES', '218.75'),
+        _fee('DNU-SURCHARGE ALL STATE CHARGES', '218.75'),
+        _fee('DNU-FINES/FORFEITED BAIL/CIVIL PENALTY', '625.00'),
+        _fee('DNU-FINES/FORFEITED BAIL/CIVIL PENALTY', '625.00'),
+        _fee('INDIGENT DEFENSE-MISC-REIMBURSE STATE', '109.75'),
+        _fee('INDIGENT DEFENSE-MISC-REIMBURSE STATE', '82.50'),
+        _fee('INDIGENT DEFENSE-MISC-REIMBURSE STATE', '68.75'),
+        _fee('INDIGENT DEFENSE-MISC-REIMBURSE STATE', '82.50'),
+        _fee('INDIGENT DEFENSE-MISC-REIMBURSE STATE', '82.50'),
+        _fee('INDIGENT DEFENSE-FELONY-REIMBURSE STATE', '839.78'),
+        _fee('DOMESTIC/SEXUAL ABUSE, STALKING, HUMAN TRAFF VICTIM SURCH',
+             '100.00'),
+    ],
+}
+
+
+# -- what the client reads off the workbook ----------------------------------
+
+def test_indigent_defence_collected_as_a_structured_fine_is_still_indigent_defence():
+    columns, note = crs.reconcile_financials(STRUCTURED_FINE)
+    assert columns is not None, 'the whole row fell back to the summary'
+    assert note is None, note
+    assert columns == {
+        'J': Decimal('30.00'),    # INDIGENT DEFENSE, the three reimbursements
+        'O': Decimal('55.00'),    # MISCELLANEOUS, docket, reporter, time payment
+        'Q': Decimal('69.60'),    # SURCHARGES
+        'R': Decimal('232.00'),   # FINES, the fine itself and nothing else
+    }, columns
+
+
+def test_the_structured_fine_row_still_adds_up_to_what_icos_says():
+    columns, _ = crs.reconcile_financials(STRUCTURED_FINE)
+    owed = sum(category['due']
+               for category in STRUCTURED_FINE['summary_categories'])
+    assert sum(columns.values()) == owed == Decimal('386.60'), columns
+
+
+def test_an_abbreviated_victim_surcharge_reconciles_as_a_surcharge():
+    columns, note = crs.reconcile_financials(VICTIM_SURCHARGE)
+    assert columns is not None, 'the whole row fell back to the summary'
+    # The note names categories that could not be broken down. Before the fix
+    # it named SURCHARGE and OTHER, and neither was really in doubt: the $100
+    # was in the wrong one of the two.
+    assert note is None, note
+    assert columns == {
+        'J': Decimal('1265.78'),
+        'O': Decimal('100.00'),
+        'Q': Decimal('537.50'),   # $437.50 of state surcharge plus the $100
+        'R': Decimal('1250.00'),
+    }, columns
+
+
+# -- the classification itself ------------------------------------------------
+
+def test_a_structured_fine_component_is_a_cost():
+    for detail in ('DNU-INDIGENT DEFENSE-STRUC FINES-REIMB STATE',
+                   'DNU-COURT REPORTER SERVICES STRUC FINE',
+                   'DNU-TIME PAYMENT FEES-STRUCTURED FINES',
+                   'DNU-DOCKET PROC - STRUCT FINE ABOVE SIMP'):
+        assert crs.get_summary_bucket(detail) == 'COSTS', detail
+
+
+def test_the_fine_in_a_structured_fine_is_still_a_fine():
+    detail = 'DNU-FINES AND FORFEITED BAIL-STRUCTURED FINES'
+    assert crs.get_summary_bucket(detail) == 'FINE'
+    assert crs.get_finance_column(detail) == 'R'
+
+
+# Every wording in the 400 case corpus carrying one of the words this change
+# reorders around, with the bucket and the column it has to keep. The fix works
+# by testing four specific fees before the general test for FINE, and the way
+# that goes wrong is by catching something it was never meant to.
+CLASSIFICATION = (
+    ('STATE FINES/COUNTY SPEED,WEIGHT,COPYCAT ORDINANCES', 'FINE', 'R'),
+    ('DNU-FINES/FORFEITED BAIL/CIVIL PENALTY', 'FINE', 'R'),
+    ('FINE-DRIVING-NO PROOF OF INSURANCE', 'FINE', 'R'),
+    ('DNU-FINES AND FORFEITED BAIL-STRUCTURED FINES', 'FINE', 'R'),
+    ('DNU-CITY/COUNTY FINES/FORFEITED BAIL', 'FINE', 'R'),
+    ('CITY FINES', 'FINE', 'R'),
+    ('DOT FINES', 'FINE', 'R'),
+    ('DNU-CITY FINES AND FORFEITED BAIL-NON-TRAFFIC', 'FINE', 'R'),
+    ('DEFERRED JUDGMENT CIVIL PENALTY A-R', 'FINE', 'R'),
+    ('DNU-SURCHARGE ALL STATE CHARGES', 'SURCHARGE', 'Q'),
+    ('DNU-LAW ENFORCEMENT INITIATIVE SURCHARGE', 'SURCHARGE', 'Q'),
+    ('CRIME SERVICES SURCHARGE', 'SURCHARGE', 'Q'),
+    ('DNU-DRUG ABUSE SURCHARGE', 'SURCHARGE', 'Q'),
+    ('DNU-SURCHARGE ALL LOCAL CHARGES', 'SURCHARGE', 'Q'),
+    ('DNU-COUNTY ENFORCEMENT SURCHARGE', 'SURCHARGE', 'Q'),
+    ('DNU-CONTEMPT OF DOM ABUSE PROTECTIVE ORDER SURCHARGE', 'SURCHARGE', 'Q'),
+    ('DNU-SURCHARGE, FOR ALL LOCAL CHARGES', 'SURCHARGE', 'Q'),
+    ('DNU-SURCHARGE STRUCTURED FINES', 'SURCHARGE', 'Q'),
+    # Column P because a delinquent revolving fund obligation is money ICOS
+    # will not say the nature of, which is a separate open question.
+    ('DNU-DELINQUENT REVOLVING FUND OBLIGATION--SURCHARGES', 'SURCHARGE', 'P'),
+    ('DOMESTIC/SEXUAL ABUSE, STALKING, HUMAN TRAFF VICTIM SURCH',
+     'SURCHARGE', 'Q'),
+    ('INDIGENT DEFENSE-FELONY-REIMBURSE STATE', 'COSTS', 'J'),
+    ('INDIGENT DEFENSE-MISDM-REIMBURSE STATE', 'COSTS', 'J'),
+    ('INDIGENT DEFENSE-MISC-REIMBURSE STATE', 'COSTS', 'J'),
+    ('INDIGENT DEFENSE-MISDEMEANOR-REIMBURSE COUNTY', 'COSTS', 'J'),
+    ('COURT REPORTER SERVICES', 'COSTS', 'O'),
+    ('DNU-DOCKET PROC - STRUCT FINE ABOVE SIMP', 'COSTS', 'O'),
+    ('DNU-INDIGENT DEFENSE-STRUC FINES-REIMB STATE', 'COSTS', 'J'),
+    ('DNU-COURT REPORTER SERVICES STRUC FINE', 'COSTS', 'O'),
+    ('DNU-TIME PAYMENT FEES-STRUCTURED FINES', 'COSTS', 'O'),
+)
+
+
+def test_every_fee_with_fine_or_surcharge_in_its_wording_is_classified():
+    wrong = []
+    for detail, bucket, column in CLASSIFICATION:
+        got = (crs.get_summary_bucket(detail), crs.get_finance_column(detail))
+        if got != (bucket, column):
+            wrong.append('%s: wanted %s, got %s' % (detail, (bucket, column),
+                                                    got))
+    assert not wrong, wrong
+
+
+def test_nothing_reads_the_abbreviation_as_a_word_of_its_own():
+    """SURCH is short for SURCHARGE and never appears inside anything else.
+
+    This is the risk the abbreviation carries: matching two letters short of a
+    word matches more than the word. Across 400 captured cases nothing does,
+    and the corpus is the only place that can be checked, so this pins the
+    wordings that are in it.
+    """
+    for detail, bucket, _ in CLASSIFICATION:
+        if 'SURCH' in detail:
+            assert bucket == 'SURCHARGE', detail
+        if bucket == 'SURCHARGE':
+            assert 'SURCH' in detail, detail


### PR DESCRIPTION
A structured fine is Iowa's instalment arrangement, not the debt. A clerk itemizing one writes each component fee with the arrangement's name attached, so the page carries `INDIGENT DEFENSE-STRUC FINES-REIMB STATE`, `COURT REPORTER SERVICES STRUC FINE`, `TIME PAYMENT FEES-STRUCTURED FINES` and `DOCKET PROC - STRUCT FINE ABOVE SIMP` next to the fine itself. Napier tested for the word FINE before it tested for anything more specific, so all four came out as fines.

The clerk settled it rather than us. On two Polk cases the itemization ran $79.00 over the summary's FINE and $79.00 under its COSTS, and $79.00 is exactly those four fees, twice, to the cent. That shortfall and matching excess is what the partition check exists to catch, so it caught it, and both rows told the staffer their balances could not be broken down fee by fee. Only `FINES AND FORFEITED BAIL-STRUCTURED FINES` matched the summary's FINE on the nose.

Within a category that does reconcile, the same misreading put the reimbursement to the state public defender in FINES. The expungement sheet reads J through P and cannot see FINES at all, bankruptcy calls it not dischargeable, and the statute of limitations sheet looks for old attorney fee debt in J and K. The test builds that row with a balance still owed and $30.00 moves from MISCELLANEOUS to INDIGENT DEFENSE.

Two letters cost a victim surcharge its category the same way. ICOS abbreviates the word when the wording runs long, and `DOMESTIC/SEXUAL ABUSE, STALKING, HUMAN TRAFF VICTIM SURCH` runs long. A $100.00 surcharge landed in OTHER, leaving SURCHARGE short by exactly $100.00 and OTHER over by exactly $100.00 on a third Polk case, failing both. Napier reads SURCH now, in the bucket as well as the column.

## What it is worth, measured

Across all 400 captured cases: three false "did not add up" warnings clear, and one row goes from a category total to a real fee breakdown. **No money moves on the corpus.** Those three rows are either paid off or land in the same column either way, so the totals were right by luck. The $30.00 above is a constructed row showing what happens when they are not.

Stating that plainly because the fix is worth having on the mechanism rather than on a number: the partition check was firing on a fee classification error, which is exactly the situation its own comment says it exists to detect, and it was being read as the itemization being untrustworthy instead.

## Proof

Backing the change out: 4 tests fail with real assertion failures, 3 pass either way (they are the guards).

```
FAILED test_indigent_defence_collected_as_a_structured_fine_is_still_indigent_defence
FAILED test_an_abbreviated_victim_surcharge_reconciles_as_a_surcharge
FAILED test_a_structured_fine_component_is_a_cost
FAILED test_every_fee_with_fine_or_surcharge_in_its_wording_is_classified
4 failed, 3 passed
```

`test_every_fee_with_fine_or_surcharge_in_its_wording_is_classified` pins all 29 corpus wordings carrying FINE or SURCH with the bucket and column each has to keep, because the way a reordering like this goes wrong is by catching something it was never meant to.

Full suite 968 to 975.

## Open question

`OPEN_QUESTIONS.md` carries it: two cases from one county is thin evidence for a rule even when both are exact, so this is worth confirming with Iowa Legal Aid. If another county's clerk files them the other way the partition check will say so by failing, which is the reason to leave the check alone rather than loosen it.