### PR TITLE
Ari 18 Aug feedback: conviction date in D, suffix vocabulary, JUVENILE ADMISSION

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -368,17 +368,41 @@ other six have no disposition of any kind and are genuinely pending. Both of the
 uncoded rows leave column G empty, which BANKRUPTCY, EXEMPTIONS and SOL all read
 as "open charge", and the row says so in column V.
 
+## Two answers from 18 August 2026 waiting on a real page
+
+Iowa Legal Aid's 18 August 2026 email settled the charge class suffix
+vocabulary — the misdemeanour codes end in S, not D, and a non-scheduled
+violation earns [NSV] — and supplied five real Polk county traffic cases that
+carry it. None of those pages is captured yet, so the map holds the class
+wording in two candidate spellings, hyphenated and not, and a test says it
+will narrow to whichever one the real page uses once one is replayed. Until
+then one of the two entries is a guess about ICOS's habits.
+
+The same email supplied a real two-case example of OUT OF COUNTY WARRANT,
+which appears among a case's filings rather than its dispositions, and said
+the current output on such cases, other civil and CLOSED, is acceptable to
+them. That reading has not been checked against the real pages either, so the
+confirmation is theirs and not yet the corpus's. Both replays wait on an
+off-hours capture window, because live ICOS runs on the shared accounts do
+not happen during business hours.
+
 ## Smaller ones
 
 A case whose counts were adjudicated on different days is reported under the
-last date that carries the winning disposition code, so the code and the date
-on the row agree with each other. On one of the 210 cases that is 9 days
-before the case's actual last adjudication, because the later count was
-disposed under a different code. Pairing the code with its own date and
-reporting the case as finished on its last day cannot both be true, and Iowa
-Legal Aid settled it on 3 August 2026 in favour of the pairing: a probation
-violation's date on a conviction's row was the thing they flagged. Column V
-lists the other dates when the counts were disposed on different days.
+earliest date that carries the winning disposition code, so the code and the
+date on the row agree with each other and the date is the conviction's own.
+Iowa Legal Aid settled this in two halves. On 3 August 2026 they settled the
+pairing: a probation violation's date on a conviction's row was the thing they
+flagged, so column D follows the count column G names. On 18 August 2026 they
+settled which date wins when several counts share the winning code: the
+conviction date, meaning the earliest, because the expungement waiting periods
+on four sheets run off column D and a contempt or violation found guilty years
+later was holding them open past when the client had cleared them. The cost
+runs the other way on the SOL sheet, which they accepted: a judgment can look
+older than the last enforceable piece of it, so the column V note, in their
+own words, sends an SOL reader back to ICOS for the timeline of debt
+assessed. Column V lists the other dates when the counts were disposed on
+different days.
 
 Column I, "Under supervison?", was briefly answered off the sentence table on
 the charges page and is deliberately not any more. Iowa Legal Aid answered on

--- a/case_parser.py
+++ b/case_parser.py
@@ -228,6 +228,10 @@ charge_code_dict = {
     "NOT GUILTY": "ACQ",
     "WAIVED TO ADULT COURT": "JWV",
     "ADJUDICATED": "JUV",
+    # Alerted 2026-08-18 on two JVJV cases. The juvenile court's admission is
+    # its guilty plea, so it codes as the adjudication it is. See the twin
+    # entry in crs.charge_code_map for the full reasoning.
+    "JUVENILE ADMISSION": "JUV",
     "WITHDRAWN": "WTHD",
     "NOT FILED": "NOTF",
     "CIVIL": "CIV",
@@ -279,15 +283,26 @@ NOT_ADJUDICATED = frozenset({"WTHD", "DISM", "ACQ", "NOTF", "TNSF"})
 # suffix that says nothing is noise in a legal document. A wording not in
 # this map simply adds no suffix, so an ICOS wording we have not seen cannot
 # put a guess in column E.
+#
+# The misdemeanour suffixes are Iowa Legal Aid's, not ICOS's: their 8/18
+# review corrected the first cut's AGMD/SRMD/SMMD to the AGMS/SRMS/SMMS
+# their attorneys actually write, and added NSV for a non-scheduled
+# violation. The left-hand wordings still belong to ICOS. NON-SCHEDULED
+# VIOLATION is carried in both spellings ICOS could plausibly print because
+# no page bearing it has been captured yet -- Iowa Legal Aid named five Polk
+# NTA cases that carry one, and a wrong guess here costs nothing: a wording
+# that matches neither spelling adds no suffix.
 CHARGE_CLASS_SUFFIXES = {
     "CLASS A FELONY": "FELA",
     "CLASS B FELONY": "FELB",
     "CLASS C FELONY": "FELC",
     "CLASS D FELONY": "FELD",
-    "AGGRAVATED MISDEMEANOR": "AGMD",
-    "SERIOUS MISDEMEANOR": "SRMD",
-    "SIMPLE MISDEMEANOR": "SMMD",
+    "AGGRAVATED MISDEMEANOR": "AGMS",
+    "SERIOUS MISDEMEANOR": "SRMS",
+    "SIMPLE MISDEMEANOR": "SMMS",
     "SCHEDULED VIOLATION": "SV",
+    "NON-SCHEDULED VIOLATION": "NSV",
+    "NON SCHEDULED VIOLATION": "NSV",
     "CONTEMPT OF COURT": "CNTP",
 }
 

--- a/crs.py
+++ b/crs.py
@@ -93,6 +93,15 @@ charge_code_map = {
     "NOT GUILTY": {"ACQ":0},
     "WAIVED TO ADULT COURT": {"JWV":0},
     "ADJUDICATED": {"JUV":1},
+    # Alerted on a real run 2026-08-18: two juvenile delinquency cases (both
+    # JVJV numbers) carried this wording and coded OTH. It is the juvenile
+    # court's admission -- the delinquency analogue of a guilty plea, an
+    # adjudication reached by the child admitting the allegation rather than
+    # the court finding it -- so it earns JUV at the rank of a conviction,
+    # exactly as ADJUDICATED does. On a case that is not the juvenile
+    # court's, get_dominant_charge demotes any JUV to JUV_RANK_ADULT_CASE by
+    # code, not by wording, so this entry inherits that safety unchanged.
+    "JUVENILE ADMISSION": {"JUV":1},
     "WITHDRAWN": {"WTHD":0},
     "NOT FILED": {"NOTF":0},
     "CIVIL": {"CIV":0},
@@ -281,22 +290,19 @@ ORDINANCE_VEHICULAR_NOTE = (
     "it."
 )
 
-# The row has one disposition date and the case had several. Column D now holds
-# the one that goes with the code in column G, which is the pairing the sheets
-# assume, but the SOL sheet runs its twenty year test off that single date and
-# will apply it to every dollar on the row including debt from a count disposed
-# years earlier.
+# The row has one disposition date and the case had several. Column D holds the
+# earliest date on the counts behind the code in column G -- the conviction
+# date, per Iowa Legal Aid on 18 August 2026, because the expungement waiting
+# periods run off D and a contempt or probation violation was pushing it years
+# forward. The SOL sheet runs its twenty year test off that same single date
+# and now sees the oldest one, so the note sends an SOL reader back to ICOS.
+# The wording is close to the one Iowa Legal Aid supplied; two earlier drafts
+# here were misread, so the sentence naming what column D counts is hers.
 DISPOSITION_SPREAD_NOTE = (
-    "Counts on this case were disposed on different dates (%s). Column G is the "
-    "disposition code and column D is a date: %s, the day the count behind that "
-    "code was disposed. The SOL sheet applies its 20 year test to that one date "
-    "for the whole row, so if this case is near the 20 year line check the "
-    "counts separately."
+    "This case has %d disposition dates (%s). Column D counts the conviction "
+    "date: %s. For SOL analysis please review ICOS information for the "
+    "timeline of debt assessed."
 )
-
-# The wording above used to be "Column D holds X, the date of the disposition in
-# column G", which Iowa Legal Aid read as a claim that column G holds a date.
-# It does not and never did. Both halves are named now.
 
 # What column V says when a case that is not a JVJV still comes out as JUV. See
 # JUV_RANK_ADULT_CASE for why that is now rare and why it is still possible.
@@ -846,20 +852,24 @@ def get_dominant_charge(charges, case_id=None):
     # count and adjudicated on another more than a year later reported the later
     # code against the earlier date.
     #
-    # That pairing is not cosmetic. The SOL sheet asks IF(D+7300 < today) on
-    # every row, the twenty year limit on enforcing an Iowa judgment, and it
-    # sorts the row's debt into time barred or "NO ARGUMENT" on the answer.
-    # Taking the earliest date available makes a judgment look older than it is,
-    # so the error ran toward telling an attorney a debt had aged out when it
-    # had not.
-    #
-    # Where several counts share the winning code, the last of them is the day
-    # the case finished reaching that disposition, and it is also the reading
-    # that will not retire a debt early.
+    # Where several counts share the winning code, the FIRST of them dates the
+    # row. This took the last until Iowa Legal Aid overruled it on 18 August
+    # 2026, and both readings are defensible, so the choice is theirs to make:
+    # a contempt or probation violation found guilty years into the sentence
+    # shares GTR with the conviction it violates, and taking the later date
+    # made the conviction look years younger than it is. The expungement
+    # waiting periods -- the misdemeanour eight years, public intoxication,
+    # PAULA, juvenile prostitution -- all run off column D on every workbook,
+    # and a date pushed forward holds a remedy back past when the client
+    # earned it. The cost runs the other way on the SOL sheet, whose twenty
+    # year test now sees the older date and can retire enforcement of the
+    # later judgment early; Iowa Legal Aid rates that acceptable because an
+    # SOL analysis is rare and the spread note on the row sends its reader
+    # back to ICOS for the timeline.
     winning_dates = dates_by_code.get(delisted['disposition']) or []
     if winning_dates:
-        delisted['dispositionDate'] = max(
-            winning_dates, key=lambda d: parse_us_date(d) or date.min)
+        delisted['dispositionDate'] = min(
+            winning_dates, key=lambda d: parse_us_date(d) or date.max)
 
     # A row that compresses counts disposed on different days is saying less
     # than the case does, and the sheet that reads the date cannot see the
@@ -2014,7 +2024,7 @@ def process_case(case, worksheet, row, as_of=None):
     spread = charge.get('disposition_date_spread') or []
     if spread and owes_money(worksheet, i):
         append_note(worksheet, i, DISPOSITION_SPREAD_NOTE
-                    % (", ".join(spread), disposition_date))
+                    % (len(spread), ", ".join(spread), disposition_date))
     # Only where the SOL sheet has something to be wrong about. A pending case
     # with nothing outstanding puts zero in all three of its columns whatever
     # column D says, and a caveat there describes a decision nobody is making.

--- a/tests/test_adult_adjudication.py
+++ b/tests/test_adult_adjudication.py
@@ -219,9 +219,13 @@ def test_the_juvenile_row_is_left_alone():
 
 def test_the_spread_note_does_not_claim_column_g_holds_a_date():
     """Their words: "The note says that column G will hold the disposition date,
-    but that one should just have the dispo code". It never held a date. The
-    wording invited the reading and now names both columns."""
-    note = crs.DISPOSITION_SPREAD_NOTE % ('01/01/1900, 03/03/1903',
+    but that one should just have the dispo code". It never held a date, and
+    two drafts written here were misread in a row. The wording is now the
+    sentence Iowa Legal Aid supplied on 18 August 2026, which does not
+    mention column G at all: column D counts the conviction date, and an SOL
+    reader goes back to ICOS."""
+    note = crs.DISPOSITION_SPREAD_NOTE % (2, '01/01/1900, 03/03/1903',
                                           '01/01/1900')
-    assert 'Column G is the disposition code' in note
+    assert 'Column D counts the conviction date' in note
+    assert 'column G' not in note
     assert 'the date of the disposition in column G' not in note

--- a/tests/test_ari_aug7_workbook.py
+++ b/tests/test_ari_aug7_workbook.py
@@ -155,14 +155,35 @@ class TestChargeClassSuffixes:
         charge = parse([count('124.401(5)', 'SYNTHETIC POSSESSION',
                               'DISMISSED',
                               adjudicated_class='AGGRAVATED MISDEMEANOR')])
-        assert charge['description'] == 'SYNTHETIC POSSESSION[AGMD][DISM]'
+        assert charge['description'] == 'SYNTHETIC POSSESSION[AGMS][DISM]'
         assert charge['charge'] == ''
 
     def test_the_suffix_survives_into_the_workbook_column(self):
         cells, _ = _row(_case([count('123.46(2)', 'SYNTHETIC INTOXICATION',
                                      'GUILTY - OTHER',
                                      adjudicated_class='SIMPLE MISDEMEANOR')]))
-        assert cells['E'] == 'SYNTHETIC INTOXICATION[SMMD][GTR]'
+        assert cells['E'] == 'SYNTHETIC INTOXICATION[SMMS][GTR]'
+
+    def test_the_suffix_codes_are_iowa_legal_aids_own(self):
+        """Her 8/18 correction, pinned: FELA through FELD, AGMS, SRMS, SMMS,
+        SV, NSV -- plus CNTP for the contempt rows she asked for by example.
+        The first cut shipped AGMD/SRMD/SMMD, which read fine and were codes
+        nobody at Iowa Legal Aid writes. The right-hand side of the map is
+        her staff's vocabulary, not a free choice, so a new entry whose code
+        is not on this list has to be one she has asked for."""
+        assert sorted(set(case_parser.CHARGE_CLASS_SUFFIXES.values())) == [
+            'AGMS', 'CNTP', 'FELA', 'FELB', 'FELC', 'FELD', 'NSV', 'SMMS',
+            'SRMS', 'SV']
+
+    def test_both_spellings_of_a_non_scheduled_violation_read_nsv(self):
+        """No captured page carries the class row yet -- her five Polk NTA
+        examples are pending capture -- so the map holds the hyphenated and
+        the spaced spelling and this test holds the map to both. When the
+        real page lands, the spelling it shows stays and this test narrows."""
+        for wording in ('NON-SCHEDULED VIOLATION', 'NON SCHEDULED VIOLATION'):
+            charge = parse([count('321.218', 'SYNTHETIC DENIED', 'GUILTY',
+                                  adjudicated_class=wording)])
+            assert charge['description'] == 'SYNTHETIC DENIED[NSV][GTR]'
 
 
 # -- a case pending on more than one count ----------------------------------

--- a/tests/test_charge_pages.py
+++ b/tests/test_charge_pages.py
@@ -217,6 +217,46 @@ class TestTheStoryCountyWording:
         assert dominant['unknown_dispositions'] == []
 
 
+class TestTheJuvenileAdmissionWording:
+    """'JUVENILE ADMISSION': the juvenile court's guilty plea.
+
+    Two JVJV delinquency cases served it on 18 August 2026 and both coded OTH
+    and alerted, because neither map knew the wording. An admission is the
+    adjudication reached by the child admitting the allegation rather than the
+    court finding it, so it earns JUV at the rank ADJUDICATED already earns,
+    and the demotion on non-juvenile case numbers keys on the code, so it
+    rides along without being restated.
+    """
+
+    def test_it_codes_juv_in_both_maps(self):
+        assert case_parser.disposition_code('JUVENILE ADMISSION') == 'JUV'
+        assert case_parser.disposition_code('DNU-JUVENILE ADMISSION') == 'JUV'
+        import crs
+        assert crs.charge_code_map['JUVENILE ADMISSION'] == {'JUV': 1}
+
+    def test_a_jvjv_case_reads_juv_and_stops_alerting(self):
+        """The alerted shape: a delinquency case whose only adjudication
+        is the admission. The case number is synthetic; both real ones
+        were JVJV dockets."""
+        charge = parse(
+            ('232.2', 'SYNTHETIC DELINQUENCY', 'JUVENILE ADMISSION'))
+        import crs
+        dominant = crs.get_dominant_charge([charge], '00000  JVJV000000')
+        assert dominant['disposition'] == 'JUV'
+        # And no alert: the wording is known now, not an unknown coded OTH.
+        assert dominant['unknown_dispositions'] == []
+
+    def test_on_an_adult_case_it_loses_to_a_real_conviction(self):
+        """The clerks enter juvenile vocabulary on adult cases too; the
+        JUV_RANK_ADULT_CASE demotion has to catch this wording the same as
+        it catches ADJUDICATED."""
+        charge = parse(GUILTY,
+                       ('232.2', 'SYNTHETIC ADMISSION', 'JUVENILE ADMISSION'))
+        import crs
+        dominant = crs.get_dominant_charge([charge], '00000  FECR000000')
+        assert dominant['disposition'] == 'GTR'
+
+
 # -- the invariant the typo broke ------------------------------------------
 
 def test_every_not_adjudicated_code_is_one_the_map_can_produce():

--- a/tests/test_multi_count.py
+++ b/tests/test_multi_count.py
@@ -175,18 +175,23 @@ def test_the_conviction_coming_first_is_left_alone():
     assert cells['D'] == '01/01/1900'
 
 
-def test_two_counts_sharing_the_winning_code_take_the_later_date():
-    """A captured case convicted on two counts two years apart.
+def test_two_counts_sharing_the_winning_code_take_the_earliest_date():
+    """The shape Iowa Legal Aid reported on 13 August 2026:
+    a conviction, then a contempt or probation violation found guilty years
+    later on the same case. Both counts code GTR, and taking the later date
+    made the conviction look years younger than it is, holding the
+    expungement waiting periods open past when the client cleared them.
 
-    The case finished reaching that disposition on the second date, and it is
-    the reading that will not retire a debt early.
+    This test asserted the later date until Iowa Legal Aid overruled that
+    reading on 18 August 2026: column D counts the conviction date, and the
+    SOL reader is sent to ICOS by the note instead.
     """
     cells = _row([
         ('714.2(3)', 'SYNTHETIC THEFT', 'GUILTY', '01/01/1900'),
-        ('714.2(3)', 'SYNTHETIC THEFT', 'GUILTY', '02/02/1901'),
+        ('665.4', 'SYNTHETIC CONTEMPT', 'GUILTY', '02/02/1901'),
     ])
     assert cells['G'] == 'GTR'
-    assert cells['D'] == '02/02/1901'
+    assert cells['D'] == '01/01/1900'
 
 
 def test_a_single_count_case_is_untouched():
@@ -215,7 +220,13 @@ def test_an_unadjudicated_count_contributes_no_date():
 # -- and the row says it is compressing more than one judgment ---------------
 
 def test_a_case_disposed_over_several_days_says_so():
-    """The sheet reads one date and applies it to every dollar on the row."""
+    """The sheet reads one date and applies it to every dollar on the row.
+
+    The note's sentence naming what column D counts is Iowa Legal Aid's own
+    wording, supplied 18 August 2026 after two drafts written here were
+    misread. Pinned loosely: the dates, that D counts the conviction date,
+    and that an SOL reader is sent back to ICOS.
+    """
     cells = _row([
         ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
         ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
@@ -223,7 +234,8 @@ def test_a_case_disposed_over_several_days_says_so():
     note = cells['V'] or ''
     assert '01/01/1900' in note
     assert '02/02/1901' in note
-    assert '20 year' in note
+    assert 'conviction date' in note
+    assert 'SOL' in note
 
 
 def test_counts_disposed_the_same_day_stay_quiet():
@@ -236,7 +248,7 @@ def test_counts_disposed_the_same_day_stay_quiet():
         ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '02/02/1901'),
         ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
     ])
-    assert 'different dates' not in (cells['V'] or '')
+    assert 'disposition dates' not in (cells['V'] or '')
 
 
 def test_a_case_that_owes_nothing_stays_quiet():
@@ -246,7 +258,7 @@ def test_a_case_that_owes_nothing_stays_quiet():
         ('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED BY COURT', '01/01/1900'),
         ('124.401(5)', 'SYNTHETIC POSSESSION', 'GUILTY', '02/02/1901'),
     ], costs='0')
-    assert 'different dates' not in (cells['V'] or '')
+    assert 'disposition dates' not in (cells['V'] or '')
 
 
 def test_the_caveat_joins_what_the_money_left_in_column_v():
@@ -263,4 +275,4 @@ def test_the_caveat_joins_what_the_money_left_in_column_v():
     crs.process_case(case, sheet, crs.FIRST_CASE_ROW)
     note = sheet['V' + str(crs.FIRST_CASE_ROW)].value or ''
     assert 'MISCELLANEOUS' in note, note
-    assert 'different dates' in note, note
+    assert 'disposition dates' in note, note


### PR DESCRIPTION
Three changes from Iowa Legal Aid's 18 August 2026 email plus the same day's unrecognised-disposition alerts.

## Column D is the conviction date
When several counts share the winning disposition code, column D now takes the **earliest** of their dates instead of the latest. Ari's report: a contempt/probation-violation guilty found years after the plea was dating the row, which held the expungement waiting periods (misdemeanor, public intox, PAULA, jv prostitution — all run off D) open past when the client had cleared them. She accepted the SOL-side tradeoff explicitly; the column V spread note is now her own sentence and sends an SOL reader back to ICOS for the timeline of debt assessed.

## Charge class suffixes are Iowa Legal Aid's vocabulary
`AGMD/SRMD/SMMD` → `AGMS/SRMS/SMMS`, and non-scheduled violations earn `[NSV]`. NSV is carried in both candidate spellings (hyphenated and not) until one of the five real Polk NTA pages she supplied is captured off-hours; a test pins the full suffix set and another narrows when the real page lands.

## JUVENILE ADMISSION → JUV
Two JVJV delinquency cases on the 18 Aug production run alerted and coded OTH. The wording is the juvenile court's guilty-plea analogue, so it's mapped to JUV in both disposition maps at ADJUDICATED's rank; the adult-case demotion keys on the code and rides along.

## Also
- OPEN_QUESTIONS.md: rewrote the multi-day disposition rule for the 18 Aug decision and added a section for the two confirmations waiting on a real-page capture (NSV spelling; OUT OF COUNTY WARRANT reading, which she said is acceptable as-is).
- Confirmed correct per her email, no change: the transferred-case CIV behavior.

**Tests: 1118 passed** (baseline 1111, +7 new). Prod stays frozen at v55; staging auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVNYr1kwQfQzGJQ2vsVneP