### PR TITLE
Apply the remaining Iowa Legal Aid recodes

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -375,6 +375,56 @@ def cites_section(statutes, sections):
     return "NO"
 
 
+# Two statutes that are not crimes. Fugitive from justice is an extradition
+# hold and violation of parole is an executive revocation, so neither is a
+# conviction the client carries, and Iowa Legal Aid asked for both to read as
+# civil. Napier codes off whatever the clerk typed in the disposition, so the
+# four captured fugitive cases came out under four different codes: GTR, TNSF,
+# WTHD and OTH. All five owe nothing, so no money moves today.
+#
+# Exactly these two, never chapter 908. Violation of probation is 908.11, one
+# section over, and the same 538 cases carry 20 of those worth about $17,600,
+# most of them real guilty pleas. A chapter rule would flip all of them to
+# civil, which is the opposite of what Iowa Legal Aid asked for the last time
+# this came up. cites_section is what keeps them apart: it will not match 908.1
+# against 908.11 because it refuses a trailing digit.
+CIVIL_SECTIONS = ('820.2', '908.1')
+
+# What a clerk files a pre-electronic-docket case under. Either spelling is
+# enough on its own, because the captured case carries both and there is no
+# reading of one without the other that means anything else.
+OLD_CASE_CODE = 'CR/OLDCASE'
+OLD_CASE_DESCRIPTION = 'OLD CASE CHARGE CODE'
+
+
+def is_old_case_code(charge):
+    """Is this the clerk's placeholder for a case whose file is on paper?"""
+    code = (charge.get('original_charge') or charge.get('charge') or '')
+    description = (charge.get('original_description')
+                   or charge.get('description') or '')
+    return (code.strip().upper() == OLD_CASE_CODE
+            or description.strip().upper() == OLD_CASE_DESCRIPTION)
+
+
+def only_civil_sections(statutes):
+    """True when every adjudicated count on the case is one of CIVIL_SECTIONS.
+
+    Every count, not any count. A case holding someone as a fugitive alongside
+    a real conviction is a case with a real conviction, and Iowa Legal Aid was
+    explicit that the conviction wins. Recoding the whole row CIV on the
+    strength of one non-criminal count would move the conviction's balance into
+    the dischargeable and exempt columns on the bankruptcy and exemption
+    sheets, which is a worse error than the label it fixes.
+    """
+    if not statutes:
+        return False
+    codes = [code.strip() for code in str(statutes).split(';')]
+    codes = [code for code in codes if code and code.lower() != 'n/a']
+    if not codes:
+        return False
+    return all(cites_section(code, CIVIL_SECTIONS) == "YES" for code in codes)
+
+
 # How far back to look when working out what somebody is paying now. A court
 # asking whether a person can pay wants the recent record, not an average that
 # a garnishment in 2003 drags upwards.
@@ -767,8 +817,21 @@ def case_level_code(status):
 
 
 def get_finance_column(detail):
+    # A county attorney collection fee is really a payment marker, so no column
+    # is truly right for it. Across 538 captured cases it puts $0.00 of
+    # assessed-and-unpaid money anywhere: 16 cases carry one, 49 rows between
+    # them, and the clerk marked 47 of those paid with a receipt and a tender.
+    # The other 2 sit on a case Napier already drops. So this moves nothing
+    # today on any case anyone has measured.
+    #
+    # It is in K rather than P for the rare case that does carry a balance.
+    # What it would be then is collection debt, and K is where the other two
+    # collection fees go, which is the half of the bankruptcy sheet's J+K that
+    # reads as dischargeable. P is UNKNOWN, and unknown money is covered by no
+    # exemption and called not dischargeable, which is the wrong way for a
+    # guess about a client's debt to run.
     if "COLLECTION BY CO ATTY" in detail:
-        return "P" # UNKNOWN
+        return "K" # COLLECTION FEE
     if "DELINQUENT REVOLVING FUND" in detail:
         return "P" # UNKNOWN
 
@@ -1716,6 +1779,32 @@ def process_case(case, worksheet, row, as_of=None):
                             charge['unknown_dispositions'] + [status])
                 else:
                     disposition = code
+            if not disposition and is_old_case_code(charge):
+                # OLD CASE CHARGE CODE is what Iowa's clerks put on a case that
+                # predates the electronic docket. There is no adjudication to
+                # read because the disposition is on paper in a courthouse
+                # basement, and the status is CLOSED, which is not a
+                # disposition Napier can translate.
+                #
+                # Left empty, column G is 0 to Excel, and the SOL, BANKRUPTCY
+                # and EXEMPTIONS sheets each render IF(G=0, "open charge", G).
+                # So a case closed in 1993 was printing as an open charge on
+                # three sheets. OTH is a string, so those sheets print OTH, and
+                # OTH appears in no formula anywhere in either template, so it
+                # is in no cleared set and the money does not move. The one
+                # captured case owes $197.43 and stays in the same buckets on
+                # all three sheets.
+                #
+                # Keyed on the charge code and not on the status. CLOSED turns
+                # up on cases that have a real adjudication to read, and this
+                # must not speak for any of those.
+                disposition = "OTH"
+
+        # After the clerk's wording has had its say and before anything is
+        # written, because what the charge is beats how the disposition was
+        # typed. This is the only place the statute overrides the code.
+        if only_civil_sections(charge['charge']):
+            disposition = "CIV"
 
         worksheet['C' + i] = charge['offenseDate']
         worksheet['D' + i] = disposition_date

--- a/tests/test_ari_aug5_items.py
+++ b/tests/test_ari_aug5_items.py
@@ -1,0 +1,300 @@
+"""Three changes Iowa Legal Aid asked for on 5 August, and what each may not do.
+
+All three are meant to change a label and no money. The tests that matter here
+are the ones checking the second half of that, because a code on CASE DATA is
+read by formulas on five other sheets and moving one quietly moves a client's
+debt between dischargeable, exempt and not.
+
+  OLD CASE CHARGE CODE reads OTH instead of leaving column G empty, which three
+  sheets were rendering as "open charge" on a case closed in 1993.
+
+  Fugitive from justice and violation of parole read CIV, keyed on the statute
+  rather than on whatever the clerk typed in the disposition.
+
+  COLLECTION BY CO ATTY moves from column P to column K.
+
+The trap in the middle one is 908.11. Violation of probation is one section
+away from violation of parole and there are 20 of them in the same captured
+corpus carrying about $17,600, mostly real guilty pleas. A rule written on
+chapter 908 rather than on the section would flip all of them to civil, which
+is the opposite of what Iowa Legal Aid asked for. That is the test to keep.
+
+Synthetic pages throughout. The repository is public and a real charges page is
+one person's unredacted criminal record.
+"""
+
+import os
+import sys
+from datetime import date
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+
+
+def _cells(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page(counts):
+    """ICOS's real shape: each count charged, then adjudicated.
+
+    counts is (statute, description, outcome). outcome of None is the page ICOS
+    serves before a court has ruled, with the adjudication block present and
+    its cells empty.
+    """
+    html = ['<html><body><table>']
+    for number, (statute, description, outcome) in enumerate(counts, start=1):
+        html.append(_cells('Count %02d' % number, 'Original Charge'))
+        html.append(_cells('Charge:', statute, 'Description:', description))
+        html.append(_cells('Offense Date:', '01/01/1900', 'Arrest Date:', ''))
+        html.append(_cells('Adjudication'))
+        if outcome is None:
+            html.append(_cells('Charge:', '', 'Description:', ''))
+            html.append(_cells('Adjudication:', '', 'Adjudication Date:', ''))
+        else:
+            html.append(_cells('Charge:', statute, 'Description:', description))
+            html.append(_cells('Adjudication:', outcome,
+                               'Adjudication Date:', '02/02/1901'))
+    html.append('</table></body></html>')
+    return ''.join(html).encode('utf-8')
+
+
+def _case(counts, status='', dispo_date='', financials=None):
+    case = {'id': '00000  SMSM000000', 'county': 'SYNTHETIC',
+            'financials': financials or [], 'summary_categories': [],
+            'sentences': [], 'summary_created_date': '01/01/1900',
+            'summary_disposition_date': dispo_date,
+            'summary_dispo_status': status}
+    case_parser.parse_case_charges(charges_page(counts), case)
+    return case
+
+
+def _row(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    unknown = crs.process_case(case, sheet, crs.FIRST_CASE_ROW, CLINIC)
+    i = str(crs.FIRST_CASE_ROW)
+    cells = {column: sheet[column + i].value
+             for column in ('A', 'D', 'F', 'G', 'J', 'K', 'P', 'V')}
+    return cells, unknown
+
+
+# -- OLD CASE CHARGE CODE ---------------------------------------------------
+
+OLD_CASE = [('CR/OLDCASE', 'OLD CASE CHARGE CODE', None)]
+
+
+class TestTheOldCaseCode:
+    def test_it_stops_reading_as_an_open_charge(self):
+        """Empty is 0 to Excel and SOL, BANKRUPTCY and EXEMPTIONS all render
+        IF(G=0, "open charge", G). A case closed in 1993 was printing as an
+        open charge on three sheets."""
+        cells, _ = _row(_case(OLD_CASE, status='CLOSED',
+                              dispo_date='09/23/1901'))
+        assert cells['G'] == 'OTH'
+
+    def test_it_is_in_no_cleared_set_so_no_money_moves(self):
+        """The whole reason this one is safe. OTH appears in no formula in
+        either template, so nothing that sorts a balance can see it."""
+        workbook = load_workbook(FULL)
+        for name in ('BANKRUPTCY', 'SOL', 'EXEMPTIONS',
+                     'EXPUNGEMENT & 910.7'):
+            sheet = workbook[name]
+            for row in sheet.iter_rows():
+                for cell in row:
+                    if isinstance(cell.value, str):
+                        assert '"OTH"' not in cell.value, (
+                            "%s!%s tests for OTH" % (name, cell.coordinate))
+
+    def test_the_date_icos_gave_is_still_kept(self):
+        """The guard on the fix that came before this one. A blank column D is
+        how the expungement sheet counts pending charges, so losing the date
+        here would put the case back to blocking expungement."""
+        cells, _ = _row(_case(OLD_CASE, status='CLOSED',
+                              dispo_date='09/23/1901'))
+        assert cells['D'] == '09/23/1901'
+
+    def test_the_status_it_could_not_read_is_still_reported(self):
+        """Coding the row does not mean Napier understood CLOSED. The note
+        changes to the one that describes a row carrying a code, but the
+        wording still travels."""
+        cells, unknown = _row(_case(OLD_CASE, status='CLOSED',
+                                    dispo_date='09/23/1901'))
+        assert unknown == [('CLOSED', True)]
+        assert 'CLOSED' in (cells['V'] or '')
+
+    def test_a_closed_case_that_is_not_an_old_case_is_left_alone(self):
+        """Keyed on the charge code, not on the status. CLOSED turns up on
+        cases with a real adjudication and this must not speak for them."""
+        cells, _ = _row(_case([('321.285', 'SYNTHETIC SPEED', None)],
+                              status='CLOSED', dispo_date='09/23/1901'))
+        assert cells['G'] in (None, '')
+
+    def test_a_genuinely_pending_case_still_reads_as_open(self):
+        """No status, no date, nothing adjudicated. This is the row the "open
+        charge" rendering exists for and it has to keep working."""
+        cells, _ = _row(_case([('321.285', 'SYNTHETIC SPEED', None)]))
+        assert cells['G'] in (None, '')
+        assert cells['D'] in (None, '')
+
+    def test_an_old_case_that_did_get_adjudicated_codes_off_that(self):
+        """If ICOS ever does print an adjudication on one of these, the
+        adjudication is the better answer and OTH must not overwrite it."""
+        cells, _ = _row(_case([('CR/OLDCASE', 'OLD CASE CHARGE CODE',
+                                'GUILTY')]))
+        assert cells['G'] == 'GTR'
+
+
+# -- CIV on the statute -----------------------------------------------------
+
+class TestFugitiveAndParoleReadCivil:
+    @pytest.mark.parametrize('outcome', ['GUILTY', 'GUILTY BY COURT',
+                                         'DEFERRED', 'SYNTHETIC NONSENSE'])
+    def test_fugitive_reads_civil_whatever_the_clerk_typed(self, outcome):
+        """Her actual complaint. The four captured fugitive cases came out as
+        four different codes because Napier reads the disposition wording.
+        SYNTHETIC NONSENSE is the one that was coming out OTH."""
+        cells, _ = _row(_case([('820.2', 'FUGITIVE FROM JUSTICE - 1989',
+                                outcome)]))
+        assert cells['G'] == 'CIV'
+
+    @pytest.mark.parametrize('outcome,expected', [('WITHDRAWN', 'WTHD'),
+                                                  ('CHANGE OF VENUE', 'TNSF'),
+                                                  ('DISMISSED', 'DISM')])
+    def test_a_fugitive_hold_that_was_never_adjudicated_keeps_its_code(
+            self, outcome, expected):
+        """Deliberate, and the safer way round.
+
+        A withdrawn or transferred count has no adjudicated statute, so 820.2
+        never reaches column F and there is nothing for the statute rule to
+        read. Leaving these alone is also what protects the client: WTHD, TNSF
+        and DISM are all in the EXPUNGEMENT & 910.7 cleared set and CIV is not,
+        so recoding them would take away expungement eligibility to fix a
+        label. They already land in the same dischargeable and exempt buckets
+        CIV would have put them in.
+        """
+        cells, _ = _row(_case([('820.2', 'FUGITIVE FROM JUSTICE - 1989',
+                                outcome)]))
+        assert cells['G'] == expected
+
+    def test_violation_of_parole_reads_civil(self):
+        cells, _ = _row(_case([('908.1', 'VIOLATION OF PAROLE - 1985',
+                                'GUILTY')]))
+        assert cells['G'] == 'CIV'
+
+    def test_a_subsection_of_either_still_counts(self):
+        cells, _ = _row(_case([('820.2(1)', 'SYNTHETIC FUGITIVE', 'GUILTY')]))
+        assert cells['G'] == 'CIV'
+
+
+class TestProbationViolationStaysPut:
+    """The 20 cases and about $17,600 that a chapter rule would have taken."""
+
+    @pytest.mark.parametrize('outcome,expected', [
+        ('GUILTY', 'GTR'),
+        ('GUILTY - NEGOTIATED/VOLUN PLEA', 'GPL'),
+        ('DEFERRED', 'DEF'),
+        ('ADJUDICATED', 'JUV'),
+    ])
+    def test_violation_of_probation_keeps_its_own_code(self, outcome, expected):
+        """908.11 is one section from 908.1 and it is a real conviction. Iowa
+        Legal Aid said the conviction wins."""
+        cells, _ = _row(_case([('908.11', 'VIOLATION OF PROBATION - 1985',
+                                outcome)]))
+        assert cells['G'] == expected
+
+    def test_a_subsection_of_908_11_is_not_908_1_either(self):
+        cells, _ = _row(_case([('908.11(1)', 'SYNTHETIC PROBATION',
+                                'GUILTY')]))
+        assert cells['G'] == 'GTR'
+
+    def test_the_rest_of_chapter_908_is_untouched(self):
+        cells, _ = _row(_case([('908.3', 'SYNTHETIC CHAPTER 908', 'GUILTY')]))
+        assert cells['G'] == 'GTR'
+
+    def test_820_21_is_not_820_2(self):
+        cells, _ = _row(_case([('820.21', 'SYNTHETIC CHAPTER 820', 'GUILTY')]))
+        assert cells['G'] == 'GTR'
+
+
+class TestAConvictionAlongsideOneOfThem:
+    def test_the_conviction_wins(self):
+        """A case holding someone as a fugitive alongside a real conviction is
+        a case with a real conviction. Coding the row CIV would move the
+        conviction's whole balance into dischargeable and exempt."""
+        cells, _ = _row(_case([('820.2', 'SYNTHETIC FUGITIVE', 'GUILTY'),
+                               ('124.401', 'SYNTHETIC CONTROLLED', 'GUILTY')]))
+        assert cells['G'] == 'GTR'
+
+    def test_two_of_them_together_are_still_civil(self):
+        cells, _ = _row(_case([('820.2', 'SYNTHETIC FUGITIVE', 'GUILTY'),
+                               ('908.1', 'SYNTHETIC PAROLE', 'GUILTY')]))
+        assert cells['G'] == 'CIV'
+
+    def test_an_unadjudicated_count_does_not_block_it(self):
+        """Only adjudicated statutes reach column F, so a pending count next
+        to a fugitive hold leaves the fugitive hold speaking alone."""
+        cells, _ = _row(_case([('820.2', 'SYNTHETIC FUGITIVE', 'GUILTY'),
+                               ('321.285', 'SYNTHETIC SPEED', None)]))
+        assert cells['G'] == 'CIV'
+
+
+class TestWhatCivilDoesDownstream:
+    def test_it_is_in_the_dischargeable_and_exempt_sets(self):
+        """Worth pinning, because this is the part Iowa Legal Aid is agreeing
+        to when they ask for CIV. It moves the whole balance."""
+        workbook = load_workbook(FULL)
+        for name in ('BANKRUPTCY', 'EXEMPTIONS'):
+            formulas = [cell.value for row in workbook[name].iter_rows()
+                        for cell in row if isinstance(cell.value, str)]
+            assert any('"CIV"' in formula for formula in formulas), name
+
+    def test_it_does_not_make_a_case_expungeable(self):
+        """The other half of what they were told. CIV is not in the 901C.2
+        column's cleared set, so this does not turn a fugitive hold into an
+        expungement candidate."""
+        sheet = load_workbook(FULL)['EXPUNGEMENT & 910.7']
+        for row in sheet.iter_rows():
+            for cell in row:
+                if isinstance(cell.value, str) and '"DISM"' in cell.value:
+                    assert '"CIV"' not in cell.value, (
+                        "%s puts CIV in the dischargeable-or-acquitted test"
+                        % cell.coordinate)
+
+
+# -- COLLECTION BY CO ATTY --------------------------------------------------
+
+class TestCollectionByCountyAttorney:
+    def test_it_lands_in_the_collection_column(self):
+        assert crs.get_finance_column('COLLECTION BY CO ATTY') == 'K'
+
+    def test_it_sits_with_the_other_collection_fees(self):
+        """K is where the Linebarger and Department of Revenue fees go, which
+        is what makes it collection debt rather than unknown money."""
+        assert crs.get_finance_column('THIRD PARTY COLLECTION FEE') == 'K'
+        assert crs.get_finance_column('IOWA REVENUE COLLECTION FEE') == 'K'
+        assert crs.get_finance_column('COLLECTION BY CO ATTY') == \
+            crs.get_finance_column('THIRD PARTY COLLECTION FEE')
+
+    def test_the_other_unknown_fee_did_not_move_with_it(self):
+        assert crs.get_finance_column('DELINQUENT REVOLVING FUND') == 'P'
+
+    def test_an_unpaid_one_reaches_the_dischargeable_bucket(self):
+        """The rare case this is for. 47 of the 49 captured rows are marked
+        paid, so on almost every real case this changes nothing at all."""
+        case = _case([('321.285', 'SYNTHETIC SPEED', 'GUILTY')],
+                     financials=[{'detail': 'COLLECTION BY CO ATTY',
+                                  'amount': 25.00, 'paid': None}])
+        cells, _ = _row(case)
+        assert cells['K'] == 25.00
+        assert not cells['P']

--- a/tests/test_pending_cases.py
+++ b/tests/test_pending_cases.py
@@ -187,14 +187,22 @@ def test_a_closed_case_stops_counting_as_a_pending_charge():
     """A 1993 case was being counted as a live charge blocking expungement.
 
     CLOSED is not a disposition Napier can code, and the date is a fact ICOS
-    stated either way. Taking the date is what stops the false pending charge;
-    the code stays blank because that part really is unknown.
+    stated either way. Taking the date is what stops the false pending charge.
+
+    Column G used to stay blank here, on the reasoning that the disposition
+    really was unknown. Iowa Legal Aid asked for OTH instead on 5 August,
+    because blank is 0 to Excel and SOL, BANKRUPTCY and EXEMPTIONS all render
+    IF(G=0, "open charge", G), so honest silence was printing as a live charge
+    on three sheets. OTH is in no formula in either template, so the label is
+    the only thing that changed. tests/test_ari_aug5_items.py holds that down
+    from the other side, including the part where the wording is still
+    reported.
     """
     cells, unknown = _row(_case('CR/OLDCASE', 'SYNTHETIC OLD CASE CODE',
                                 status='CLOSED', dispo_date='09/23/1901'))
     assert cells['D'] == '09/23/1901'
-    assert cells['G'] in (None, '')
-    assert unknown == [('CLOSED', False)]
+    assert cells['G'] == 'OTH'
+    assert unknown == [('CLOSED', True)]
 
 
 def test_a_status_napier_cannot_read_is_reported_not_guessed():


### PR DESCRIPTION
Implements the remaining August 5 feedback now rather than leaving it promised in the email.

- Maps 820.2 fugitive and 908.1 parole matters to CIV.
- Explicitly protects 908.11 probation violations and mixed-conviction cases from that rule.
- Moves COLLECTION BY CO ATTY from unknown column P to collection column K.
- Labels paper-era CR/OLDCASE placeholders OTH so closed cases do not render as open charges.

Verification: 1,064 tests passed. Focused regression set: 44 passed.