### PR TITLE
Classify property owner as a party role

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -157,6 +157,11 @@ KNOWN_PARTY_ROLES = frozenset({
     'PRO SE APPELLANT',
     'APPELLEE',
     'PRO SE APPELLEE',
+    # The owner named on a case about their property: condemnation, tax sale,
+    # a municipal infraction, an in rem forfeiture. The case can assess costs
+    # against them personally, so it is their record, unlike the LIEN FILER
+    # and INTERESTED PARTY bystander roles. Seen on a live search 2026-08-12.
+    'PROPERTY OWNER',
 })
 
 # The notice ICOS shows when a name matches more cases than it will list. The

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -161,6 +161,21 @@ def test_a_juvenile_involved_is_the_person_the_search_is_about():
     assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
 
 
+def test_a_property_owner_is_the_person_the_search_is_about():
+    """Found by a live search on 2026-08-12: ICOS answered with PROPERTY OWNER,
+    which was in neither list, so the case was kept by default and the role
+    mailed out as unrecognised.
+
+    The owner is named on a case about their own property — condemnation, tax
+    sale, a municipal infraction, an in rem forfeiture — and those cases can
+    assess costs against them personally, so the case belongs in their record
+    summary and the role is vouched for rather than suppressed.
+    """
+    cases, _ = case_parser.parse_search(role_row('PROPERTY OWNER'))
+    assert ids(cases) == ['00000  FECR000000']
+    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
+
+
 def test_the_two_role_lists_do_not_overlap():
     """A role in both would be suppressed and vouched for at the same time."""
     assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)


### PR DESCRIPTION
Closes out the 2026-08-12 unrecognised-role alert (search job b5323d36, role `PROPERTY OWNER`).

The role goes in `KNOWN_PARTY_ROLES`, not `NON_PARTY_ROLES`: a property owner is named on a case about their own property (condemnation, tax sale, municipal infraction, in rem forfeiture) and those cases can assess costs against them personally, so the case belongs in the client's record summary. Behavior in the workbook is unchanged — unknown roles were already kept by default — this just vouches for the role so the alert stops firing.

One new test mirroring the `JUVENILE - INVOLVED` one; suite is 1074 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013u25hSaHMsw9pp2veLd4EN