### PR TITLE
Catch superseded ledger entries recoded under legacy fee codes

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -1371,10 +1371,19 @@ def uncounted_collection_rows(case):
     total says so: original amounts equal to the summary only once the
     duplicates and the collection rows are set aside.
 
+    A simple misdemeanor from a third county shows the same duplicate with its
+    wording recoded: an unpaid surcharge under a legacy DNU (do not use) fee
+    code, same amount as the paid surcharge next to it under the current code,
+    and the summary counts only the paid one. Other cases from the same county
+    carry unpaid DNU rows their summaries do count, so a legacy code alone
+    proves nothing; the candidate is the pairing, an unpaid DNU row whose
+    amount matches a row the clerk marked paid in the same bucket.
+
     Which fees a summary leaves out varies case by case, the way third party
     fees already do, so this is decided per case and only on the clerk's own
-    arithmetic. Candidates are grouped, collection fees by their exact wording
-    and unpaid rows that duplicate an identical earlier row together, and a
+    arithmetic. Candidates are grouped, collection fees by their exact wording,
+    unpaid rows that duplicate an identical earlier row together, and unpaid
+    legacy-coded rows shadowing a paid amount in their bucket together, and a
     union of groups is excluded only when the itemization exceeds the summary
     by exactly that union's sum, every one of the five buckets then matches
     its summary original to the cent, and no other union manages the same.
@@ -1394,6 +1403,15 @@ def uncounted_collection_rows(case):
     if set(summary) != set(ICOS_BUCKETS):
         return frozenset()
 
+    # The paid counterpart of a recoded duplicate can sit on either side of
+    # it in the ledger, so paid amounts are collected before grouping.
+    paid_amounts = set()
+    for row in rows:
+        detail = (row.get('detail') or '').strip().upper()
+        if row.get('amount') is None or row.get('paid') is None:
+            continue
+        paid_amounts.add((get_summary_bucket(detail), str(row['amount'])))
+
     groups = {}
     seen = set()
     for index, row in enumerate(rows):
@@ -1405,6 +1423,10 @@ def uncounted_collection_rows(case):
             groups.setdefault(('fee', detail), []).append(index)
         elif (detail, str(amount)) in seen and row.get('paid') is None:
             groups.setdefault(('duplicate', detail, str(amount)),
+                              []).append(index)
+        elif (detail.startswith('DNU') and row.get('paid') is None
+              and (get_summary_bucket(detail), str(amount)) in paid_amounts):
+            groups.setdefault(('dnu', detail, str(amount)),
                               []).append(index)
         seen.add((detail, str(amount)))
     # The union search below is exhaustive, so it needs a bound; ten groups is

--- a/tests/test_uncounted_collection_fees.py
+++ b/tests/test_uncounted_collection_fees.py
@@ -8,7 +8,9 @@ summary by exactly that fee. Another lists every collection fee plus a second
 ledger entry for an already-paid surcharge, identical wording and amount but
 no payment, no receipt, no date, and counts none of them; the raw ICOS page
 itself carries those rows, so they are superseded ledger entries, not a
-parsing error and not debt.
+parsing error and not debt. A third case shows the same duplicate recoded:
+an unpaid surcharge under a legacy DNU (do not use) fee code, same amount as
+the paid surcharge next to it under the current code, counted only once.
 
 uncounted_collection_rows decides per case, the way summary_counts_third_party
 already does for third party fees, and only on the clerk's own arithmetic: a
@@ -164,3 +166,66 @@ def test_an_ordinary_unpaid_duplicate_is_not_touched():
     columns, note = crs.reconcile_financials(case)
     assert note is None, note
     assert columns == {'Q': Decimal('250.00')}, columns
+
+
+# The third shape: the superseded entry with its wording recoded. The paid
+# surcharge sits under the current fee code and the leftover ledger entry under
+# a legacy DNU (do not use) code, same amount, no payment, and the summary
+# counts only the paid one. Identical-wording matching cannot see this pair.
+LEGACY_CODE_CASE = {
+    'id': '00000  SMSM000001',
+    'summary_categories': _five(SURCHARGE='300.00', SURCHARGE_PAID='300.00'),
+    'financials': [
+        _fee('LAW ENFORCEMENT INITIATIVE SURCHARGE', '90.00', '90.00'),
+        _fee('DNU-LAW ENFORCEMENT INITIATIVE SURCHARGE', '90.00'),
+        _fee('DNU-CRIME SERVICES SURCHARGE', '210.00', '210.00'),
+    ],
+}
+
+
+def test_a_recoded_legacy_duplicate_the_summary_leaves_out_is_excluded():
+    assert crs.uncounted_collection_rows(LEGACY_CODE_CASE) == frozenset({1})
+
+
+def test_the_legacy_duplicate_case_reconciles_with_nothing_owed():
+    columns, note = crs.reconcile_financials(LEGACY_CODE_CASE)
+    assert note is None, note
+    assert columns == {}, columns
+
+
+def test_a_counted_legacy_row_is_left_alone():
+    """The same paid-and-unpaid pairing, but here the clerk counts both. The
+    candidate forms and the arithmetic gate must keep the rule silent."""
+    case = {
+        'id': '00000  SMSM000002',
+        'summary_categories': _five(SURCHARGE='180.00',
+                                    SURCHARGE_PAID='90.00'),
+        'financials': [
+            _fee('LAW ENFORCEMENT INITIATIVE SURCHARGE', '90.00', '90.00'),
+            _fee('DNU-LAW ENFORCEMENT INITIATIVE SURCHARGE', '90.00'),
+        ],
+    }
+    assert crs.uncounted_collection_rows(case) == frozenset()
+    columns, note = crs.reconcile_financials(case)
+    assert note is None, note
+    assert columns == {'Q': Decimal('90.00')}, columns
+
+
+def test_a_legacy_row_without_a_paid_counterpart_is_not_a_candidate():
+    """A legacy code alone proves nothing: other captured cases carry unpaid
+    DNU rows their summaries do count. Without a paid row of the same amount
+    in the same bucket the row is not a candidate, so this case keeps its
+    honest failure note even though excluding the DNU row would balance."""
+    case = {
+        'id': '00000  SMSM000003',
+        'summary_categories': _five(COSTS='60.00', SURCHARGE='210.00'),
+        'financials': [
+            _fee('COURT COSTS', '60.00'),
+            _fee('DNU-LAW ENFORCEMENT INITIATIVE SURCHARGE', '90.00'),
+            _fee('DNU-CRIME SERVICES SURCHARGE', '210.00'),
+        ],
+    }
+    assert crs.uncounted_collection_rows(case) == frozenset()
+    columns, note = crs.reconcile_financials(case)
+    assert note is not None and 'SURCHARGE' in note, note
+    assert 'COSTS' not in note, note


### PR DESCRIPTION
Defect 27 in the replay series, the twenty-eighth time the real pages have exposed one. Follows directly on #114. All case material is described by county only; every id and amount in the tests is synthetic.

## What the real pages showed

After #114, eight captured cases still failed the partition check, two of them unexplained. Both are now explained. One needed code; the other needed none, and the commit records why.

A simple misdemeanor case carries the same superseded ledger entry #114 handles, with its wording recoded. The paid surcharge sits under the current fee code, and the leftover entry sits under a legacy DNU (do not use) fee code, same amount, no payment, and the summary counts only the paid one. The identical-wording match in #114 cannot see that pair, so the case surrendered its surcharge breakdown. Three other cases from the same county carry unpaid DNU rows their summaries do count, which is what makes a legacy code alone worthless as a signal.

## The rule

One new candidate group joins the search from #114: an unpaid DNU row whose amount matches a row marked paid in the same summary bucket. The paid counterpart can appear before or after it in the ledger, so paid amounts are collected in a pass before grouping. The triple gate is unchanged: excluded only when the itemization exceeds the summary by exactly the union's sum, every one of the five buckets then closes to the cent, and no other union manages the same.

## The case that needed no code

The last unexplained failure, a Pottawattamie County aggravated misdemeanor whose COSTS ran 33.00 over, resolved into net-collection accounting. Its two `COLLECTION BY CO ATTY(NET)` rows, 28.00 and 5.00, are counted under FINE, and the summary's COSTS drops the same 33.00: the collector kept it out of a partially collected 100.00 fee, so the clerk counts that fee at 67.00 while the itemization keeps its original 100.00. Reconciling would mean rewriting a fee amount the clerk reduced, which is a heavier inference than this rule makes anywhere. The case is fully paid, the degraded note it keeps is accurate, and it stays as it is.

## Measured impact

- Across all 400 captured cases exactly one changes: the failing simple misdemeanor, which now reconciles fee by fee with nothing owed.
- That case is paid off, so no dollar amounts move in any column.
- The rule still never fires on a case that already reconciles, structurally: it only engages when the itemization runs over the summary.

## Proof

- Two of the four new tests fail against the previous code with genuine assertion failures: the empty exclusion set and the whole-row summary fallback.
- The other two pin the guards: a counted legacy row where the candidate forms but the arithmetic keeps the rule silent, and a legacy row with no paid counterpart that must not become a candidate even though excluding it would balance the books.
- Full suite: 989 passed (985 before, 4 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQqxXnkKFiT72ZVMqzK66t
