### PR TITLE
Work through Ari's 8/07 workbook review and the 8/13 alerts

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -103,6 +103,11 @@ NON_PARTY_ROLES = frozenset({
     'INTERPRETOR',
     'INTERVENOR',
     'JUDGE',
+    # The officer on a case, not its subject. Surfaced by a live search on
+    # 2026-08-13 that alerted NOVEL_ROLE; the same class as ATTORNEY, WITNESS
+    # and JUDGE -- being on the case professionally does not make the record
+    # theirs.
+    'LAW ENFORCEMENT',
     'LIEN FILER',
     'NAME OF TRUST',
     # Someone who filed a document into a case they are not party to,
@@ -226,7 +231,22 @@ charge_code_dict = {
     "WITHDRAWN": "WTHD",
     "NOT FILED": "NOTF",
     "CIVIL": "CIV",
-    "CHANGE OF VENUE": "TNSF"
+    "CHANGE OF VENUE": "TNSF",
+    # crs.charge_code_map learned this wording first, so a Hamilton public
+    # intoxication ICOS disposed GUILTY - OTHER coded GTR in column G while
+    # its charge description read [OTH]: the maps disagreed about the same
+    # count on the same row. The agreement test now walks both key sets, so
+    # the next wording either map learns alone fails a test instead of
+    # shipping a workbook that contradicts itself.
+    "GUILTY - OTHER": "GTR",
+    # A Story County OWI alerted on this on 2026-08-13, behind the spaced
+    # DNU - prefix strip_dnu now handles. JCS is Iowa's justice data system;
+    # the wording says another court adjudicated the count, without saying
+    # how it came out. OTH on purpose: the outcome lives on the other
+    # court's record, and OTH is the code that moves no money and marks the
+    # row as coded on less than a full answer. The entry exists so the
+    # wording stops alerting as unknown on every run that touches the case.
+    "JCS OTHER ADJ OTHER COURT": "OTH"
 }
 
 # The outcomes that mean no adjudicated charge, so the statutory code is not
@@ -242,6 +262,48 @@ charge_code_dict = {
 # VENUE was decided on the receiving county's case and not on this one, so its
 # statute is not the client's to carry off this record.
 NOT_ADJUDICATED = frozenset({"WTHD", "DISM", "ACQ", "NOTF", "TNSF"})
+
+# The 'Adjudicated Charge Class:' wording ICOS prints per count, and the
+# suffix it earns in column E ahead of the disposition suffix, so a count
+# reads FORGERY[FELD][GPL] and a 321.218 reads [SV][GTR] -- the shapes Iowa
+# Legal Aid's 8/07 review asked for by example. The class is the severity,
+# which the description alone often does not carry, and severity is what the
+# expungement waits and the licence consequences turn on.
+#
+# The felony codes are ICOS's own: a captured Polk burglary describes itself
+# as 'BURGLARY 1ST DEGREE - 1983 (FELB)' against a CLASS B FELONY class row,
+# and FELD is the code the 8/07 review used. Class B and the misdemeanours,
+# scheduled violation and contempt wordings are observed on captured pages;
+# classes A, C and D complete ICOS's own lettering and nothing else. OTHER is
+# deliberately absent: it is the class row's way of saying nothing, and a
+# suffix that says nothing is noise in a legal document. A wording not in
+# this map simply adds no suffix, so an ICOS wording we have not seen cannot
+# put a guess in column E.
+CHARGE_CLASS_SUFFIXES = {
+    "CLASS A FELONY": "FELA",
+    "CLASS B FELONY": "FELB",
+    "CLASS C FELONY": "FELC",
+    "CLASS D FELONY": "FELD",
+    "AGGRAVATED MISDEMEANOR": "AGMD",
+    "SERIOUS MISDEMEANOR": "SRMD",
+    "SIMPLE MISDEMEANOR": "SMMD",
+    "SCHEDULED VIOLATION": "SV",
+    "CONTEMPT OF COURT": "CNTP",
+}
+
+
+def strip_dnu(wording):
+    """The ICOS wording with its DNU (do not use) prefix taken off.
+
+    Iowa's clerks spell the prefix more than one way. Every capture through
+    July 2026 said DNU-GUILTY, unspaced, and both maps stripped exactly that.
+    Then a Story County OWI served 'DNU -JCS OTHER ADJ OTHER COURT', space
+    before the hyphen, and the literal replace could not see it, so the
+    wording missed both maps and alerted as unknown on every run that touched
+    the case. Anchored to the front because the prefix is a prefix: a wording
+    that mentions DNU anywhere else is its own wording.
+    """
+    return re.sub(r'^DNU\s*-\s*', '', (wording or '').strip())
 
 
 def disposition_code(wording):
@@ -260,7 +322,7 @@ def disposition_code(wording):
     next wording Iowa prefixes is already handled, and the two maps cannot
     answer differently about the same count again.
     """
-    return charge_code_dict.get((wording or "").replace("DNU-", ""), "OTH")
+    return charge_code_dict.get(strip_dnu(wording), "OTH")
 
 
 def parse_search(html):
@@ -400,6 +462,13 @@ def parse_case_charges(html, case):
     cur_section = None
     prior_charge = str()
     prior_description = str()
+    # Per count, in the order the page lists them. The accumulated strings
+    # above are what the sheet reads; these are what lets the end of this
+    # function look back at one count on its own. The disposition list cannot
+    # serve for that because it is built newest first.
+    original_description_parts = []
+    adjudication_wordings = []
+    adjudicated_classes = []
     #disposition = {}
     rows = soup.find_all('tr')
     for row in rows:
@@ -439,6 +508,7 @@ def parse_case_charges(html, case):
                 # statute the expungement sheet reads in 792 formulas.
                 cur_charge['original_charge'] = texts[1]
                 cur_charge['original_description'] = texts[3]
+                original_description_parts.append(texts[3])
             if len(texts) >= 3 and texts[0].startswith("Offense Date:"):
                 if 'prior_offenseDate' not in vars():
                     cur_charge['offenseDate'] = texts[1]
@@ -466,7 +536,17 @@ def parse_case_charges(html, case):
                 cur_charge['description'] = prior_description+texts[3]
                 prior_description = cur_charge['description']
             
+            if "Adjudicated Charge Class:" in texts:
+                # Present on every captured count, riding the same row as
+                # 'Judge:' and printing a non-breaking space when there is
+                # nothing to say, so appending per row stays in step with
+                # the counts. Found by label rather than position because
+                # the row leads with the judge.
+                position = texts.index("Adjudicated Charge Class:")
+                adjudicated_classes.append(
+                    texts[position + 1] if position + 1 < len(texts) else '')
             if len(texts) >= 4 and texts[0].startswith("Adjudication:"):
+                adjudication_wordings.append(texts[1])
                 charge_list.insert(0, texts[1])
                 cur_charge['disposition'] = charge_list
                 charge_date_list.insert(0, texts[3])
@@ -481,6 +561,28 @@ def parse_case_charges(html, case):
 
         
     if cur_charge is not None:
+        # The statutes as ICOS listed them, before the NOT_ADJUDICATED filter
+        # empties or trims 'charge'. crs.py needs them for exactly one thing:
+        # a case whose every count went unadjudicated here still reads CIV
+        # when every count cites a civil section. A Polk parole violation
+        # (908.1) disposed CHANGE OF VENUE had its statute stripped as TNSF,
+        # so the civil check saw no statutes at all and column G said
+        # transferred about a case Iowa Legal Aid asked to read as civil.
+        cur_charge['all_statutes'] = cur_charge['charge']
+        # The class suffix goes in ahead of the disposition suffix, count by
+        # count: FORGERY[GPL] becomes FORGERY[FELD][GPL]. Only counts that
+        # carry a disposition suffix get one -- a still-pending count is
+        # about to have its suffix stripped below, and ICOS leaves its class
+        # row blank anyway.
+        class_parts = cur_charge['description'].split(';')
+        for index, part in enumerate(class_parts):
+            if index >= len(adjudicated_classes):
+                break
+            class_suffix = CHARGE_CLASS_SUFFIXES.get(adjudicated_classes[index])
+            if class_suffix and part.endswith(']'):
+                head, _, tail = part.rpartition('[')
+                class_parts[index] = '%s[%s][%s' % (head, class_suffix, tail)
+        cur_charge['description'] = ';'.join(class_parts)
         if ";" not in cur_charge['description']:
             # A real adjudication keeps its [GTR]/[GPL]/[DISM] suffix just as a
             # multi-count case does. An empty adjudication row is different:
@@ -495,21 +597,40 @@ def parse_case_charges(html, case):
             if disp_code in NOT_ADJUDICATED:
                 cur_charge['charge'] = ""
         else:
-            cleaned_list = [] 
+            cleaned_list = []
+            display_list = []
             filter_charge_string = cur_charge['charge']
             filter_description_string = cur_charge['description']
             filter_charge_list = filter_charge_string.split(";")
             filter_description_list = filter_description_string.split(";")
             combined_list = list(zip(filter_charge_list, filter_description_list))
             for index, charge_tuple in enumerate(combined_list):
+                wording = (adjudication_wordings[index]
+                           if index < len(adjudication_wordings) else '')
+                if not wording and not charge_tuple[0]:
+                    # An empty adjudication row: no result and no adjudicated
+                    # statute, the count is still pending. The single-count
+                    # path already showed the charge as filed instead of a
+                    # synthetic [OTH]; this path did not, so a two-count open
+                    # OWI read [OTH];[OTH] in column E and ';' in column F and
+                    # staff could not tell what the State had accused the
+                    # client of. Same rule as one count: describe the charge
+                    # as filed with no suffix, keep column F to adjudicated
+                    # statutes only.
+                    display_list.append(
+                        original_description_parts[index]
+                        if index < len(original_description_parts) else '')
+                    continue
+                display_list.append(charge_tuple[1])
                 if any("[" + x + "]" in charge_tuple[1] for x in NOT_ADJUDICATED):
                     #print("Excluding: " + charge_tuple[0] + " " + charge_tuple[1])
                     pass
-                else: 
+                else:
                     #print("Including: " + charge_tuple[0] + " " + charge_tuple[1])
                     cleaned_list.append(charge_tuple[0])
             #print("Cleaned Charge List: " + ';'.join(cleaned_list))
             cur_charge['charge'] = ';'.join(cleaned_list)
+            cur_charge['description'] = ';'.join(display_list)
         charges.append(cur_charge)
         
     case['charges'] = charges

--- a/crs.py
+++ b/crs.py
@@ -1,6 +1,12 @@
 import itertools
 import re
 
+# For strip_dnu alone. The two modules keep separate disposition maps by
+# design, and the tests hold the key sets equal; the prefix strip is the one
+# reading they must share as code, because the 2026-08-13 alert was the two
+# of them agreeing on the maps and differing on the strip.
+import case_parser
+
 from calendar import monthrange
 from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
@@ -111,10 +117,21 @@ charge_code_map = {
     # finding came from a trial or a plea, which is the only thing "- OTHER"
     # leaves open. What it does not leave open is that the client was found
     # guilty, and that is what every sheet actually asks.
-    "GUILTY - OTHER": {"GTR":1}
+    "GUILTY - OTHER": {"GTR":1},
+    # A Story County OWI alerted on this on 2026-08-13, behind the spaced
+    # DNU - prefix case_parser.strip_dnu now handles. JCS is Iowa's justice
+    # data system; the wording says another court adjudicated the count,
+    # without saying how it came out. OTH on purpose, at the same rank an
+    # unrecognised wording gets: the outcome lives on the other court's
+    # record, and OTH moves no money and marks the row as coded on less than
+    # a full answer. The entry exists so the wording stops alerting as
+    # unknown on every run that touches the case, and so a case that also
+    # carries a real conviction still reads as the conviction.
+    "JCS OTHER ADJ OTHER COURT": {"OTH": 0.5}
 }
 
-# The rank for a disposition string charge_code_map has never seen. It sits
+# The rank for a disposition string charge_code_map has never seen, and the
+# rank the one OTH entry above carries explicitly. It sits
 # between a dismissal and a conviction on purpose.
 #
 # It used to be 3, above everything else here. So one unrecognised word on one
@@ -390,6 +407,14 @@ def cites_section(statutes, sections):
 # against 908.11 because it refuses a trailing digit.
 CIVIL_SECTIONS = ('820.2', '908.1')
 
+# Charge wordings that mean the same thing when the clerk typed no statute
+# worth matching: the case is Iowa holding somebody for another jurisdiction,
+# not a conviction of theirs. Iowa Legal Aid's August 2026 debt review asked
+# for the civil reading to reach these by name, alongside the sections above.
+# Matched against the count's description with its [GTR]-style suffixes
+# stripped, and only when the statute check could not already answer.
+CIVIL_DESCRIPTIONS = ('OUT OF COUNTY WARRANT',)
+
 # What a clerk files a pre-electronic-docket case under. Either spelling is
 # enough on its own, because the captured case carries both and there is no
 # reading of one without the other that means anything else.
@@ -423,6 +448,57 @@ def only_civil_sections(statutes):
     if not codes:
         return False
     return all(cites_section(code, CIVIL_SECTIONS) == "YES" for code in codes)
+
+
+# The codes that already clear the EXPUNGEMENT & 910.7 sheet's DISM ACQ?
+# column on their own -- all of its cleared set except TNSF. A civil-in-nature
+# case wearing one of these keeps it: CIV is not in that cleared set, so
+# recoding a dismissed fugitive hold would take away expungement eligibility
+# to fix a label, and it already lands in the same dischargeable and exempt
+# buckets CIV would put it in. TNSF is deliberately not here. It is in the
+# sheet's cleared set too, but Iowa Legal Aid's 8/07 review flagged a parole
+# violation reading "transferred" and asked for CIV by name, and transferred
+# is also the one wording that claims the case went on somewhere else rather
+# than ending -- so for TNSF the label is the error and the trade is theirs.
+KEEPS_ITS_CLEARED_CODE = ('WTHD', 'DISM', 'ACQ', 'NOTF')
+
+
+def reads_civil(charge, disposition=''):
+    """Does this case read as civil once every count has had its say?
+
+    disposition is the code column G is about to carry. Three ways in, tried
+    in order of how much the record can be trusted:
+
+    1. The adjudicated statutes are all CIVIL_SECTIONS. Unchanged.
+    2. Nothing was adjudicated at all -- every count's statute was stripped
+       by the NOT_ADJUDICATED filter -- but the statutes ICOS listed were
+       all civil. A Polk parole violation (908.1) disposed CHANGE OF VENUE
+       had its one statute stripped as TNSF, so check 1 saw an empty string
+       and column G said the case was transferred. Falling back to the
+       pre-filter statutes only when the adjudicated set is empty keeps the
+       only_civil_sections partition intact: a case with a real conviction
+       still answers to check 1 alone, and the conviction still wins.
+    3. Every count's description, suffixes stripped, is a CIVIL_DESCRIPTIONS
+       wording. For the fugitive holds ICOS files with no statute worth
+       matching, where checks 1 and 2 have nothing to read.
+
+    Checks 2 and 3 stand down when the code already protects the client --
+    see KEEPS_ITS_CLEARED_CODE. Check 1 never meets that gate: a code in
+    that set means the count was not adjudicated, so its statute never
+    reached 'charge'.
+    """
+    if only_civil_sections(charge.get('charge')):
+        return True
+    if disposition in KEEPS_ITS_CLEARED_CODE:
+        return False
+    if (not charge.get('charge')
+            and only_civil_sections(charge.get('all_statutes'))):
+        return True
+    descriptions = [re.sub(r'(\[[A-Z]+\])+$', '', part).strip()
+                    for part in str(charge.get('description') or '').split(';')]
+    descriptions = [part for part in descriptions if part]
+    return bool(descriptions) and all(
+        part.upper() in CIVIL_DESCRIPTIONS for part in descriptions)
 
 
 # How far back to look when working out what somebody is paying now. A court
@@ -732,7 +808,7 @@ def get_dominant_charge(charges, case_id=None):
     dates_by_code = {}
     unknown = set()
     for index, disposition in enumerate(raw_charge):
-        disposition = disposition.replace("DNU-", "")
+        disposition = case_parser.strip_dnu(disposition)
         if not disposition:
             # ICOS printed no adjudication for this count. That is the absence
             # of a disposition, and it used to be recorded as NOTF, NOT FILED,
@@ -812,7 +888,7 @@ def case_level_code(status):
     unknown_dispositions, which already puts the wording in column V and tells
     the run, so the case is visibly uncoded rather than quietly miscoded.
     """
-    entry = charge_code_map.get((status or "").replace("DNU-", "").strip())
+    entry = charge_code_map.get(case_parser.strip_dnu(status))
     return next(iter(entry)) if entry else None
 
 
@@ -1273,12 +1349,28 @@ def reconcile_financials(case):
                 line_paid = sum((entry[2] for entry in entries), Decimal(0))
                 missing = category['original'] - assessed
                 visible_due = assessed - line_paid
+                # The part of the balance no identified line accounts for.
+                # This used to be `missing` itself, guarded by requiring
+                # visible_due + missing == due, which holds only when every
+                # payment in the category landed on an identified line. A
+                # Webster case pays its COSTS through blank-detail rows the
+                # itemization never names: $201.95 assessed, $30.00 of it
+                # identified (an unpaid indigent defense fee), $137.95 paid
+                # against the unidentified rest. The old equality failed and
+                # the whole $64.00 balance was spread over the one identified
+                # line, so $34.00 of money ICOS never identifies inflated
+                # INDIGENT DEFENSE. due - visible_due is the same number as
+                # `missing` whenever the old equality held, and is still the
+                # unidentified balance when payments cannot be attributed;
+                # the bound against `missing` is what keeps it honest when
+                # the summary and itemization disagree some third way.
+                unknown_gap = due - visible_due
                 identifies_something = (name == 'FINE'
                                         or assessed > Decimal('0.01'))
                 if (identifies_something
                         and missing > Decimal('0.01')
-                        and abs((visible_due + missing) - due)
-                        <= Decimal('0.01')):
+                        and unknown_gap > Decimal('0.01')
+                        and unknown_gap <= missing + Decimal('0.01')):
                     recovered.append(name)
                     if name == 'FINE':
                         # No part of this went to UNKNOWN, so it is deliberately
@@ -1296,7 +1388,7 @@ def reconcile_financials(case):
                             column = get_finance_column(detail)
                             columns[column] = columns.get(
                                 column, Decimal(0)) + owed
-                        columns['P'] = columns.get('P', Decimal(0)) + missing
+                        columns['P'] = columns.get('P', Decimal(0)) + unknown_gap
                         landed[name] = {
                             get_finance_column(detail)
                             for detail, amount, paid in entries
@@ -1867,8 +1959,8 @@ def process_case(case, worksheet, row, as_of=None):
 
         # After the clerk's wording has had its say and before anything is
         # written, because what the charge is beats how the disposition was
-        # typed. This is the only place the statute overrides the code.
-        if only_civil_sections(charge['charge']):
+        # typed. This is the only place the charge overrides the code.
+        if reads_civil(charge, disposition):
             disposition = "CIV"
 
         worksheet['C' + i] = charge['offenseDate']

--- a/tests/test_ari_aug5_items.py
+++ b/tests/test_ari_aug5_items.py
@@ -169,23 +169,40 @@ class TestFugitiveAndParoleReadCivil:
         assert cells['G'] == 'CIV'
 
     @pytest.mark.parametrize('outcome,expected', [('WITHDRAWN', 'WTHD'),
-                                                  ('CHANGE OF VENUE', 'TNSF'),
                                                   ('DISMISSED', 'DISM')])
-    def test_a_fugitive_hold_that_was_never_adjudicated_keeps_its_code(
+    def test_a_fugitive_hold_that_ended_here_keeps_its_code(
             self, outcome, expected):
         """Deliberate, and the safer way round.
 
-        A withdrawn or transferred count has no adjudicated statute, so 820.2
-        never reaches column F and there is nothing for the statute rule to
-        read. Leaving these alone is also what protects the client: WTHD, TNSF
-        and DISM are all in the EXPUNGEMENT & 910.7 cleared set and CIV is not,
-        so recoding them would take away expungement eligibility to fix a
-        label. They already land in the same dischargeable and exempt buckets
-        CIV would have put them in.
+        A withdrawn count has no adjudicated statute, so 820.2 never reaches
+        column F and there is nothing for the statute rule to read. Leaving
+        these alone is also what protects the client: WTHD and DISM are in
+        the EXPUNGEMENT & 910.7 cleared set and CIV is not, so recoding them
+        would take away expungement eligibility to fix a label. They already
+        land in the same dischargeable and exempt buckets CIV would have put
+        them in.
         """
         cells, _ = _row(_case([('820.2', 'FUGITIVE FROM JUSTICE - 1989',
                                 outcome)]))
         assert cells['G'] == expected
+
+    def test_a_transferred_civil_case_reads_civil_anyway(self):
+        """The one cleared code the civil reading is allowed to replace.
+
+        This case used to sit in the parametrize above, with the same
+        reasoning: TNSF clears the expungement sheet and CIV does not. Then
+        Iowa Legal Aid's 8/07 workbook review flagged a real Polk parole
+        violation, 908.1 disposed CHANGE OF VENUE, reading transferred in
+        column G and asked for CIV by name. Transferred is also the one
+        cleared wording that claims the case continued somewhere else rather
+        than ending here, so for TNSF the label is the error and the
+        expungement trade is the client's own call. WTHD and DISM stay
+        protected above; nothing was said about them and their labels are
+        true.
+        """
+        cells, _ = _row(_case([('908.1', 'VIOLATION OF PAROLE - 1985',
+                                'CHANGE OF VENUE')]))
+        assert cells['G'] == 'CIV'
 
     def test_violation_of_parole_reads_civil(self):
         cells, _ = _row(_case([('908.1', 'VIOLATION OF PAROLE - 1985',

--- a/tests/test_ari_aug6_financials.py
+++ b/tests/test_ari_aug6_financials.py
@@ -51,6 +51,35 @@ def test_known_attorney_fee_survives_and_only_residual_is_unknown():
     assert columns['P'] == Decimal('34.00')
 
 
+def test_payments_on_blank_rows_still_leave_the_unpaid_fee_identified():
+    """The Webster shape from Iowa Legal Aid's 8/07 workbook review.
+
+    On the real case the clerk posted most of the payments against
+    continuation rows that name no fee: a detail of one space, no assessed
+    amount, real money in Paid. COSTS read original 201.95, paid 137.95,
+    due 64.00, and the one fee still unpaid was a 30.00 indigent defense
+    reimbursement. Iowa Legal Aid asked what the 64.00 was. The answer the
+    row has to keep giving: the 30.00 attorney fee identified in J, and the
+    34.00 ICOS never itemizes in P as unknown. A payment-only row must not
+    be read as an assessed fee, or P grows by money nobody owes.
+    """
+    case = {
+        'summary_categories': _summary(COSTS=('201.95', '137.95')),
+        'financials': [
+            {'detail': ' ', 'amount': None, 'paid': '100.00',
+             'paidDate': '04/06/2023', 'receipt': '000001', 'tender': 'EPY'},
+            {'detail': ' ', 'amount': None, 'paid': '37.95',
+             'paidDate': '11/21/2024', 'receipt': '000002', 'tender': 'EPY'},
+            {'detail': 'INDIGENT DEFENSE-MISDM-REIMBURSE STATE',
+             'amount': '30.00', 'paid': None, 'paidDate': None,
+             'receipt': None, 'tender': None},
+        ],
+    }
+    columns, _ = crs.reconcile_financials(case)
+    assert columns['J'] == Decimal('30.00')
+    assert columns['P'] == Decimal('34.00')
+
+
 def test_summary_only_fine_goes_to_fines_not_collection_costs():
     case = {
         'summary_categories': _summary(FINE=('3100.00', '0')),

--- a/tests/test_ari_aug7_workbook.py
+++ b/tests/test_ari_aug7_workbook.py
@@ -1,0 +1,255 @@
+"""Iowa Legal Aid's 7 August workbook review: what column E says about a count.
+
+Three of Ari's findings were about the same column. A conviction's description
+carried a disposition suffix but not the charge class, so FORGERY[GPL] could be
+anything from a scheduled violation to a class C felony and the reader had to
+open ICOS to find out. A case pending on more than one count read [OTH];[OTH]
+in column E and ';' in column F, so staff could not tell what the State had
+accused the client of. And an out of county warrant is Iowa holding somebody
+for another jurisdiction, not a conviction of theirs, but it is filed with no
+statute so the civil rule keyed on statutes could not see it.
+
+The pages here carry the row shapes of the real ones, including the detail the
+first cut of the class suffix missed: the class labels ride mid-row, sharing a
+row with 'DPS Number:' when filed and with 'Judge:' when adjudicated, so a
+parser reading only the first cell of each row never sees them.
+
+Synthetic pages throughout. The repository is public and a real charges page is
+one person's unredacted criminal record.
+"""
+
+import os
+import sys
+from datetime import date
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+CLINIC = date(2026, 7, 31)
+
+
+def _cells(*cells):
+    return '<tr>%s</tr>' % ''.join(
+        '<td><font size="2">%s</font></td>' % cell for cell in cells)
+
+
+def charges_page(counts):
+    """ICOS's real row shapes, class rows included.
+
+    counts is a list of dicts: statute, description, outcome, and optionally
+    adjudicated_class. outcome of None is the page ICOS serves before a court
+    has ruled: the adjudication block present, its cells empty, the class row
+    printing a non-breaking space.
+    """
+    html = ['<html><body><table>']
+    for number, count in enumerate(counts, start=1):
+        html.append(_cells('Count %02d' % number, 'Original Charge'))
+        html.append(_cells('Charge:', count['statute'],
+                           'Description:', count['description']))
+        html.append(_cells('Offense Date:', '01/01/1900', 'Arrest Date:', ''))
+        html.append(_cells('DPS Number:', '&nbsp;', 'Charge Class:',
+                           count.get('filed_class', '&nbsp;')))
+        html.append(_cells('Adjudication'))
+        if count['outcome'] is None:
+            html.append(_cells('Charge:', '', 'Description:', ''))
+            html.append(_cells('Adjudication:', '', 'Adjudication Date:', ''))
+            html.append(_cells('Judge:', '&nbsp;',
+                               'Adjudicated Charge Class:', '&nbsp;'))
+        else:
+            html.append(_cells('Charge:', count['statute'],
+                               'Description:', count['description']))
+            html.append(_cells('Adjudication:', count['outcome'],
+                               'Adjudication Date:', '02/02/1901'))
+            html.append(_cells('Judge:', 'SYNTHETIC, JUDGE A',
+                               'Adjudicated Charge Class:',
+                               count.get('adjudicated_class', '&nbsp;')))
+    html.append('</table></body></html>')
+    return ''.join(html).encode('utf-8')
+
+
+def parse(counts):
+    case = {'id': '00000  FECR000000'}
+    case_parser.parse_case_charges(charges_page(counts), case)
+    return case['charges'][0]
+
+
+def _case(counts, status='', dispo_date=''):
+    case = {'id': '00000  SMSM000000', 'county': 'SYNTHETIC',
+            'financials': [], 'summary_categories': [],
+            'sentences': [], 'summary_created_date': '01/01/1900',
+            'summary_disposition_date': dispo_date,
+            'summary_dispo_status': status}
+    case_parser.parse_case_charges(charges_page(counts), case)
+    return case
+
+
+def _row(case):
+    sheet = load_workbook(FULL)['CASE DATA']
+    unknown = crs.process_case(case, sheet, crs.FIRST_CASE_ROW, CLINIC)
+    i = str(crs.FIRST_CASE_ROW)
+    cells = {column: sheet[column + i].value
+             for column in ('D', 'E', 'F', 'G', 'V')}
+    return cells, unknown
+
+
+def count(statute, description, outcome, **extra):
+    return dict(statute=statute, description=description, outcome=outcome,
+                **extra)
+
+
+# -- the charge class in column E -------------------------------------------
+
+
+class TestChargeClassSuffixes:
+    def test_the_class_lands_between_description_and_disposition(self):
+        """Her exemplar shape: FORGERY[FELD][GPL], class first, result last."""
+        charge = parse([count('715A.2', 'SYNTHETIC FORGERY',
+                              'GUILTY - NEGOTIATED/VOLUN PLEA',
+                              adjudicated_class='CLASS D FELONY')])
+        assert charge['description'] == 'SYNTHETIC FORGERY[FELD][GPL]'
+
+    @pytest.mark.parametrize('wording,suffix',
+                             sorted(case_parser.CHARGE_CLASS_SUFFIXES.items()))
+    def test_every_wording_in_the_map_reaches_the_column(self, wording, suffix):
+        charge = parse([count('321.218', 'SYNTHETIC OFFENSE', 'GUILTY',
+                              adjudicated_class=wording)])
+        assert charge['description'] == \
+            'SYNTHETIC OFFENSE[%s][GTR]' % suffix
+
+    def test_each_count_wears_its_own_class(self):
+        """Classes pair with counts by position, so a two-count case where the
+        classes differ is the test that a shared index cannot fake."""
+        charge = parse([count('715A.2', 'SYNTHETIC FORGERY', 'GUILTY',
+                              adjudicated_class='CLASS D FELONY'),
+                        count('321.218', 'SYNTHETIC SCHEDULED', 'GUILTY',
+                              adjudicated_class='SCHEDULED VIOLATION')])
+        assert charge['description'] == \
+            'SYNTHETIC FORGERY[FELD][GTR];SYNTHETIC SCHEDULED[SV][GTR]'
+
+    def test_a_blank_class_row_adds_no_suffix(self):
+        """ICOS prints the row with a non-breaking space when it has nothing
+        to say, which is most of the corpus before 2010."""
+        charge = parse([count('321.218', 'SYNTHETIC OFFENSE', 'GUILTY')])
+        assert charge['description'] == 'SYNTHETIC OFFENSE[GTR]'
+
+    def test_a_wording_the_map_does_not_know_adds_no_suffix(self):
+        """Deliberate. ICOS's class vocabulary is its own, and a wording this
+        map has not vouched for going out as an invented bracket code would be
+        Napier asserting something nobody checked. No suffix, no guess."""
+        charge = parse([count('321.218', 'SYNTHETIC OFFENSE', 'GUILTY',
+                              adjudicated_class='OTHER')])
+        assert charge['description'] == 'SYNTHETIC OFFENSE[GTR]'
+
+    def test_a_dismissed_count_still_shows_its_class(self):
+        """The class describes the charge, not the conviction, so it stays on
+        a dismissed count's description while the statute still stays out of
+        column F."""
+        charge = parse([count('124.401(5)', 'SYNTHETIC POSSESSION',
+                              'DISMISSED',
+                              adjudicated_class='AGGRAVATED MISDEMEANOR')])
+        assert charge['description'] == 'SYNTHETIC POSSESSION[AGMD][DISM]'
+        assert charge['charge'] == ''
+
+    def test_the_suffix_survives_into_the_workbook_column(self):
+        cells, _ = _row(_case([count('123.46(2)', 'SYNTHETIC INTOXICATION',
+                                     'GUILTY - OTHER',
+                                     adjudicated_class='SIMPLE MISDEMEANOR')]))
+        assert cells['E'] == 'SYNTHETIC INTOXICATION[SMMD][GTR]'
+
+
+# -- a case pending on more than one count ----------------------------------
+
+
+class TestAMultiCountPendingCase:
+    PENDING = [count('321.561', 'SYNTHETIC BARRED', None),
+               count('321.218', 'SYNTHETIC DENIED', None)]
+
+    def test_the_counts_show_as_filed(self):
+        """Her AGCR400914: two open counts read [OTH];[OTH] in column E and
+        ';' in column F. The single-count path already showed the charge as
+        filed; this is the same rule reaching the multi-count path."""
+        charge = parse(self.PENDING)
+        assert charge['description'] == 'SYNTHETIC BARRED;SYNTHETIC DENIED'
+        assert charge['charge'] == ''
+
+    def test_no_count_wears_a_synthetic_suffix(self):
+        """No suffix at all: disposition_code cannot name an absent result,
+        and [OTH] was the parser talking about its own confusion."""
+        assert '[' not in parse(self.PENDING)['description']
+
+    def test_a_pending_count_beside_a_conviction_stays_as_filed(self):
+        """The mixed case: the adjudicated count keeps its suffix and its
+        statute, the open one is described as filed and keeps out of F."""
+        charge = parse([count('124.401', 'SYNTHETIC CONTROLLED', 'GUILTY'),
+                        count('321.218', 'SYNTHETIC DENIED', None)])
+        assert charge['description'] == \
+            'SYNTHETIC CONTROLLED[GTR];SYNTHETIC DENIED'
+        assert charge['charge'] == '124.401'
+
+    def test_the_row_still_reads_as_an_open_case(self):
+        """The guard the fix must not break: blank D is how the EXPUNGEMENT
+        sheet counts pending charges, and blank G is what SOL, BANKRUPTCY and
+        EXEMPTIONS render as "open charge". Describing the counts must not
+        smuggle in a date or a code."""
+        cells, _ = _row(_case(self.PENDING))
+        assert cells['D'] in (None, '')
+        assert cells['F'] in (None, '')
+        assert cells['G'] in (None, '')
+        assert cells['E'] == 'SYNTHETIC BARRED;SYNTHETIC DENIED'
+
+
+# -- out of county warrant ---------------------------------------------------
+
+
+class TestOutOfCountyWarrant:
+    """The fugitive holds ICOS files with no statute worth matching.
+
+    The 5 August civil rule reads statutes, and these counts cite none, so a
+    clerk's disposition wording still decided column G. Iowa Legal Aid asked
+    for the civil reading to reach them by name.
+    """
+
+    def test_it_reads_civil_whatever_the_clerk_typed(self):
+        cells, _ = _row(_case([count('', 'OUT OF COUNTY WARRANT', 'GUILTY')]))
+        assert cells['G'] == 'CIV'
+
+    def test_the_class_suffix_does_not_hide_the_wording(self):
+        """The name match strips suffixes, and after the class change there
+        can be two of them stacked."""
+        cells, _ = _row(_case([count('', 'OUT OF COUNTY WARRANT', 'GUILTY',
+                                     adjudicated_class='SIMPLE MISDEMEANOR')]))
+        assert cells['G'] == 'CIV'
+
+    def test_a_dismissed_one_keeps_its_cleared_code(self):
+        """Same protection as the 820.2 holds: DISM clears the expungement
+        sheet and CIV does not, so the label stands where the label is true."""
+        cells, _ = _row(_case([count('', 'OUT OF COUNTY WARRANT',
+                                     'DISMISSED')]))
+        assert cells['G'] == 'DISM'
+
+    def test_a_conviction_alongside_it_wins(self):
+        """Every count, not any count -- the same rule as the statute path."""
+        cells, _ = _row(_case([count('', 'OUT OF COUNTY WARRANT', 'GUILTY'),
+                               count('124.401', 'SYNTHETIC CONTROLLED',
+                                     'GUILTY')]))
+        assert cells['G'] == 'GTR'
+
+    def test_two_of_them_together_are_still_civil(self):
+        cells, _ = _row(_case([count('', 'OUT OF COUNTY WARRANT', 'GUILTY'),
+                               count('', 'OUT OF COUNTY WARRANT', 'GUILTY')]))
+        assert cells['G'] == 'CIV'
+
+    def test_some_other_unmatched_description_is_not_civil(self):
+        """The list is a list, not a heuristic. A statute-less count with a
+        wording nobody vouched for keeps whatever the disposition said."""
+        cells, _ = _row(_case([count('', 'SYNTHETIC MYSTERY HOLD',
+                                     'GUILTY')]))
+        assert cells['G'] == 'GTR'

--- a/tests/test_charge_pages.py
+++ b/tests/test_charge_pages.py
@@ -72,6 +72,11 @@ NOT_ADJUDICATED_WORDINGS = [
     ('DNU-DISMISSED', 'DISM'),
     ('DNU-ACQUITTED', 'ACQ'),
     ('DNU-NOT FILED', 'NOTF'),
+    # And the prefix as Story County spaces it: 'DNU -', space before the
+    # hyphen. A literal replace of 'DNU-' cannot see it and the wording fell
+    # through to OTH, which is how 'DNU -JCS OTHER ADJ OTHER COURT' alerted
+    # on 13 August 2026.
+    ('DNU -DISMISSED', 'DISM'),
 ]
 
 
@@ -128,17 +133,88 @@ def test_the_two_maps_agree_on_what_a_prefixed_wording_means():
     """
     import crs
     for wording in case_parser.charge_code_dict:
-        for form in (wording, 'DNU-' + wording):
+        # Both prefix shapes ICOS has actually served: DNU-GUILTY from Polk
+        # and 'DNU -JCS OTHER ADJ OTHER COURT' from Story, space before the
+        # hyphen. Both sides strip with the same function now, but the test
+        # keeps feeding both shapes so a regression to a literal replace
+        # fails here instead of in an alert email.
+        for form in (wording, 'DNU-' + wording, 'DNU -' + wording):
             ours = case_parser.disposition_code(form)
-            theirs = crs.charge_code_map.get(form.replace('DNU-', ''))
+            theirs = crs.charge_code_map.get(case_parser.strip_dnu(form))
             if theirs is None:
                 continue
             assert ours == next(iter(theirs)), form
 
 
+def test_neither_map_knows_a_wording_the_other_does_not():
+    """Walking one map's keys cannot see a wording only the other learned.
+
+    GUILTY - OTHER went into crs.charge_code_map alone, so a Hamilton public
+    intoxication coded GTR in column G while its description read [OTH], and
+    the agreement test above never looked because it iterates case_parser's
+    keys. The key sets have to match before agreement on shared keys means
+    anything.
+    """
+    import crs
+    assert set(case_parser.charge_code_dict) == set(crs.charge_code_map)
+
+
 def test_a_deferred_judgment_is_adjudicated():
     """A deferred judgment is still an adjudication and still carries debt."""
     assert parse(('321J.2', 'SYNTHETIC OWI', 'DEFERRED'))['charge'] == '321J.2'
+
+
+# -- the DNU prefix ---------------------------------------------------------
+
+@pytest.mark.parametrize('form,bare', [
+    ('DNU-GUILTY', 'GUILTY'),
+    ('DNU -JCS OTHER ADJ OTHER COURT', 'JCS OTHER ADJ OTHER COURT'),
+    ('DNU - GUILTY', 'GUILTY'),
+    ('  DNU-GUILTY  ', 'GUILTY'),
+])
+def test_strip_dnu_takes_off_the_prefix_however_it_is_spaced(form, bare):
+    assert case_parser.strip_dnu(form) == bare
+
+
+def test_strip_dnu_only_reads_the_front_of_the_wording():
+    """DNU is a prefix, not a substring. A wording that merely contains the
+    letters keeps them."""
+    assert case_parser.strip_dnu('GUILTY') == 'GUILTY'
+    assert case_parser.strip_dnu('REDNU-CTION') == 'REDNU-CTION'
+    assert case_parser.strip_dnu('') == ''
+    assert case_parser.strip_dnu(None) == ''
+
+
+class TestTheStoryCountyWording:
+    """'JCS OTHER ADJ OTHER COURT': another court adjudicated, JCS is relaying.
+
+    A Story County OWI served it with the spaced DNU prefix on 13 August 2026
+    and Napier alerted on every run because neither map knew the wording. It
+    codes OTH: the adjudication happened somewhere ICOS is not showing, so the
+    row moves no money and the note still travels.
+    """
+
+    def test_it_codes_oth_in_both_maps(self):
+        assert case_parser.disposition_code('JCS OTHER ADJ OTHER COURT') == \
+            'OTH'
+        assert case_parser.disposition_code(
+            'DNU -JCS OTHER ADJ OTHER COURT') == 'OTH'
+        import crs
+        assert crs.charge_code_map['JCS OTHER ADJ OTHER COURT'] == \
+            {'OTH': crs.OTH_RANK}
+
+    def test_a_conviction_alongside_it_still_wins_the_case_code(self):
+        """The OWCR056327 shape: the count another court took stays OTH, the
+        count this court adjudicated codes the case."""
+        charge = parse(GUILTY,
+                       ('321J.2', 'SYNTHETIC OWI',
+                        'DNU -JCS OTHER ADJ OTHER COURT'))
+        assert '[OTH]' in charge['description']
+        import crs
+        dominant = crs.get_dominant_charge([charge])
+        assert dominant['disposition'] == 'GTR'
+        # And no alert: the wording is known now, not an unknown coded OTH.
+        assert dominant['unknown_dispositions'] == []
 
 
 # -- the invariant the typo broke ------------------------------------------

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -154,6 +154,19 @@ def test_a_beneficiary_is_not_the_person_the_search_is_about():
     assert cases == []
 
 
+def test_law_enforcement_is_not_the_person_the_search_is_about():
+    """Served by a live search on 2026-08-13: someone matching the searched
+    name is on a case as LAW ENFORCEMENT, a role in neither list, so the case
+    was kept by default and the role mailed out as unrecognised on every run.
+
+    The officer is on the case professionally, like ATTORNEY, WITNESS and
+    JUDGE. Nothing on it is their record or their debt, so the case stays out
+    of the summary.
+    """
+    cases, _ = case_parser.parse_search(role_row('LAW ENFORCEMENT'))
+    assert cases == []
+
+
 def test_a_juvenile_involved_is_the_person_the_search_is_about():
     """JVIN identifies the juvenile party, not a relative or other nonparty."""
     cases, _ = case_parser.parse_search(role_row('JUVENILE - INVOLVED'))


### PR DESCRIPTION
Six findings from Iowa Legal Aid's 8/07 review of a client workbook, plus the two automated alerts from 8/13, each verified against the live ICOS case that raised it (captures kept outside the repo).

- **Charge class suffixes (finding 3):** column E now reads `FORGERY[FELD][GPL]` / `[SV][GTR]` from a vouched-for map of ICOS's `Adjudicated Charge Class` wordings. The labels ride mid-row (with `DPS Number:` / `Judge:`), so they're found by label rather than position. Unknown wordings add no suffix.
- **Multi-count pending cases (finding 5):** counts with an empty adjudication row show as filed instead of `[OTH];[OTH]`; column F stays empty and column D stays blank, so EXPUNGEMENT pending detection and the "open charge" rendering are untouched. Verified on the live two-count case from the review.
- **CIV for transfers and fugitive holds (finding 6):** a 908.1 parole violation disposed CHANGE OF VENUE reads CIV off the pre-filter statutes; OUT OF COUNTY WARRANT reads CIV by description. WTHD/DISM/ACQ/NOTF holds keep their codes because those clear the expungement sheet and CIV doesn't — TNSF is deliberately allowed through, as asked.
- **8/13 alerts:** `GUILTY - OTHER` and `JCS OTHER ADJ OTHER COURT` join both disposition maps (key sets held equal by test); the DNU prefix strips via one shared `strip_dnu` that handles Story County's spaced `DNU -` form; `LAW ENFORCEMENT` joins NON_PARTY_ROLES.

Full suite: 1111 passed, 0 failed (baseline had 3 failures from the earlier CIV cut; resolved by the cleared-code gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4sPpCx52MzxaP7zkACyJx