### PR TITLE
Classify juvenile involved as a party role

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -144,6 +144,9 @@ KNOWN_PARTY_ROLES = frozenset({
     'DEFENDANT',
     'PRO SE DEFENDANT',
     'DEFENDANT - PRO SE',
+    # ICOS code JVIN: the juvenile whose case this is, unlike the suppressed
+    # JUVENILE - MOTHER OF and JUVENILE - FATHER OF relationship roles.
+    'JUVENILE - INVOLVED',
     'PLAINTIFF',
     'PRO SE PLAINTIFF',
     'PETITIONER',
@@ -600,5 +603,3 @@ def parse_case_financials(html, case):
             'tender': _text(cols[8]) if len(cols) > 8 else None,
         })
     case['financials'] = financials
-
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -154,6 +154,13 @@ def test_a_beneficiary_is_not_the_person_the_search_is_about():
     assert cases == []
 
 
+def test_a_juvenile_involved_is_the_person_the_search_is_about():
+    """JVIN identifies the juvenile party, not a relative or other nonparty."""
+    cases, _ = case_parser.parse_search(role_row('JUVENILE - INVOLVED'))
+    assert ids(cases) == ['00000  FECR000000']
+    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
+
+
 def test_the_two_role_lists_do_not_overlap():
     """A role in both would be suppressed and vouched for at the same time."""
     assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)


### PR DESCRIPTION
## What changed

- classify the ICOS `JUVENILE - INVOLVED` (`JVIN`) designation as a known party role
- add a parser regression test confirming the juvenile's case remains included

## Why

Search job `1e64bf37` completed successfully but generated an unrecognised-party-role alert because this valid ICOS party designation was absent from `KNOWN_PARTY_ROLES`.

Unlike the suppressed `JUVENILE - MOTHER OF` and `JUVENILE - FATHER OF` relationship roles, `JUVENILE - INVOLVED` identifies the juvenile whose case is being searched.

## Impact

Future searches retain these juvenile cases without generating a false novel-role alert.

## Validation

- `.venv/bin/pytest -q tests/test_parser.py tests/test_alerts.py -k 'role or ordinary_search'`
- 13 passed
