### PR TITLE
Set aside collection fees the clerk's own summary leaves out

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -264,6 +264,22 @@ collection cost, which would put it in column K where the statute of
 limitations sheet can see it, but calling it that is a decision about what the
 county attorney fee is rather than about what the page says.
 
+Two captured cases complicate the county attorney fee further: their own
+summaries leave it out of the balance entirely. A Black Hawk felony case
+counts its state and county collection splits under FINE and not the bare
+fee, so the itemization ran over the summary by exactly that fee. A Union
+County case lists every collection fee, plus a second ledger entry for an
+already paid surcharge, identical wording and amount but no payment, no
+receipt and no date, and counts none of them; the raw ICOS page carries those
+rows itself, so they read as superseded entries from the collection process
+rather than debt. Napier now sets such rows aside case by case, and only when
+the clerk's own totals prove it: the itemization has to exceed the summary by
+exactly those rows, every category has to reconcile to the cent once they are
+gone, and no other reading of the page can manage the same. So the
+classification question above is really two questions about one fee: which
+column it belongs in when it is owed, and whether ICOS considers it owed at
+all, which the summaries answer differently on different cases.
+
 ## What a structured fine is made of
 
 A structured fine is the instalment arrangement, not the debt. A clerk

--- a/crs.py
+++ b/crs.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 
 from calendar import monthrange
@@ -1065,6 +1066,47 @@ def spread_over_fee_columns(due, entries, paid=None):
     return shares
 
 
+def _bucket_partition(rows, keep_third_party, skip=frozenset()):
+    """Sort the itemization into the five buckets the summary reports.
+
+    Returns {bucket: [[detail, assessed, paid], ...]}, carrying the last
+    detail across continuation rows the way itemized_financials does. A
+    continuation row has no detail and no amount, only a payment against the
+    line above it, so its payment is credited to that line rather than
+    dropped. A skipped or excluded row breaks that chain instead, so a payment
+    that follows one is dropped rather than credited to a line ICOS does not
+    count.
+
+    skip holds indexes into rows, from uncounted_collection_rows.
+    """
+    buckets = {name: [] for name in ICOS_BUCKETS}
+    last_detail = None
+    current = None
+    for index, row in enumerate(rows):
+        detail = row.get('detail') or ''
+        if index in skip or (is_excluded_fee(detail) and not keep_third_party):
+            last_detail = None
+            current = None
+            continue
+        if not detail.strip():
+            if last_detail is None:
+                continue
+            detail = last_detail
+        else:
+            last_detail = detail
+        amount = row.get('amount')
+        paid = row.get('paid')
+        if amount is None:
+            # Continuation row: a further payment against the line above.
+            if current is not None and paid is not None:
+                current[2] += Decimal(str(paid))
+            continue
+        current = [detail, Decimal(str(amount)),
+                   Decimal(str(paid)) if paid is not None else Decimal(0)]
+        buckets[get_summary_bucket(detail)].append(current)
+    return buckets
+
+
 def reconcile_financials(case):
     """Per-column amounts owed, keeping the fee breakdown and the ICOS balance.
 
@@ -1098,39 +1140,12 @@ def reconcile_financials(case):
     if set(summary) != set(ICOS_BUCKETS):
         return None, None
 
-    # Partition the itemization, carrying the last detail across continuation
-    # rows the way itemized_financials does. A continuation row has no detail
-    # and no amount, only a payment against the line above it, so its payment
-    # is credited to that line rather than dropped.
-    buckets = {name: [] for name in ICOS_BUCKETS}
-    last_detail = None
-    current = None
     # A third party collection fee is normally ICOS listing a debt it does not
     # count, so it is dropped before the buckets are checked. When this case's
     # summary does count it, dropping it would break the bucket it belongs to.
     keep_third_party = summary_counts_third_party(case)
-    for row in rows:
-        detail = row.get('detail') or ''
-        if is_excluded_fee(detail) and not keep_third_party:
-            last_detail = None
-            current = None
-            continue
-        if not detail.strip():
-            if last_detail is None:
-                continue
-            detail = last_detail
-        else:
-            last_detail = detail
-        amount = row.get('amount')
-        paid = row.get('paid')
-        if amount is None:
-            # Continuation row: a further payment against the line above.
-            if current is not None and paid is not None:
-                current[2] += Decimal(str(paid))
-            continue
-        current = [detail, Decimal(str(amount)),
-                   Decimal(str(paid)) if paid is not None else Decimal(0)]
-        buckets[get_summary_bucket(detail)].append(current)
+    buckets = _bucket_partition(rows, keep_third_party,
+                                uncounted_collection_rows(case))
 
     # A bucket has to add up to what the summary says was assessed before any
     # payment is attributed off it. A fee read into the wrong bucket shows up as
@@ -1337,6 +1352,97 @@ def summary_counts_third_party(case):
             return False
         summarised += category['original']
     return abs(assessed - summarised) <= Decimal('0.01')
+
+
+def uncounted_collection_rows(case):
+    """Indexes of itemization rows this case's ICOS summary leaves out.
+
+    The county attorney's collection fee is usually part of the case balance,
+    filed under FINE, which is what the SUMMARY_BUCKET_OVERRIDES entry says
+    and what most captured cases carrying one show. On two of the 400 the
+    clerk's own arithmetic says the opposite. A Black Hawk felony case
+    counts its state and county collection splits in FINE and leaves the bare
+    COLLECTION BY CO ATTY fee out entirely, so the itemization runs over the
+    summary by exactly that fee. A Union County case goes further: its raw
+    ICOS page lists every collection fee, plus a second CRIME SERVICES
+    SURCHARGE ledger entry identical to the paid one but with no payment, no
+    receipt and no date, and its summary counts none of them. Those are
+    superseded entries from the collection process, not debt, and the clerk's
+    total says so: original amounts equal to the summary only once the
+    duplicates and the collection rows are set aside.
+
+    Which fees a summary leaves out varies case by case, the way third party
+    fees already do, so this is decided per case and only on the clerk's own
+    arithmetic. Candidates are grouped, collection fees by their exact wording
+    and unpaid rows that duplicate an identical earlier row together, and a
+    union of groups is excluded only when the itemization exceeds the summary
+    by exactly that union's sum, every one of the five buckets then matches
+    its summary original to the cent, and no other union manages the same.
+    A wrong exclusion would need all three to conspire. When no union
+    qualifies, nothing is excluded and the partition check fails the way it
+    does today, which is the safety net all of these guesses share.
+    """
+    categories = case.get('summary_categories') or []
+    rows = case.get('financials') or []
+    if not categories or not rows:
+        return frozenset()
+    summary = {}
+    for category in categories:
+        if category.get('original') is None:
+            return frozenset()
+        summary[category['label'].upper()] = category
+    if set(summary) != set(ICOS_BUCKETS):
+        return frozenset()
+
+    groups = {}
+    seen = set()
+    for index, row in enumerate(rows):
+        detail = (row.get('detail') or '').strip().upper()
+        amount = row.get('amount')
+        if amount is None:
+            continue
+        if 'COLLECTION BY CO ATTY' in detail:
+            groups.setdefault(('fee', detail), []).append(index)
+        elif (detail, str(amount)) in seen and row.get('paid') is None:
+            groups.setdefault(('duplicate', detail, str(amount)),
+                              []).append(index)
+        seen.add((detail, str(amount)))
+    # The union search below is exhaustive, so it needs a bound; ten groups is
+    # far past anything captured (Union County, the worst, has five).
+    if not groups or len(groups) > 10:
+        return frozenset()
+
+    keep_third_party = summary_counts_third_party(case)
+    assessed = Decimal(0)
+    for row in rows:
+        if row.get('amount') is None:
+            continue
+        if is_excluded_fee(row.get('detail')) and not keep_third_party:
+            continue
+        assessed += Decimal(str(row['amount']))
+    summarised = sum(summary[name]['original'] for name in ICOS_BUCKETS)
+    overage = assessed - summarised
+    if overage <= Decimal('0.01'):
+        return frozenset()
+
+    sums = {key: sum(Decimal(str(rows[index]['amount']))
+                     for index in indexes)
+            for key, indexes in groups.items()}
+    keys = sorted(groups)
+    winners = []
+    for size in range(1, len(keys) + 1):
+        for combo in itertools.combinations(keys, size):
+            if sum(sums[key] for key in combo) != overage:
+                continue
+            skip = frozenset(index for key in combo for index in groups[key])
+            buckets = _bucket_partition(rows, keep_third_party, skip)
+            if all(abs(sum((entry[1] for entry in buckets[name]), Decimal(0))
+                       - summary[name]['original']) <= Decimal('0.01')
+                   for name in ICOS_BUCKETS):
+                winners.append(skip)
+    if len(winners) == 1:
+        return winners[0]
+    return frozenset()
 
 
 def summary_financials(case):

--- a/tests/test_uncounted_collection_fees.py
+++ b/tests/test_uncounted_collection_fees.py
@@ -1,0 +1,166 @@
+"""Collection fees the clerk's own summary leaves out of the balance.
+
+The county attorney's collection fee usually counts toward the case balance
+under FINE. On two of the 400 captured cases the clerk's arithmetic says
+otherwise. One case counts its state and county collection splits and leaves
+the bare COLLECTION BY CO ATTY fee out, so the itemization runs over the
+summary by exactly that fee. Another lists every collection fee plus a second
+ledger entry for an already-paid surcharge, identical wording and amount but
+no payment, no receipt, no date, and counts none of them; the raw ICOS page
+itself carries those rows, so they are superseded ledger entries, not a
+parsing error and not debt.
+
+uncounted_collection_rows decides per case, the way summary_counts_third_party
+already does for third party fees, and only on the clerk's own arithmetic: a
+group of rows is excluded only when the itemization exceeds the summary by
+exactly that group's sum, every bucket then reconciles to the cent, and no
+other grouping manages the same.
+
+Every case number and amount below is synthetic. The repo is public.
+"""
+
+import os
+import sys
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+
+
+def _five(**totals):
+    rows = []
+    for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER'):
+        original = Decimal(totals.get(label, '0'))
+        paid = Decimal(totals.get('%s_PAID' % label, '0'))
+        rows.append({'label': label, 'original': original, 'paid': paid,
+                     'due': original - paid})
+    return rows
+
+
+def _fee(detail, amount, paid=None):
+    return {'detail': detail,
+            'amount': Decimal(amount) if amount is not None else None,
+            'paid': Decimal(paid) if paid is not None else None}
+
+
+# The first shape: the summary's FINE is the two collection splits and nothing
+# else. The bare collection fee is listed, partially paid, and not counted.
+# Before the fix the FINE bucket ran $60.00 over, failed, and surrendered its
+# breakdown with a note; the $60.00 was never owed by the clerk's own total.
+SPLIT_CASE = {
+    'id': '00000  FECR000000',
+    'summary_categories': _five(COSTS='90.00', FINE='450.00',
+                                FINE_PAID='45.00'),
+    'financials': [
+        _fee('SHERIFF SERVICE FEES', '90.00'),
+        _fee('COLLECTION BY CO ATTY - STATE SPLIT', '300.00', '30.00'),
+        _fee('COLLECTION BY CO ATTY - COUNTY SPLIT', '150.00', '15.00'),
+        _fee('COLLECTION BY CO ATTY', '60.00', '12.00'),
+    ],
+}
+
+
+def test_a_collection_fee_the_summary_leaves_out_is_excluded():
+    assert crs.uncounted_collection_rows(SPLIT_CASE) == frozenset({3})
+
+
+def test_the_split_case_reconciles_fee_by_fee():
+    columns, note = crs.reconcile_financials(SPLIT_CASE)
+    assert note is None, note
+    assert columns is not None
+    # FINE due 405.00 stays with the two split lines; COSTS 90.00 in SHERIFF.
+    assert sum(columns.values()) == Decimal('495.00'), columns
+    assert columns.get('M') == Decimal('90.00'), columns
+
+
+# The second shape: a fully paid case whose page lists a second ledger entry
+# for the paid surcharge (same wording and amount, no payment) and collection
+# fees the summary counts nowhere. Before the fix both FINE and SURCHARGE
+# failed the partition and the row said two categories could not be broken
+# down, on a case the clerk shows as paid off to the cent.
+SUPERSEDED_CASE = {
+    'id': '00000  AGCR000000',
+    'summary_categories': _five(FINE='700.00', FINE_PAID='700.00',
+                                SURCHARGE='105.00', SURCHARGE_PAID='105.00'),
+    'financials': [
+        _fee('CRIME SERVICES SURCHARGE', '105.00', '105.00'),
+        _fee('CRIME SERVICES SURCHARGE', '105.00'),
+        _fee('COLLECTION BY CO ATTY - COUNTY SPLIT', '80.00', '80.00'),
+        _fee('COLLECTION BY CO ATTY', '250.00'),
+        _fee('STATE FINES/COUNTY SPEED,WEIGHT,COPYCAT ORDINANCES',
+             '700.00', '540.00'),
+        _fee('COLLECTION BY CO ATTY(THRESHOLD MET)-CO SPLIT',
+             '70.00', '70.00'),
+        _fee('COLLECTION BY CO ATTY(THRESHOLD MET)-CO ATTY',
+             '10.00', '10.00'),
+    ],
+}
+
+
+def test_superseded_ledger_entries_are_excluded():
+    skip = crs.uncounted_collection_rows(SUPERSEDED_CASE)
+    assert skip == frozenset({1, 2, 3, 5, 6})
+
+
+def test_the_superseded_case_reconciles_with_nothing_owed():
+    columns, note = crs.reconcile_financials(SUPERSEDED_CASE)
+    assert note is None, note
+    assert columns == {}, columns
+
+
+# The guard: a case where the overage equals the collection fees to the cent
+# and excluding them would still be wrong. Here the summary counts the
+# collection fee under FINE and the real discrepancy is in OTHER, so pulling
+# the collection fee out would break FINE to fix nothing. The rule must not
+# fire, and the honest failure note must survive.
+CARVE_OUT_CASE = {
+    'id': '00000  SRCR000000',
+    'summary_categories': _five(FINE='85.00', OTHER='715.00'),
+    'financials': [
+        _fee('DELINQUENT PMT TO REVOLVING FUND', '800.00'),
+        _fee('COLLECTION BY CO ATTY', '85.00', '85.00'),
+    ],
+}
+
+
+def test_the_rule_refuses_when_exclusion_would_break_another_bucket():
+    assert crs.uncounted_collection_rows(CARVE_OUT_CASE) == frozenset()
+    columns, note = crs.reconcile_financials(CARVE_OUT_CASE)
+    assert note is not None and 'OTHER' in note, note
+
+
+# A counted collection fee, which is the common shape: totals agree, nothing
+# to exclude, and the fee keeps its place in the FINE bucket.
+COUNTED_CASE = {
+    'id': '00000  SMSM000000',
+    'summary_categories': _five(FINE='40.00'),
+    'financials': [
+        _fee('COLLECTION BY CO ATTY', '40.00'),
+    ],
+}
+
+
+def test_a_counted_collection_fee_is_left_alone():
+    assert crs.uncounted_collection_rows(COUNTED_CASE) == frozenset()
+    columns, note = crs.reconcile_financials(COUNTED_CASE)
+    assert note is None, note
+    assert sum(columns.values()) == Decimal('40.00'), columns
+
+
+def test_an_ordinary_unpaid_duplicate_is_not_touched():
+    """Two identical unpaid assessments the summary counts, as two counts of
+    the same charge legitimately produce. The totals agree, so the duplicate
+    group must never form an exclusion."""
+    case = {
+        'id': '00000  SCSC000000',
+        'summary_categories': _five(SURCHARGE='250.00'),
+        'financials': [
+            _fee('CRIME SERVICES SURCHARGE', '125.00'),
+            _fee('CRIME SERVICES SURCHARGE', '125.00'),
+        ],
+    }
+    assert crs.uncounted_collection_rows(case) == frozenset()
+    columns, note = crs.reconcile_financials(case)
+    assert note is None, note
+    assert columns == {'Q': Decimal('250.00')}, columns


### PR DESCRIPTION
Defect 26 in the replay series, the twenty-seventh time the real pages have exposed one. All case material below is described by county only; every id and amount in the tests is synthetic.

## What the real pages showed

After #113, ten of the 400 captured cases still failed the partition check that compares each summary category to the itemization lines sorted into it. Two of them turned out to share a cause: the clerk's own summary leaves county attorney collection fees out of the balance, while Napier counts them.

On a Black Hawk felony case the summary's FINE is the state and county collection splits and nothing else. The bare `COLLECTION BY CO ATTY` fee is listed and partially paid, and counted nowhere, so the FINE bucket ran over by exactly that fee, failed, and told the staffer the balance could not be broken down, about money the clerk's total says was never owed.

A Union County case goes further. Its raw ICOS page lists every collection fee, plus a second `CRIME SERVICES SURCHARGE` ledger entry identical to the paid one but with no payment, no receipt and no date, and its summary counts none of them. The raw HTML was checked row by row: the duplicates are on the page, at their own ledger row numbers, so this is ICOS carrying superseded entries from the collection process, not a parser defect. The paid collection splits on that page are distributions of fine payments, and they close to the cent: the payments on the fine line plus the splits sum to exactly the 855.00 FINE. Before this change the whole row fell back to the summary with the summary-only caveat.

## The rule

`uncounted_collection_rows` decides per case, the way `summary_counts_third_party` already does for third party fees, and only on the clerk's own arithmetic. Candidate rows are grouped: collection fees by their exact wording, and unpaid rows that duplicate an identical earlier row together. A union of groups is set aside only when three things hold at once: the itemization exceeds the summary by exactly that union's sum, every one of the five buckets then matches its summary original to the cent, and no other union manages the same. When no union qualifies, nothing is excluded and the partition check fails the way it does today.

The corpus supplied the case that proves the guard matters. A Linn felony case's overage equals its collection fees to the cent, and excluding them would still be wrong: there the summary counts the fee under FINE and the real discrepancy is in OTHER. The full-reconciliation condition refuses it, and a test pins that refusal.

The partition loop moves out of `reconcile_financials` into `_bucket_partition` so the rule tests a candidate exclusion with the same code that lives with the result.

## Measured impact

- Ten cases failed the partition check; these two now reconcile fee by fee, eight keep failing and keep saying so.
- The Black Hawk case loses a false "FINE did not add up" note. The Union County case stops surrendering its whole row to the summary fallback.
- Both cases are paid off, so no money moves in any column, and no other case in the corpus changes. The rule never fires on a case that already reconciles.

## Proof

- Two of the seven new tests fail against the previous code with genuine assertion failures: the false note on the split case, and the whole-row fallback on the superseded case.
- The other five pin the guards: the carve-out case the rule must refuse, a counted collection fee it must leave alone, an ordinary duplicate assessment (two counts of the same charge) it must never touch, and the two exclusion sets row by row.
- Full suite: 985 passed (978 before, 7 added).

Also extends the `COLLECTION BY CO ATTY` entry in OPEN_QUESTIONS: the column question and the whether-it-is-owed question are now visibly the same fee asked twice, and Iowa Legal Aid may want to answer both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
