### PR TITLE
Narrow NSV to ICOS's hyphenated spelling (real-page confirmed)

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -368,23 +368,28 @@ other six have no disposition of any kind and are genuinely pending. Both of the
 uncoded rows leave column G empty, which BANKRUPTCY, EXEMPTIONS and SOL all read
 as "open charge", and the row says so in column V.
 
-## Two answers from 18 August 2026 waiting on a real page
+## Two answers from 18 August 2026, checked against the real pages
 
 Iowa Legal Aid's 18 August 2026 email settled the charge class suffix
 vocabulary — the misdemeanour codes end in S, not D, and a non-scheduled
 violation earns [NSV] — and supplied five real Polk county traffic cases that
-carry it. None of those pages is captured yet, so the map holds the class
-wording in two candidate spellings, hyphenated and not, and a test says it
-will narrow to whichever one the real page uses once one is replayed. Until
-then one of the two entries is a guess about ICOS's habits.
+carry it. Replayed the same day on the agreed test account: every one prints
+NON-SCHEDULED VIOLATION with the hyphen, as does the one earlier captured
+NTA page from another county, so the map holds that spelling alone and the
+spaced spelling that was briefly carried alongside it is dropped. All five
+rows render the suffix, on convictions and dismissals alike, and this one is
+closed.
 
-The same email supplied a real two-case example of OUT OF COUNTY WARRANT,
-which appears among a case's filings rather than its dispositions, and said
-the current output on such cases, other civil and CLOSED, is acceptable to
-them. That reading has not been checked against the real pages either, so the
-confirmation is theirs and not yet the corpus's. Both replays wait on an
-off-hours capture window, because live ICOS runs on the shared accounts do
-not happen during business hours.
+The same email supplied a real two-case example of OUT OF COUNTY WARRANT and
+said the current output on such cases, other civil and CLOSED, is acceptable
+to them. The same replay confirmed why that is all Napier can say: the
+warrant wording sits among the case's filings, a page Napier does not fetch,
+and appears nowhere on the summary, charges or financials pages it does. The
+charges pages carry no counts at all, so the case takes the no-charges civil
+path and both rows render other civil - CLOSED, coded CIV, with nothing
+owed, which is the output they accepted. Closed as acceptable rather than solved: reading
+the filings docket would be a new page type, and nothing on the sheets asks
+for it today.
 
 ## Smaller ones
 

--- a/case_parser.py
+++ b/case_parser.py
@@ -287,11 +287,13 @@ NOT_ADJUDICATED = frozenset({"WTHD", "DISM", "ACQ", "NOTF", "TNSF"})
 # The misdemeanour suffixes are Iowa Legal Aid's, not ICOS's: their 8/18
 # review corrected the first cut's AGMD/SRMD/SMMD to the AGMS/SRMS/SMMS
 # their attorneys actually write, and added NSV for a non-scheduled
-# violation. The left-hand wordings still belong to ICOS. NON-SCHEDULED
-# VIOLATION is carried in both spellings ICOS could plausibly print because
-# no page bearing it has been captured yet -- Iowa Legal Aid named five Polk
-# NTA cases that carry one, and a wrong guess here costs nothing: a wording
-# that matches neither spelling adds no suffix.
+# violation. The left-hand wordings still belong to ICOS: replaying the
+# five Polk NTA cases Iowa Legal Aid named, on 18 August 2026, showed every
+# one printing NON-SCHEDULED VIOLATION with the hyphen, as does the one
+# earlier captured NTA page from another county, so only that spelling is
+# mapped. A wording not in the map adds no suffix, so if some county's
+# clerk ever spells it without the hyphen the case loses its suffix rather
+# than gaining a wrong one, which is the standing no-guess rule here.
 CHARGE_CLASS_SUFFIXES = {
     "CLASS A FELONY": "FELA",
     "CLASS B FELONY": "FELB",
@@ -302,7 +304,6 @@ CHARGE_CLASS_SUFFIXES = {
     "SIMPLE MISDEMEANOR": "SMMS",
     "SCHEDULED VIOLATION": "SV",
     "NON-SCHEDULED VIOLATION": "NSV",
-    "NON SCHEDULED VIOLATION": "NSV",
     "CONTEMPT OF COURT": "CNTP",
 }
 

--- a/tests/test_ari_aug7_workbook.py
+++ b/tests/test_ari_aug7_workbook.py
@@ -175,15 +175,21 @@ class TestChargeClassSuffixes:
             'AGMS', 'CNTP', 'FELA', 'FELB', 'FELC', 'FELD', 'NSV', 'SMMS',
             'SRMS', 'SV']
 
-    def test_both_spellings_of_a_non_scheduled_violation_read_nsv(self):
-        """No captured page carries the class row yet -- her five Polk NTA
-        examples are pending capture -- so the map holds the hyphenated and
-        the spaced spelling and this test holds the map to both. When the
-        real page lands, the spelling it shows stays and this test narrows."""
-        for wording in ('NON-SCHEDULED VIOLATION', 'NON SCHEDULED VIOLATION'):
-            charge = parse([count('321.218', 'SYNTHETIC DENIED', 'GUILTY',
-                                  adjudicated_class=wording)])
-            assert charge['description'] == 'SYNTHETIC DENIED[NSV][GTR]'
+    def test_a_non_scheduled_violation_reads_nsv(self):
+        """The wording is ICOS's, confirmed by replaying the five Polk NTA
+        cases Iowa Legal Aid named, on 18 August 2026: every one prints
+        NON-SCHEDULED VIOLATION with the hyphen, as does the one earlier
+        captured NTA page from another county. This test carried both
+        spellings until then and narrowed to the one the real pages use."""
+        charge = parse([count('321.218', 'SYNTHETIC DENIED', 'GUILTY',
+                              adjudicated_class='NON-SCHEDULED VIOLATION')])
+        assert charge['description'] == 'SYNTHETIC DENIED[NSV][GTR]'
+
+    def test_an_unmapped_spelling_adds_no_suffix_rather_than_a_guess(self):
+        """The no-guess rule, held to on the spelling that was dropped."""
+        charge = parse([count('321.218', 'SYNTHETIC DENIED', 'GUILTY',
+                              adjudicated_class='NON SCHEDULED VIOLATION')])
+        assert charge['description'] == 'SYNTHETIC DENIED[GTR]'
 
 
 # -- a case pending on more than one count ----------------------------------


### PR DESCRIPTION
Follow-up to #124. Replayed Ari's real cases on the agreed test account (one session, ~5s of ICOS traffic, clean logoff):

- **All five Polk NTA cases** print `Adjudicated Charge Class: NON-SCHEDULED VIOLATION` — hyphenated — matching the one earlier-captured NTA page from another county. The spaced spelling carried as a hedge in #124 is dropped; a test now pins that an unmapped spelling adds no suffix rather than a guess. All five rows render `[NSV]` correctly (convictions and dismissals alike).
- **Both Dubuque warrant cases**: the warrant wording lives in the filings docket, which Napier does not fetch, and appears nowhere on the pages it reads. No counts on the charges pages → no-charges civil path → `other civil - CLOSED`, coded CIV, $0 owed — exactly the output Ari accepted. No code change; ledger updated.

Raw captures at `~/napier-icos-capture/ari818/` (0600), nothing committed.

**Tests: 1118 passed** (one parametrized case dropped with the spelling, one test replaced by two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVNYr1kwQfQzGJQ2vsVneP