### PR TITLE
Say what the sheets do with an untranslated case status

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -97,9 +97,16 @@ as unrecognised until then.
 
 CLOSED is deliberately not mapped. A case closes after a conviction and after a
 dismissal alike, and the word does not say which. Mapping it either way would
-put a number in a bankruptcy column on the strength of a guess, so it stays
-OTH, which is the code that means Napier does not know, and it keeps being
-emailed out while the run is happening.
+put a number in a bankruptcy column on the strength of a guess, so the case goes
+onto the sheet uncoded and keeps being emailed out while the run is happening.
+
+Where it lands depends on which vocabulary produced it, and this paragraph used
+to say it stayed OTH, which is only true of one of them. CLOSED written on a
+count is a disposition `charge_code_map` has no word for, and that does code the
+case OTH. CLOSED as the status of a case with no adjudicated count is not read
+by `charge_code_map` at all, and `case_level_code` declines it, so column G is
+left empty and BANKRUPTCY, EXEMPTIONS and SOL read the row as an open charge.
+The email now says which of the two it met.
 
 Asked Iowa Legal Aid on 5 August 2026, in the concrete form of a 1993 case
 whose only status is CLOSED and whose column G is empty because of it, with the

--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ when the wait gives up, a run that succeeded but needed three or more attempts,
 an unusable response once signed in, ICOS not answering at all, a case that
 would not parse, a case ICOS would not retrieve, a job crashing, an unhandled
 exception in a request, a party role or a disposition ICOS used that Napier
-does not recognise, a workbook built and never collected, and a progress page
-that lost contact with the server.
+does not recognise, a case status ICOS used that Napier will not translate, a
+workbook built and never collected, and a progress page that lost contact with
+the server.
 
 An unusable response and no answer at all are separate subject lines, and each
 carries the reason as its first line. They used to be one class with a size
@@ -211,6 +212,17 @@ body was is no longer recoverable, because the one email that would have said so
 had already been spent on something else. A court site that is down and a
 session that has lost its place look the same from outside, and only one of them
 is Iowa's fault.
+
+An unreadable disposition and an untranslated case status are separate subject
+lines for the same reason, and they were not until 5 August. A word missing from
+`charge_code_map` codes the case OTH and the fix is to add the word. A case with
+no adjudicated count carries only the status ICOS prints for the case as a
+whole, `case_level_code` refuses most of that vocabulary on purpose, and column
+G is left empty, which BANKRUPTCY, EXEMPTIONS and SOL render as "open charge".
+Column V was taught the difference on 3 August. The progress line and the email
+were not, so a run reported a closed 1993 case as coded OTH, named a notes
+column that said the opposite, and under one shared class would have silenced
+whichever of the two came second.
 
 The last two are the ones nothing else would catch, because the server thinks
 those runs went fine. A staffer whose phone drops the progress page sees a

--- a/alerts.py
+++ b/alerts.py
@@ -82,6 +82,21 @@ NOVEL_ROLE = 'unrecognised party role on an ICOS search'
 # surfaced is somebody noticing a sheet was wrong about a client. The alert
 # carries the ICOS wording and the case number and no defendant.
 UNKNOWN_DISPOSITION = 'unrecognised disposition on an ICOS case'
+# Its own class, because it is a different fact about a different row and it
+# wants a different answer. Above is a word missing from charge_code_map, and
+# the fix is to add it. This is the status ICOS prints for a case as a whole on
+# a case where no count was adjudicated, and case_level_code refuses to
+# translate all but one wording of it on purpose: guessing a conviction code
+# off a case status is the error it is avoiding. Column G is left empty, which
+# BANKRUPTCY, EXEMPTIONS and SOL read as an open charge.
+#
+# Sharing the class with the one above cost the distinction twice over. Both
+# suppress each other under the per-class floor, so a run carrying one of each
+# mailed whichever came first, and the subject line said a word was missing
+# from a map when nothing was. Splitting them also stops these drowning the
+# other: what CLOSED deserves is an open question with Iowa Legal Aid, so this
+# fires on every run of the same client until they answer it.
+UNCODED_CASE_STATUS = 'untranslated case status on an ICOS case'
 
 # A run that eventually worked but took this many attempts is the early warning
 # that ICOS is degrading, which is worth one email before staff start noticing.

--- a/crs.py
+++ b/crs.py
@@ -1641,6 +1641,13 @@ def process_case(case, worksheet, row, as_of=None):
     Almost always empty. When it is not, the case is on the sheet under a code
     Napier guessed at, and the return value is how the run gets to say so.
 
+    Each wording comes back paired with whether the row ended up carrying a
+    code, because the two cases the run has to describe are not the same one. A
+    count whose adjudication could not be read is coded OTH; a case with nothing
+    adjudicated at all leaves column G empty and three sheets call it an open
+    charge. The pairing is what stops the run reporting the second as the first,
+    and it is read off column G for the same reason the note is.
+
     as_of is the clinic date, the same one build_workbook puts in BASIC INFO B3.
     Nothing here reads it since column I went back to the staff. It is kept
     because every caller passes it and because a date-sensitive cell landing in
@@ -1775,14 +1782,19 @@ def process_case(case, worksheet, row, as_of=None):
     if charge.get('disposition') == 'JUV' and not is_juvenile_case(case['id']):
         append_note(worksheet, i, ADULT_ADJUDICATION_NOTE)
     unknown = charge.get('unknown_dispositions') or []
-    if unknown:
-        # Which of the two notes belongs here is decided by the cell the sheets
-        # actually read, not by which branch above collected the wording. A
-        # count Napier could not read still leaves a code in column G, and the
-        # OTH note describes what the sheets do with it. A case with nothing
-        # adjudicated leaves column G empty, and the sheets do something else
-        # entirely with that.
-        append_note(worksheet, i,
-                    (UNKNOWN_DISPOSITION_NOTE if worksheet['G' + i].value
-                     else UNCODED_CASE_STATUS_NOTE) % ", ".join(unknown))
-    return unknown
+    if not unknown:
+        return []
+    # Which of the two notes belongs here is decided by the cell the sheets
+    # actually read, not by which branch above collected the wording. A count
+    # Napier could not read still leaves a code in column G, and the OTH note
+    # describes what the sheets do with it. A case with nothing adjudicated
+    # leaves column G empty, and the sheets do something else entirely with
+    # that.
+    coded = bool(worksheet['G' + i].value)
+    append_note(worksheet, i,
+                (UNKNOWN_DISPOSITION_NOTE if coded
+                 else UNCODED_CASE_STATUS_NOTE) % ", ".join(unknown))
+    # The same answer goes back to the caller rather than being worked out a
+    # second time. The run's account of the row and the row's account of itself
+    # were allowed to disagree once already.
+    return [(wording, coded) for wording in unknown]

--- a/tasks.py
+++ b/tasks.py
@@ -168,31 +168,75 @@ def report_novel_roles(job, cases):
     return novel
 
 
-def report_unknown_dispositions(job, unknown):
-    """Say when a case was coded on a guess, on the page and by email.
+# What the run says about a count whose adjudication wording is not in
+# charge_code_map. The case is on the sheet under a guess, and the guess is OTH.
+UNKNOWN_DISPOSITION_LINE = (
+    "Iowa Courts recorded \"%s\" on %d case%s, which Napier does not "
+    "recognise. Those rows are coded OTH and say so in the notes column: %s."
+)
 
-    charge_code_map has a word for every outcome anyone has seen ICOS use.
-    Anything else codes the case OTH, and OTH is what the expungement,
-    bankruptcy, exemption and licence sheets read as no conviction, so a client
-    with a real conviction can come out of four sheets looking clean. The row
-    itself says so in column V, but the workbook goes to whoever runs the
-    clinic and the map only gets the missing word added if it reaches Alex.
+# What it says about the other row, which used to get the line above.
+#
+# Nothing about that was true of it. Its wording is not missing from
+# charge_code_map, because charge_code_map is not what read it: the case has no
+# adjudicated count at all, so the only disposition it carries is the status
+# ICOS prints for the case as a whole, and case_level_code translates one
+# wording of that vocabulary and refuses the rest on purpose. Nothing is coded
+# OTH. Column G is empty, which BANKRUPTCY, EXEMPTIONS and SOL render as "open
+# charge", so the row this line is about is being reported to the attorney as a
+# charge still pending against a client whose case Iowa Courts has closed.
+#
+# Column V was taught the difference in August; this line was not, and it is the
+# half Alex reads. It named a code the row does not carry and sent him to a
+# notes column that says something else.
+UNCODED_CASE_STATUS_LINE = (
+    "Iowa Courts recorded \"%s\" as the status of %d case%s with no "
+    "adjudicated count, which Napier does not translate into a CRS code. "
+    "Column G is left empty, so the BANKRUPTCY, EXEMPTIONS and SOL sheets read "
+    "%s as an open charge, and the notes column says so: %s."
+)
+
+
+def report_unknown_dispositions(job, unknown):
+    """Say what a case was coded on, on the page and by email.
+
+    Two things arrive here and they need telling apart. charge_code_map has a
+    word for every outcome anyone has seen ICOS use, and anything else codes the
+    case OTH, which is what the expungement, bankruptcy, exemption and licence
+    sheets read as no conviction, so a client with a real conviction can come
+    out of four sheets looking clean. The other is a case with nothing
+    adjudicated on it, where column G is left empty rather than guessed at and
+    three sheets read the empty cell as an open charge.
+
+    Both leave the row saying so in column V, but the workbook goes to whoever
+    runs the clinic. The map only gets a missing word added if it reaches Alex,
+    and what an untranslated case status deserves is a question for Iowa Legal
+    Aid, so the two go out under separate subjects rather than one.
 
     The wording and the case number go out. Both are court public record and
-    neither is any use without the other: the word is what the map is missing
-    and the case is the page to read it off. The client is not in it.
+    neither is any use without the other: the word is what Napier could not act
+    on and the case is the page to read it off. The client is not in it.
     """
-    for disposition, case_ids in sorted(unknown.items()):
-        job.log("Iowa Courts recorded \"%s\" on %d case%s, which Napier does not "
-                "recognise. Those rows are coded OTH and say so in the notes "
-                "column: %s."
-                % (disposition, len(case_ids), "" if len(case_ids) == 1 else "s",
-                   ", ".join(case_ids)))
-        alerts.record(job.id[:8], job.kind, alerts.UNKNOWN_DISPOSITION,
-                      progress=alerts.recent_progress(job),
-                      disposition=disposition,
-                      cases=", ".join(case_ids))
-    return sorted(unknown)
+    for (disposition, coded), case_ids in sorted(unknown.items()):
+        count = len(case_ids)
+        plural = "" if count == 1 else "s"
+        listed = ", ".join(case_ids)
+        if coded:
+            job.log(UNKNOWN_DISPOSITION_LINE
+                    % (disposition, count, plural, listed))
+            alerts.record(job.id[:8], job.kind, alerts.UNKNOWN_DISPOSITION,
+                          progress=alerts.recent_progress(job),
+                          disposition=disposition,
+                          cases=listed)
+        else:
+            job.log(UNCODED_CASE_STATUS_LINE
+                    % (disposition, count, plural,
+                       "that row" if count == 1 else "those rows", listed))
+            alerts.record(job.id[:8], job.kind, alerts.UNCODED_CASE_STATUS,
+                          progress=alerts.recent_progress(job),
+                          **{'case status': disposition,
+                             'cases': listed})
+    return sorted({disposition for disposition, _ in unknown})
 
 
 def search_task(job, username, password, firstname, middlename, lastname):
@@ -847,8 +891,8 @@ def retry_task(job, username, password, payload):
             # stops being read.
             fresh_ids = {case['id'] for case in recovered}
             report_unknown_dispositions(job, {
-                wording: [case_id for case_id in case_ids if case_id in fresh_ids]
-                for wording, case_ids in unknown.items()
+                key: [case_id for case_id in case_ids if case_id in fresh_ids]
+                for key, case_ids in unknown.items()
                 if any(case_id in fresh_ids for case_id in case_ids)})
             record['written'] = len(cases)
             record['file'] = path
@@ -908,10 +952,12 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     serves, and one that is quietly short two cases is worse than one that
     says it is short two cases.
 
-    The second value is a map of the ICOS wording to the case numbers it turned
-    up on. Empty on almost every run. When it is not, those cases are on the
-    sheet under a guessed code and somebody needs to know before the workbook is
-    used, so the caller reports it rather than the file quietly carrying it.
+    The second value maps the ICOS wording, paired with whether the row it
+    landed on came out with a code in column G, to the case numbers it turned up
+    on. Empty on almost every run. When it is not, those cases are either on the
+    sheet under a guessed code or on it with no code at all, and somebody needs
+    to know which before the workbook is used, so the caller reports it rather
+    than the file quietly carrying it.
     """
     workbook = load_workbook('CRS Lite 3.5.5.xlsx' if is_lite else 'CRS 3.5.5.xlsx')
     sheet = workbook['CASE DATA']
@@ -923,8 +969,8 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     row = 4
     unknown = {}
     for case in cases:
-        for disposition in crs.process_case(case, sheet, row, clinic_date) or []:
-            unknown.setdefault(disposition, []).append(case['id'])
+        for key in crs.process_case(case, sheet, row, clinic_date) or []:
+            unknown.setdefault(key, []).append(case['id'])
         row += 1
 
     # Columns W to AH take column F apart one statute per column, and the

--- a/tests/test_pending_cases.py
+++ b/tests/test_pending_cases.py
@@ -194,7 +194,7 @@ def test_a_closed_case_stops_counting_as_a_pending_charge():
                                 status='CLOSED', dispo_date='09/23/1901'))
     assert cells['D'] == '09/23/1901'
     assert cells['G'] in (None, '')
-    assert unknown == ['CLOSED']
+    assert unknown == [('CLOSED', False)]
 
 
 def test_a_status_napier_cannot_read_is_reported_not_guessed():
@@ -206,7 +206,7 @@ def test_a_status_napier_cannot_read_is_reported_not_guessed():
     cells, unknown = _row(_case('321.285', 'SYNTHETIC SPEED',
                                 status='VIOLATIONS HANDLED BY CLERK',
                                 dispo_date='03/03/1903'))
-    assert unknown == ['VIOLATIONS HANDLED BY CLERK']
+    assert unknown == [('VIOLATIONS HANDLED BY CLERK', False)]
     assert 'VIOLATIONS HANDLED BY CLERK' in cells['V']
     assert cells['G'] in (None, '')
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -108,6 +108,9 @@ class FakeClient:
         self.logged_in = False
 
 
+# Keyed the way build_workbook keys it: the ICOS wording paired with whether the
+# row it landed on came out with a code in column G. True here because an
+# unreadable count is coded OTH, which is the reporting these tests are about.
 UNKNOWN = {}
 
 
@@ -391,7 +394,7 @@ class TestGoingBackForThem:
         updated once. Telling them again about the same one on every rebuild is
         how alerting stops being read."""
         FakeClient.fail_cases = {DOE_CASES[1]}
-        UNKNOWN.update({'HELD IN ABEYANCE': list(DOE_CASES)})
+        UNKNOWN.update({('HELD IN ABEYANCE', True): list(DOE_CASES)})
         _, job_id = run_one(client)
         FakeClient.fail_cases = set()
         new_id, state = follow_retry(client, job_id)
@@ -408,7 +411,7 @@ class TestGoingBackForThem:
         empty list still reads out as "recorded X on 0 cases" and still emails,
         which is the same nag with the evidence taken out of it."""
         FakeClient.fail_cases = {DOE_CASES[1]}
-        UNKNOWN.update({'HELD IN ABEYANCE': [DOE_CASES[0], DOE_CASES[2]]})
+        UNKNOWN.update({('HELD IN ABEYANCE', True): [DOE_CASES[0], DOE_CASES[2]]})
         _, job_id = run_one(client)
         FakeClient.fail_cases = set()
 

--- a/tests/test_uncoded_case_status.py
+++ b/tests/test_uncoded_case_status.py
@@ -35,8 +35,10 @@ from openpyxl import load_workbook
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import alerts
 import case_parser
 import crs
+import tasks
 from test_multi_count import charges_page
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -46,10 +48,9 @@ CLOSED = 'CLOSED'
 TRANSFERRED = 'TRANSFERRED'
 
 
-def _row(counts, status, costs='197.43'):
-    """A row built the way process_case builds one, off parsed ICOS pages."""
-    sheet = load_workbook(FULL)['CASE DATA']
-    case = {'id': '00000  FECR000000', 'county': 'SYNTHETIC',
+def _case(counts, status, costs='197.43', case_id='00000  FECR000000'):
+    """A case the shape build_workbook takes, off parsed ICOS pages."""
+    case = {'id': case_id, 'county': 'SYNTHETIC',
             'financials': [], 'sentences': [],
             'summary_created_date': '01/01/1900',
             'summary_disposition_date': '02/02/1901',
@@ -62,7 +63,13 @@ def _row(counts, status, costs='197.43'):
          'due': Decimal(costs) if label == 'COSTS' else Decimal('0')}
         for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')]
     case['total_due'] = '$' + costs
-    crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
+    return case
+
+
+def _row(counts, status, costs='197.43'):
+    """A row built the way process_case builds one, off parsed ICOS pages."""
+    sheet = load_workbook(FULL)['CASE DATA']
+    crs.process_case(_case(counts, status, costs), sheet, crs.FIRST_CASE_ROW)
     row = str(crs.FIRST_CASE_ROW)
     return {column: sheet[column + row].value
             for column in ('D', 'G', 'V')}
@@ -177,3 +184,143 @@ def test_the_three_sheets_really_do_read_an_empty_column_g_that_way():
         formula = book[sheet]['B' + row].value or ''
         assert 'open charge' in formula, (sheet, formula)
         assert "'CASE DATA'!G" + row in formula, (sheet, formula)
+
+
+# -- what the run said about the row, which is the half that stayed wrong ----
+#
+# Column V learned the difference above. The progress page and the email did
+# not, and they are the half Alex reads. A production run on 5 August pulled 71
+# cases and mailed:
+#
+#   Iowa Courts recorded "CLOSED" on 1 case, which Napier does not recognise.
+#   Those rows are coded OTH and say so in the notes column: <case>.
+#
+# Every clause of that is false of the row it names. The wording is not missing
+# from charge_code_map, the row is not coded OTH, and the notes column says
+# something else entirely, so the one sentence pointing at the workbook pointed
+# at a note that contradicted it.
+
+
+class FakeJob(object):
+    id = 'synthetic-job-id'
+    kind = 'crs'
+
+    def __init__(self):
+        self.progress = []
+        self.messages = []
+
+    def log(self, message, **kwargs):
+        self.messages.append(message)
+
+
+@pytest.fixture(autouse=True)
+def clean_alerts():
+    alerts.reset()
+    yield
+    alerts.reset()
+
+
+def _recorded(monkeypatch):
+    sent = []
+    monkeypatch.setattr(alerts, 'record',
+                        lambda *a, **kw: sent.append((a, kw)))
+    return sent
+
+
+UNREADABLE_WORDING = 'SYNTHETIC WORDING NOBODY HAS SEEN'
+UNCODED = {(CLOSED, False): ['00000  SRCR000000']}
+CODED = {(UNREADABLE_WORDING, True): ['00000  FECR000000']}
+
+
+def test_the_run_does_not_say_the_row_is_coded_oth(monkeypatch):
+    """The defect, in the words that were mailed out."""
+    _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, UNCODED)
+    assert job.messages
+    for message in job.messages:
+        assert 'OTH' not in message, message
+
+
+def test_the_run_says_what_the_sheets_will_do_with_the_row(monkeypatch):
+    """Same thing column V had to say, for the same reason: an attorney is
+    about to read three sheets calling a closed case a pending charge."""
+    _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, UNCODED)
+    message = " ".join(job.messages)
+    assert 'open charge' in message, message
+    for sheet in ('BANKRUPTCY', 'EXEMPTIONS', 'SOL'):
+        assert sheet in message, message
+
+
+def test_the_run_still_names_the_wording_and_the_case(monkeypatch):
+    """The two facts the old line did carry. Without them the mail says a run
+    went wrong somewhere and stops."""
+    _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, UNCODED)
+    message = " ".join(job.messages)
+    assert CLOSED in message and '00000  SRCR000000' in message, message
+
+
+def test_it_goes_out_under_its_own_subject(monkeypatch):
+    """Not the missing-word subject. Nothing is missing from charge_code_map
+    here, and what CLOSED deserves is a question for Iowa Legal Aid, so it is
+    filed and answered separately."""
+    sent = _recorded(monkeypatch)
+    tasks.report_unknown_dispositions(FakeJob(), UNCODED)
+    assert len(sent) == 1
+    args, kwargs = sent[0]
+    assert args[2] == alerts.UNCODED_CASE_STATUS
+    assert kwargs['case status'] == CLOSED
+    assert '00000  SRCR000000' in kwargs['cases']
+
+
+def test_the_alert_carries_no_defendant(monkeypatch):
+    """Article 5, same as the alert it split from. The status and the case
+    number are court public record; the client is not."""
+    sent = _recorded(monkeypatch)
+    tasks.report_unknown_dispositions(FakeJob(), UNCODED)
+    _, kwargs = sent[0]
+    assert set(kwargs) <= {'progress', 'case status', 'cases'}
+
+
+def test_a_run_carrying_both_reports_both(monkeypatch):
+    """The cost of the shared class, which the wording hid. alerts.record
+    suppresses a second email of the same class within the floor, so a run with
+    one of each used to mail whichever came first and drop the other."""
+    sent = _recorded(monkeypatch)
+    job = FakeJob()
+    both = dict(UNCODED)
+    both.update(CODED)
+    tasks.report_unknown_dispositions(job, both)
+    assert {args[2] for args, _ in sent} == {alerts.UNCODED_CASE_STATUS,
+                                            alerts.UNKNOWN_DISPOSITION}
+    assert len(job.messages) == 2
+
+
+def test_the_other_row_still_gets_the_line_it_always_had(monkeypatch):
+    """A count Napier could not read is coded OTH, and nothing above changes
+    what is said about it."""
+    sent = _recorded(monkeypatch)
+    job = FakeJob()
+    tasks.report_unknown_dispositions(job, CODED)
+    assert sent[0][0][2] == alerts.UNKNOWN_DISPOSITION
+    assert 'coded OTH' in " ".join(job.messages)
+    assert 'open charge' not in " ".join(job.messages)
+
+
+# -- and that a real build carries the distinction that far -----------------
+
+def test_the_build_hands_back_which_kind_each_wording_was(tmp_path, monkeypatch):
+    """process_case can tell them apart all it likes if build_workbook drops
+    it. Both cases in one workbook, because that is the run that was losing an
+    email as well as mislabelling one."""
+    monkeypatch.setattr(tasks, 'tmp_dir', str(tmp_path) + os.sep)
+    _, unknown, _ = tasks.build_workbook(
+        [_case(UNADJUDICATED, CLOSED, case_id='00000  SRCR000000'),
+         _case(UNREADABLE, '', case_id='00000  FECR000000')],
+        'TEST CLIENT', '01/01/1980', False)
+    assert unknown == {(CLOSED, False): ['00000  SRCR000000'],
+                       (UNREADABLE_WORDING, True): ['00000  FECR000000']}

--- a/tests/test_unknown_disposition.py
+++ b/tests/test_unknown_disposition.py
@@ -120,7 +120,7 @@ def _row(case):
 def test_the_row_says_it_was_coded_on_a_guess():
     """The workbook outlives the alert and goes to whoever runs the clinic."""
     unknown, code, note = _row(_case(NOVEL))
-    assert unknown == [NOVEL]
+    assert unknown == [(NOVEL, True)]
     assert code == 'OTH'
     assert NOVEL in note
     assert 'OTH' in note
@@ -191,7 +191,7 @@ def test_an_unreadable_disposition_is_mailed_out(monkeypatch):
     """
     sent = _recorded(monkeypatch)
     job = FakeJob()
-    tasks.report_unknown_dispositions(job, {NOVEL: ['00000  FECR000000']})
+    tasks.report_unknown_dispositions(job, {(NOVEL, True): ['00000  FECR000000']})
     assert len(sent) == 1
     args, kwargs = sent[0]
     assert args[2] == alerts.UNKNOWN_DISPOSITION
@@ -207,7 +207,7 @@ def test_the_alert_carries_no_defendant(monkeypatch):
     """
     sent = _recorded(monkeypatch)
     tasks.report_unknown_dispositions(
-        FakeJob(), {NOVEL: ['00000  FECR000000']})
+        FakeJob(), {(NOVEL, True): ['00000  FECR000000']})
     _, kwargs = sent[0]
     assert set(kwargs) <= {'progress', 'disposition', 'cases'}
 
@@ -216,7 +216,7 @@ def test_the_run_says_so_on_the_progress_page_too(monkeypatch):
     """Staff read the finish page. Alex reads the mail. Both need to know."""
     _recorded(monkeypatch)
     job = FakeJob()
-    tasks.report_unknown_dispositions(job, {NOVEL: ['00000  FECR000000']})
+    tasks.report_unknown_dispositions(job, {(NOVEL, True): ['00000  FECR000000']})
     assert any(NOVEL in message for message in job.messages)
     assert any('OTH' in message for message in job.messages)
 
@@ -232,7 +232,7 @@ def test_one_alert_per_wording_not_per_case(monkeypatch):
     """A clinic pulling seventy cases through one new ICOS wording is one email."""
     sent = _recorded(monkeypatch)
     tasks.report_unknown_dispositions(
-        FakeJob(), {NOVEL: ['00000  FECR000000', '00000  FECR000001',
+        FakeJob(), {(NOVEL, True): ['00000  FECR000000', '00000  FECR000001',
                             '00000  FECR000002']})
     assert len(sent) == 1
     assert sent[0][1]['cases'].count(',') == 2
@@ -245,4 +245,4 @@ def test_the_workbook_build_hands_the_wordings_back(tmp_path, monkeypatch):
     monkeypatch.setattr(tasks, 'tmp_dir', str(tmp_path) + os.sep)
     _, unknown, _ = tasks.build_workbook(
         [_case(NOVEL), _case('GUILTY')], 'TEST CLIENT', '01/01/1980', False)
-    assert unknown == {NOVEL: ['00000  FECR000000']}
+    assert unknown == {(NOVEL, True): ['00000  FECR000000']}


### PR DESCRIPTION
The 5 August CRS run mailed this about case 06571:

  Iowa Courts recorded "CLOSED" on 1 case, which Napier does not
  recognise. Those rows are coded OTH and say so in the notes column.

Every clause after the first was wrong. CLOSED there is the status ICOS
prints for a case as a whole, not a disposition on a count.
charge_code_map never saw it, nothing was coded OTH, and column G was
left empty, which BANKRUPTCY, EXEMPTIONS and SOL render as "open
charge". The notes column said exactly that, so the sentence pointing
the reader at the note pointed at a note contradicting it.

Column V learned the distinction on 3 August; tasks.py kept the older
claim, so the run's account of the row and the row's account of itself
disagreed. process_case now decides which of the two it is once, from
the cell the sheets actually read, and hands that answer back with the
wording so the caller cannot work it out differently.

Splitting the alert class fixes a second, quieter one. alerts.record
mails one message per class per job, so a run carrying an unreadable
disposition and an untranslated case status mailed whichever came
first and dropped the other under a subject line naming the wrong
failure. They are separate questions -- one is a word to add to a map,
the other is an open question with Iowa Legal Aid -- and now separate
subjects.

997 passing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ESAVpMZmAoscmQiFn8J647
