### PR TITLE
Fix the false overflow warning and say which spelling a merged case came from

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -97,6 +97,14 @@ UNKNOWN_DISPOSITION = 'unrecognised disposition on an ICOS case'
 # other: what CLOSED deserves is an open question with Iowa Legal Aid, so this
 # fires on every run of the same client until they answer it.
 UNCODED_CASE_STATUS = 'untranslated case status on an ICOS case'
+# grid.extend_formula_grid fills the derived sheets down to the case list on
+# every build, and grid.shortfalls then measures whether it worked. It always
+# has. When it stops -- a CRS 3.6 laid out in a way the extension cannot read,
+# most likely -- the workbook is still delivered, still opens, and is short a
+# figure on a sheet nobody recounts by hand. The finish page tells the staffer,
+# and this tells the person who can fix the template, because the two are not
+# the same person and the workbook is going to a clinic either way.
+WORKBOOK_SHORT = 'workbook sheets do not reach the last case'
 
 # A run that eventually worked but took this many attempts is the early warning
 # that ICOS is degrading, which is worth one email before staff start noticing.

--- a/app.py
+++ b/app.py
@@ -363,7 +363,12 @@ def batch_crs():
         # be somebody the staffer never saw on the roster page.
         picks.append({'def_name': def_name, 'def_dob': def_dob,
                       'case_ids': case_ids, 'person': entry.get('person'),
-                      'searches': searches})
+                      'searches': searches,
+                      # A clinic list is where two spellings merging into one
+                      # workbook is least visible: the finish page shows one
+                      # row per client and def_name is the first key's name, so
+                      # the second spelling is named nowhere at all otherwise.
+                      'filed_as': tasks.docket_names(keys, entry['cases'])})
 
     if not picks:
         return jsonify({"error": "Pick a match for at least one client."}), 400

--- a/app.py
+++ b/app.py
@@ -376,6 +376,20 @@ def batch_crs():
                     "progress_url": url_for('progress', job_id=job.id)})
 
 
+def _batch_limits(clients):
+    """One list for the whole clinic list, in the order the sheets came back.
+
+    A clinic list is one page for a dozen workbooks, and the same sheet falling
+    short on four of them is one thing to fix, not four lines to read.
+    """
+    lines = []
+    for client in clients:
+        for line in client.get('limits') or []:
+            if line not in lines:
+                lines.append(line)
+    return lines
+
+
 def _finish_page(job, error=None):
     """The page a finished workbook run lands on, whichever kind of run it was.
 
@@ -397,9 +411,7 @@ def _finish_page(job, error=None):
                                can_retry=can_retry, error=error,
                                missing=sum(len(c['failed'])
                                            for c in result['clients']),
-                               limits=crs.workbook_limits(
-                                   max([c['written'] for c in result['clients']]
-                                       or [0]), result['is_lite']))
+                               limits=_batch_limits(result['clients']))
     return render_template('done.html', job=job.to_dict(),
                            atp=result.get('atp'),
                            def_name=result['def_name'],
@@ -409,8 +421,7 @@ def _finish_page(job, error=None):
                            failed=result['failed_cases'],
                            can_retry=can_retry, error=error,
                            missing=len(result['failed_cases']),
-                           limits=crs.workbook_limits(result['written_cases'],
-                                                      result['is_lite']),
+                           limits=result.get('limits') or [],
                            filename=tasks.download_name(result['def_name'],
                                                         result['is_lite']))
 

--- a/case_parser.py
+++ b/case_parser.py
@@ -162,6 +162,14 @@ KNOWN_PARTY_ROLES = frozenset({
     'PRO SE APPELLANT',
     'APPELLEE',
     'PRO SE APPELLEE',
+    # A party the original defendant brought into the suit for all or part of
+    # the claim against them. They answer a petition and a judgment can be
+    # entered against them, so it is their record in the same way DEFENDANT is.
+    # Unlike the suppressed COUNTER and CROSS roles, which ICOS puts on somebody
+    # already in the case under their own role, this is the only role the case
+    # lists them under, so suppressing it would lose the case rather than
+    # deduplicate it. Seen on two live searches 2026-08-18.
+    'THIRD PARTY DEFENDANT',
     # The owner named on a case about their property: condemnation, tax sale,
     # a municipal infraction, an in rem forfeiture. The case can assess costs
     # against them personally, so it is their record, unlike the LIEN FILER

--- a/crs.py
+++ b/crs.py
@@ -37,48 +37,19 @@ def iowa_today():
 MISMATCH_FILL = PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid")
 MISMATCH_FONT = Font(color="9C0006")
 
-# Where the CRS template stops, counted in cases rather than rows. Napier writes
-# CASE DATA from row 4 down and never stops, and Excel accepts every row it is
-# given, so outgrowing the template costs a number rather than raising anything:
-# the analysis sheets carry formulas only so far, and their totals sum a shorter
-# range still. Nobody has hit these on a real client, but the failure is a
-# quietly low figure carried into a hearing, so the run says something.
+# The first row of CASE DATA that holds a case. Rows 1 to 3 are the totals and
+# the two header rows.
 #
-# tests/test_workbook_limits.py reads these back out of the two .xlsx files, so
-# a new template that moves them fails the suite instead of going unnoticed.
+# What used to sit here alongside it was a set of constants recording where each
+# sheet of the shipped template runs out -- 147 cases on SOL, 97 in the totals,
+# 297 on CASE DATA -- and a workbook_limits() that warned staff whenever a run
+# was bigger than one of them. grid.extend_formula_grid has filled those sheets
+# down to the case list since, so the numbers stopped describing the workbook
+# Napier saves and the warning became a false one: a correct 184 case run came
+# back captioned as short, next to advice to split the search in two that no
+# screen here will carry out. The finish page now measures the saved workbook
+# with grid.shortfalls instead of predicting it from a case count.
 FIRST_CASE_ROW = 4
-# CASE DATA row 1 totals =SUM(x4:x300).
-CASE_DATA_TOTAL_LIMIT = 297
-# SOL, BANKRUPTCY and EXEMPTIONS each total =SUM(x4:x100). Full CRS only; the
-# Lite template does not have those sheets.
-ANALYSIS_TOTAL_LIMIT = 97
-# The first sheet to run out of rows altogether: SOL's formulas stop at row 150.
-ANALYSIS_ROW_LIMIT = 147
-# In the Lite template that is EXPUNGEMENT & 910.7, whose rows are offset by one
-# and stop at row 200, so its last case is CASE DATA row 201.
-LITE_ANALYSIS_ROW_LIMIT = 198
-
-
-def workbook_limits(written, is_lite):
-    """What this many cases outgrows in the CRS template, worst first."""
-    warnings = []
-    if written > CASE_DATA_TOTAL_LIMIT:
-        warnings.append(
-            "CASE DATA's totals on row 1 only add up the first %d cases, so "
-            "every total in this workbook is short."
-            % CASE_DATA_TOTAL_LIMIT)
-    row_limit = LITE_ANALYSIS_ROW_LIMIT if is_lite else ANALYSIS_ROW_LIMIT
-    if written > row_limit:
-        warnings.append(
-            "The analysis sheets have rows for the first %d cases only, so the "
-            "cases after that are on CASE DATA and nowhere else."
-            % row_limit)
-    if not is_lite and written > ANALYSIS_TOTAL_LIMIT:
-        warnings.append(
-            "The totals on SOL, BANKRUPTCY and EXEMPTIONS only add up the "
-            "first %d cases. The rows below that are right, the totals are "
-            "low." % ANALYSIS_TOTAL_LIMIT)
-    return warnings
 
 charge_code_map = {
     "GUILTY": {"GTR":1},

--- a/grid.py
+++ b/grid.py
@@ -42,6 +42,16 @@ from openpyxl.worksheet.formula import ArrayFormula
 # statute lookup. None of them is a per-case analysis of CASE DATA.
 NOT_DERIVED = ('CASE DATA', 'BASIC INFO', 'CODE SECTIONS')
 
+# CASE DATA is the case list rather than a reading of it, so it is not mirrored
+# down from a template row the way the sheets above are, and its own formulas
+# name no sheet so the survey below cannot see them. Two things on it are still
+# derived and still stop at row 300: column T, each row's own =SUM(J4:S4), and
+# the totals across row 1, =SUM(J4:J300). Columns W to AH stop there too and are
+# deliberately not touched here, because statutes.write_statute_split has
+# already written every row of them as plain text by the time this runs.
+CASE_DATA = 'CASE DATA'
+FIRST_CASE_ROW = 4
+
 # Far past any case list, and there to stop a sheet whose styled region runs to
 # the bottom of the spreadsheet from being walked cell by cell.
 ROW_CAP = 5000
@@ -201,21 +211,64 @@ def _extend_sheet(sheet, last_case_row):
     if reached >= last_case_row:
         return 0, deepest, first
 
-    template = [cell for cell in sheet[deepest] if _formula(cell)]
+    # _fill_down copies each cell's style along with its formula. Without that
+    # the new rows lose the currency and date formats the filled-down ones
+    # carry, and a dollar figure printed as a bare number reads as a different
+    # kind of number.
     added = last_case_row - reached
+    _fill_down(sheet, deepest, added)
+    return added, deepest + added, first
+
+
+def _fill_down(sheet, template_row, added):
+    """Copy a row's formulas and formats down `added` rows."""
+    template = [cell for cell in sheet[template_row] if _formula(cell)]
     for step in range(1, added + 1):
         for cell in template:
-            target = sheet.cell(row=deepest + step, column=cell.column)
+            target = sheet.cell(row=template_row + step, column=cell.column)
             _write(target,
                    Translator(_formula(cell),
                               origin=cell.coordinate).translate_formula(
                                   row_delta=step, col_delta=0),
                    source=cell, row_delta=step)
-            # Without this the new rows lose the currency and date formats the
-            # filled-down ones carry, and a dollar figure printed as a bare
-            # number reads as a different kind of number.
             target._style = copy(cell._style)
-    return added, deepest + added, first
+
+
+def _deepest_formula_row(sheet, first_row):
+    """The last row at or below first_row holding a formula of any kind."""
+    deepest = None
+    for row in sheet.iter_rows(min_row=first_row,
+                               max_row=min(sheet.max_row, ROW_CAP)):
+        if any(_formula(cell) for cell in row):
+            deepest = row[0].row
+    return deepest
+
+
+def _extend_case_data(sheet, last_case_row):
+    """Fill CASE DATA's own derived cells down and widen its totals.
+
+    Returns the rows added. Column T is what the expungement sheet reads for
+    the debt subject to 910.7, and row 1 is the figure staff read off the case
+    list itself, so a case list past row 300 loses both without saying so.
+    """
+    deepest = _deepest_formula_row(sheet, FIRST_CASE_ROW)
+    if deepest is None:
+        return 0
+
+    added = 0
+    if deepest < last_case_row:
+        added = last_case_row - deepest
+        _fill_down(sheet, deepest, added)
+
+    for cell in sheet[1]:
+        formula = _formula(cell)
+        if not formula:
+            continue
+        widened = _widen_local_ranges(formula, FIRST_CASE_ROW,
+                                      max(deepest + added, last_case_row))
+        if widened != formula:
+            _write(cell, widened)
+    return added
 
 
 def extend_formula_grid(workbook, case_count):
@@ -230,6 +283,11 @@ def extend_formula_grid(workbook, case_count):
 
     last_case_row = 3 + case_count
     changed = {}
+
+    added = _extend_case_data(workbook[CASE_DATA], last_case_row)
+    if added:
+        changed[CASE_DATA] = added
+
     for sheet in workbook.worksheets:
         if sheet.title in NOT_DERIVED:
             continue
@@ -262,3 +320,110 @@ def extend_formula_grid(workbook, case_count):
         if touched:
             changed[sheet.title] = added
     return changed
+
+
+def _range_shortfalls(sheet, first_case_row, last_row, last_case_row):
+    """Ranges above the case rows that still stop before the case list ends."""
+    short = set()
+    for row in sheet.iter_rows(min_row=1,
+                               max_row=min(sheet.max_row, first_case_row - 1)):
+        for cell in row:
+            formula = _formula(cell)
+            if not formula:
+                continue
+            if _widen_local_ranges(formula, first_case_row,
+                                   last_row) != formula:
+                short.add(cell.coordinate)
+            if _widen_case_ranges(formula, last_case_row) != formula:
+                short.add(cell.coordinate)
+    return short
+
+
+def shortfalls(workbook, case_count):
+    """Every sheet whose formulas still stop before the last case, measured.
+
+    extend_formula_grid is meant to leave this empty, and this is here because
+    of what the alternative did. The finish page used to work the warning out
+    from the case count and the depths the templates shipped with, so it went
+    on telling staff the analysis sheets stop at 147 cases, and the totals at
+    97, for as long as it took somebody to notice that they had not since the
+    grid was extended. A run of 184 cases came back correct and captioned as
+    short, next to advice to split the search in two, which is both unnecessary
+    and something no screen in Napier will do.
+
+    So this asks the workbook instead of predicting it. Anything it names is a
+    real gap in the file that was saved, and a workbook nothing is wrong with
+    says nothing at all.
+    """
+    if case_count <= 0:
+        return {}
+
+    last_case_row = 3 + case_count
+    short = {}
+
+    sheet = workbook[CASE_DATA]
+    deepest = _deepest_formula_row(sheet, FIRST_CASE_ROW)
+    if deepest is not None:
+        # On CASE DATA a sheet row is a case row, so the row the totals have to
+        # cover is the last case row itself. A total that sums further down
+        # than the case list is adding up blank rows, which is not a shortfall.
+        short[CASE_DATA] = _reasons(sheet, FIRST_CASE_ROW, last_case_row,
+                                    last_case_row, deepest < last_case_row)
+
+    for sheet in workbook.worksheets:
+        if sheet.title in NOT_DERIVED:
+            continue
+        rows, deepest, furthest = _survey(sheet)
+        if deepest is None:
+            continue
+        # The sheets do not agree on where a case lands -- SOL's row 4 reads
+        # case row 4, the expungement sheet's row 3 does, LICENSE-REGIS starts
+        # two rows up -- so the row the last case sits on is found by counting
+        # back from the deepest case the sheet does reach, not by taking the
+        # case row as a sheet row. Where that lands above the sheet's own last
+        # row, the rows past it hold no case and a total that stops short of
+        # them is not short of anything.
+        reach = deepest + (last_case_row - furthest)
+        short[sheet.title] = _reasons(sheet, min(rows), reach,
+                                      last_case_row, furthest < last_case_row)
+    return {name: reasons for name, reasons in short.items() if reasons}
+
+
+def _reasons(sheet, first_case_row, reach, last_case_row, rows_short):
+    reasons = ['rows'] if rows_short else []
+    if _range_shortfalls(sheet, first_case_row, reach, last_case_row):
+        reasons.append('totals')
+    return reasons
+
+
+def describe_shortfalls(short):
+    """What to put in front of staff about the sheets shortfalls() named.
+
+    One sentence per sheet, because the two failures read differently on a
+    finished file: a missing row is a case absent from an analysis, and a short
+    total is a figure that looks right and is low.
+    """
+    lines = []
+    for name in sorted(short):
+        reasons = short[name]
+        if name == CASE_DATA:
+            # The case list itself is never missing a case; what it can be
+            # missing is column T on the rows past where the template's own
+            # formulas stop, and the totals across the top.
+            lines.append(
+                "CASE DATA's TOTAL column and the totals across its top row "
+                "cover only part of the case list, so the rows are right and "
+                "those figures are low.")
+        elif 'rows' in reasons and 'totals' in reasons:
+            lines.append(
+                "%s stops before the last case, so the cases past that point "
+                "are missing from it and its totals are low." % name)
+        elif 'rows' in reasons:
+            lines.append(
+                "%s stops before the last case, so the cases past that point "
+                "are on CASE DATA and nowhere else." % name)
+        else:
+            lines.append(
+                "%s adds up only part of the case list, so its rows are right "
+                "and its totals are low." % name)
+    return lines

--- a/tasks.py
+++ b/tasks.py
@@ -212,6 +212,21 @@ def _failed_by_search(entry):
             for group in searches_behind(entry)]
 
 
+def report_short_workbook(job, short, written):
+    """Say when a saved workbook does not reach its own last case.
+
+    The finish page says this too, to the staffer holding the file. This says it
+    to whoever maintains the template, who is not in the room and would
+    otherwise hear about it only if the staffer thought to forward the page. The
+    case count is the useful part for reproducing it; no name and no case number
+    goes out with it.
+    """
+    if not short:
+        return
+    alerts.record(job.id[:8], job.kind, alerts.WORKBOOK_SHORT,
+                  cases=written, sheets=" ".join(short))
+
+
 def report_novel_roles(job, cases):
     """Say when a search included a role nobody has classified yet.
 
@@ -808,7 +823,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
         for index, pick in enumerate(picks, start=1):
             _stop_if_asked(job)
             record = {'name': pick['def_name'], 'requested': len(pick['case_ids']),
-                      'written': 0, 'failed': [], 'file': None, 'error': None}
+                      'written': 0, 'failed': [], 'file': None, 'error': None,
+                      'limits': []}
             built.append(record)
             # Carried alongside the record rather than inside it, because this
             # holds whole parsed cases and the record is what the finish page
@@ -860,9 +876,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
                     "cases, so there is no workbook for them.")
                 continue
             try:
-                path, unknown, atp = build_workbook(cases, pick['def_name'],
-                                                    pick['def_dob'], is_lite,
-                                                    failed)
+                path, unknown, atp, short = build_workbook(
+                    cases, pick['def_name'], pick['def_dob'], is_lite, failed)
             except Exception as e:
                 # The other clients' workbooks are already built or still to
                 # come, and neither should be lost to this one.
@@ -877,9 +892,11 @@ def batch_crs_task(job, session_token, picks, is_lite):
                                    "workbook. The rest of the list is here.")
                 continue
             report_unknown_dispositions(job, unknown)
+            report_short_workbook(job, short, len(cases))
             record['written'] = len(cases)
             record['file'] = path
             record['atp'] = atp
+            record['limits'] = short
 
         if not any(record['file'] for record in built):
             raise ValueError("no workbooks could be built")
@@ -980,13 +997,14 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
             raise ValueError("no cases could be read")
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
-        path, unknown_dispositions, atp = build_workbook(cases, def_name,
-                                                         def_dob, is_lite,
-                                                         failed)
+        path, unknown_dispositions, atp, short = build_workbook(
+            cases, def_name, def_dob, is_lite, failed)
         report_unknown_dispositions(job, unknown_dispositions)
+        report_short_workbook(job, short, len(cases))
         job.result = {
             "file": path,
             "atp": atp,
+            "limits": short,
             "def_name": def_name,
             "is_lite": is_lite,
             "written_cases": len(cases),
@@ -1058,7 +1076,8 @@ def retry_task(job, username, password, payload):
             _stop_if_asked(job)
             record = {'name': entry['def_name'],
                       'requested': len(entry['case_ids']),
-                      'written': 0, 'failed': [], 'file': None, 'error': None}
+                      'written': 0, 'failed': [], 'file': None, 'error': None,
+                      'limits': []}
             built.append(record)
 
             recovered, still_failed, reselect_failed = [], list(entry['failed']), False
@@ -1118,9 +1137,9 @@ def retry_task(job, username, password, payload):
                                        "still no workbook for them.")
                 continue
             try:
-                path, unknown, atp = build_workbook(cases, entry['def_name'],
-                                                    entry['def_dob'], is_lite,
-                                                    still_failed)
+                path, unknown, atp, short = build_workbook(
+                    cases, entry['def_name'], entry['def_dob'], is_lite,
+                    still_failed)
             except Exception as e:
                 print("Workbook failed on retry for client %d: %r" % (index, e),
                       flush=True)
@@ -1143,9 +1162,11 @@ def retry_task(job, username, password, payload):
                 key: [case_id for case_id in case_ids if case_id in fresh_ids]
                 for key, case_ids in unknown.items()
                 if any(case_id in fresh_ids for case_id in case_ids)})
+            report_short_workbook(job, short, len(cases))
             record['written'] = len(cases)
             record['file'] = path
             record['atp'] = atp
+            record['limits'] = short
 
         if not any(record['file'] for record in built):
             raise ValueError("no workbooks could be rebuilt")
@@ -1178,6 +1199,7 @@ def retry_task(job, username, password, payload):
             # so a retry that recovered two cases raises the balance the
             # calculator is about to be given.
             "atp": record.get('atp'),
+            "limits": record.get('limits', []),
             "def_name": record['name'],
             "is_lite": is_lite,
             "written_cases": record['written'],
@@ -1193,8 +1215,9 @@ def retry_task(job, username, password, payload):
 
 
 def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
-    """Returns the path written, the dispositions Napier could not read, and
-    the two figures the ability-to-pay calculator asks for.
+    """Returns the path written, the dispositions Napier could not read, the
+    two figures the ability-to-pay calculator asks for, and anything the saved
+    workbook is still short of.
 
     failed is the cases that would not come off Iowa Courts, so the workbook
     can say what is not in it. The file travels further than any page Napier
@@ -1207,6 +1230,10 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     sheet under a guessed code or on it with no code at all, and somebody needs
     to know which before the workbook is used, so the caller reports it rather
     than the file quietly carrying it.
+
+    The last value is one sentence per sheet that still stops before the last
+    case, measured off the workbook after the formula grid is extended. Empty
+    on every run the extension handles, which so far is all of them.
     """
     workbook = load_workbook('CRS Lite 3.5.5.xlsx' if is_lite else 'CRS 3.5.5.xlsx')
     sheet = workbook['CASE DATA']
@@ -1243,6 +1270,14 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     # formula's meaning, and does nothing at all to a workbook that fits.
     grid.extend_formula_grid(workbook, row - 4)
 
+    # And then measure what that left, rather than working it out from the case
+    # count and the depths the template shipped at. The finish page used to do
+    # the arithmetic, so it went on quoting ceilings the extension had already
+    # lifted: a 184 case run came back complete and captioned as short. Anything
+    # named here is a gap in the file about to be saved, so a run that fits says
+    # nothing at all.
+    short = grid.describe_shortfalls(grid.shortfalls(workbook, row - 4))
+
     sheet = workbook['BASIC INFO']
     # Every date test in the workbook compares against B3, the clinic date: the
     # twenty year cut on the SOL sheet, the two year and eight year expungement
@@ -1271,7 +1306,7 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     suffix = "_Lite_CRS_" if is_lite else "_CRS_"
     path = tmp_dir + safe_name + suffix + stamp + ".xlsx"
     workbook.save(path)
-    return path, unknown, atp
+    return path, unknown, atp, short
 
 
 def download_name(def_name, is_lite):

--- a/tasks.py
+++ b/tasks.py
@@ -186,6 +186,33 @@ def plan_searches(keys, case_dict, people, found_by=None):
             for index, case_ids in enumerate(groups) if case_ids]
 
 
+def docket_names(keys, case_dict):
+    """Which spelling of the client's name each picked case is filed under.
+
+    Iowa Courts matches a name exactly as it is written on the case, so a
+    client whose docket spells them two ways is two rows on the picking page,
+    and ticking both is one workbook. Nothing on the finished row says which of
+    them it came from: the case number, the county and the charges read the
+    same either way, and the name is nowhere on CASE DATA at all. Iowa Legal
+    Aid asked for it on 2026-08-18, to check a merged summary against the
+    client sitting in front of them.
+
+    Empty for a workbook where every case is filed the same way. A note that is
+    the same on every row of a clinic sheet is a column staff learn to skip,
+    and that is the column the coding caveats are in.
+    """
+    names = {}
+    for key in keys:
+        _, _, name = key.partition(' ')
+        for case_id in case_dict.get(key, []):
+            # First key wins, the same way found_by does: one case can be
+            # returned under both spellings, and it is one row either way.
+            names.setdefault(case_id, name)
+    if len(set(names.values())) < 2:
+        return {}
+    return names
+
+
 def searches_behind(entry):
     """Every search that has to be repeated to pull this entry's cases.
 
@@ -511,7 +538,7 @@ def _pull_cases(job, client, case_ids, offset=0, total=None, outage=None):
 
 
 def _retry_entry(def_name, def_dob, person, case_ids, cases, failed,
-                 searches=None):
+                 searches=None, filed_as=None):
     """One client's share of what a retry needs.
 
     case_ids is everything that was asked for, in the order it was asked for,
@@ -524,13 +551,20 @@ def _retry_entry(def_name, def_dob, person, case_ids, cases, failed,
     client searched under more than one. Left out for a client searched once,
     where person carries the only search there is.
 
+    filed_as is the note each case carries about which spelling of the client's
+    name it is docketed under, empty unless there is more than one.
+
     These sit in the dyno's memory for the two hours the job lives, which is
     the same window the workbook itself sits in tmp for, so nothing is exposed
     here that the finished run was not already holding. They reach no log, no
     alert and no page.
     """
     entry = {'def_name': def_name, 'def_dob': def_dob, 'person': person,
-             'case_ids': list(case_ids), 'cases': cases, 'failed': list(failed)}
+             'case_ids': list(case_ids), 'cases': cases, 'failed': list(failed),
+             # So a rebuilt workbook keeps the attribution. The keys and the
+             # search results it was worked out from belong to the search job,
+             # which a retry does not go back to.
+             'filed_as': dict(filed_as or {})}
     if searches:
         entry['searches'] = [{'person': group['person'],
                               'case_ids': list(group['case_ids'])}
@@ -831,7 +865,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
             # renders.
             entry = _retry_entry(pick['def_name'], pick['def_dob'],
                                  pick.get('person'), pick['case_ids'], [], [],
-                                 pick.get('searches'))
+                                 pick.get('searches'),
+                                 pick.get('filed_as'))
             retry_entries.append(entry)
 
             # Before the re-search, not after it. A dead site would otherwise
@@ -877,7 +912,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
                 continue
             try:
                 path, unknown, atp, short = build_workbook(
-                    cases, pick['def_name'], pick['def_dob'], is_lite, failed)
+                    cases, pick['def_name'], pick['def_dob'], is_lite, failed,
+                    pick.get('filed_as'))
             except Exception as e:
                 # The other clients' workbooks are already built or still to
                 # come, and neither should be lost to this one.
@@ -978,6 +1014,9 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
 
     try:
         searches = plan_searches(keys, case_dict, people or [person], found_by)
+        # Which spelling each case is docketed under, while the search results
+        # are still here to say so. CASE DATA carries no name of its own.
+        filed_as = docket_names(keys, case_dict)
         # The order the groups are pulled in, so the workbook's rows and the
         # retry's idea of where a recovered row goes back agree with each other.
         case_ids = [case_id for group in searches
@@ -998,7 +1037,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
         path, unknown_dispositions, atp, short = build_workbook(
-            cases, def_name, def_dob, is_lite, failed)
+            cases, def_name, def_dob, is_lite, failed, filed_as)
         report_unknown_dispositions(job, unknown_dispositions)
         report_short_workbook(job, short, len(cases))
         job.result = {
@@ -1013,7 +1052,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
             "done_url": "/done/%s" % job.id,
             "retry": _retry_payload('crs', is_lite, [
                 _retry_entry(def_name, def_dob, person, case_ids, cases,
-                             failed, searches)]),
+                             failed, searches, filed_as)]),
         }
 
         if failed:
@@ -1119,7 +1158,8 @@ def retry_task(job, username, password, payload):
             rebuilt.append(_retry_entry(entry['def_name'], entry['def_dob'],
                                         entry['person'], entry['case_ids'],
                                         cases, still_failed,
-                                        entry.get('searches')))
+                                        entry.get('searches'),
+                                        entry.get('filed_as')))
             if not cases:
                 if skipped:
                     record['error'] = ("%s before Napier reached this client, "
@@ -1139,7 +1179,7 @@ def retry_task(job, username, password, payload):
             try:
                 path, unknown, atp, short = build_workbook(
                     cases, entry['def_name'], entry['def_dob'], is_lite,
-                    still_failed)
+                    still_failed, entry.get('filed_as'))
             except Exception as e:
                 print("Workbook failed on retry for client %d: %r" % (index, e),
                       flush=True)
@@ -1214,7 +1254,14 @@ def retry_task(job, username, password, payload):
         alerts.digest(job.id[:8], job.kind, alerts.recent_progress(job))
 
 
-def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
+# What the notes column says on a workbook built out of more than one spelling
+# of the client's name. Past tense and no punctuation games, because it sits in
+# the same cell as the reconciliation and coding caveats and staff read the
+# column in one pass.
+FILED_AS_NOTE = "Filed under %s."
+
+
+def build_workbook(cases, def_name, def_dob, is_lite, failed=(), filed_as=None):
     """Returns the path written, the dispositions Napier could not read, the
     two figures the ability-to-pay calculator asks for, and anything the saved
     workbook is still short of.
@@ -1223,6 +1270,10 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     can say what is not in it. The file travels further than any page Napier
     serves, and one that is quietly short two cases is worse than one that
     says it is short two cases.
+
+    filed_as maps a case number to the spelling of the client's name it is
+    docketed under, and is empty unless the workbook holds more than one. See
+    docket_names for why the notes column is where that goes.
 
     The second value maps the ICOS wording, paired with whether the row it
     landed on came out with a code in column G, to the case numbers it turned up
@@ -1244,9 +1295,14 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=()):
     clinic_date = crs.iowa_today()
     row = 4
     unknown = {}
+    filed_as = filed_as or {}
     for case in cases:
         for key in crs.process_case(case, sheet, row, clinic_date) or []:
             unknown.setdefault(key, []).append(case['id'])
+        # Before the statute and coding notes below, so the row reads as which
+        # client this is and then what to watch on it.
+        if filed_as.get(case['id']):
+            crs.append_note(sheet, row, FILED_AS_NOTE % filed_as[case['id']])
         row += 1
 
     # Columns W to AH take column F apart one statute per column, and the

--- a/templates/batch_done.html
+++ b/templates/batch_done.html
@@ -156,15 +156,20 @@
   {% if limits %}
     <div class="notice" role="alert" style="margin-top:1.2rem">
       <p class="notice-title">
-        One of these clients has more cases than the CRS template counts.
+        Part of at least one of these workbooks does not reach the end of its
+        case list.
       </p>
       <p>
-        Every case is in the workbook and every row is right. The template's own
-        formulas stop before the end of them, and Excel does not say so:
+        Every case Iowa Courts gave up is on CASE DATA. Napier fills the rest of
+        each workbook down to match, and on this list it could not finish:
       </p>
       <ul>
         {% for limit in limits %}<li>{{ limit }}</li>{% endfor %}
       </ul>
+      <p>
+        Napier has emailed Alex about it. Nothing here needs working around at
+        the clinic, but check with him before these workbooks are relied on.
+      </p>
     </div>
   {% endif %}
 

--- a/templates/done.html
+++ b/templates/done.html
@@ -115,17 +115,18 @@
   {% if limits %}
     <div class="notice" role="alert">
       <p class="notice-title">
-        This run is bigger than the CRS template counts.
+        Part of this workbook does not reach the end of the case list.
       </p>
       <p>
-        Every case is in the workbook and every row is right. The template's own
-        formulas stop before the end of them, and Excel does not say so:
+        Every case Iowa Courts gave up is on CASE DATA. Napier fills the rest of
+        the workbook down to match, and on this one it could not finish:
       </p>
       <ul>
         {% for limit in limits %}<li>{{ limit }}</li>{% endfor %}
       </ul>
       <p>
-        Splitting the search into two workbooks is the way around it.
+        Napier has emailed Alex about it. Nothing here needs working around at
+        the clinic, but check with him before this workbook is relied on.
       </p>
     </div>
   {% endif %}

--- a/tests/test_ability_to_pay.py
+++ b/tests/test_ability_to_pay.py
@@ -167,7 +167,7 @@ class TestItSurvivesTheBuild:
         monkeypatched = tasks.tmp_dir
         tasks.tmp_dir = str(tmp_path) + os.sep
         try:
-            path, _, figures = tasks.build_workbook(
+            path, _, figures, _ = tasks.build_workbook(
                 [], 'SYNTHETIC CLIENT', '01/01/1900', False)
         finally:
             tasks.tmp_dir = monkeypatched

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ['NAPIER_DISABLE_BACKGROUND'] = '1'
 
 import alerts
+import case_parser
 import evidence
 import icos
 import tasks
@@ -665,6 +666,40 @@ def test_an_ordinary_search_says_nothing(mailbox):
     assert tasks.report_novel_roles(job, [_hit('DEFENDANT'),
                                           _hit('PRO SE DEFENDANT'),
                                           _hit('PETITIONER')]) == []
+    settle()
+    assert mailbox == []
+
+
+def test_a_third_party_defendant_is_a_party_and_stops_emailing(mailbox):
+    """Two live searches on 2026-08-18 each cost an email for this one role.
+
+    It is a party: the original defendant brought them in, they answer the
+    petition and a judgment can be entered against them, and it is the only
+    role the case lists them under. So it belongs on the known list rather
+    than the suppressed one, and saying so is the whole fix.
+    """
+    job = FakeJob('search')
+    assert tasks.report_novel_roles(job, [_hit('THIRD PARTY DEFENDANT')]) == []
+    settle()
+    assert mailbox == []
+    assert 'THIRD PARTY DEFENDANT' not in case_parser.NON_PARTY_ROLES
+
+
+def test_a_workbook_that_does_not_reach_its_last_case_reports_itself(mailbox):
+    """The finish page tells the staffer holding the file. This tells whoever
+    can fix the template, who is not in the room."""
+    job = FakeJob('crs')
+    tasks.report_short_workbook(job, ["SOL stops before the last case."], 400)
+    settle()
+    assert len(mailbox) == 1
+    assert alerts.WORKBOOK_SHORT in mailbox[0]['subject']
+    assert 'SOL' in mailbox[0]['text']
+    assert '400' in mailbox[0]['text']
+
+
+def test_a_workbook_that_reaches_its_last_case_says_nothing(mailbox):
+    job = FakeJob('crs')
+    tasks.report_short_workbook(job, [], 400)
     settle()
     assert mailbox == []
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -139,7 +139,7 @@ def record_workbook(cases, name, dob, lite, failed=()):
     path = os.path.join(tasks.tmp_dir, 'test_alias_stub.xlsx')
     with open(path, 'wb') as handle:
         handle.write(b'PK\x03\x04 stub workbook')
-    return path, {}, {'balance': '$0.00', 'monthly': None, 'months': 12}
+    return path, {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []
 
 
 @pytest.fixture

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -32,6 +32,11 @@ import roster
 import tasks
 from icos import IcosError
 
+# tasks.build_workbook is monkeypatched away for this whole file, so the
+# tests that want a real CRS keep hold of it here.
+real_build_workbook = tasks.build_workbook
+from test_formula_grid import synthetic_cases   # noqa: E402
+
 DOB = "01/01/1900"
 
 # The shared case. It is on the docket under both spellings, which is the
@@ -117,6 +122,7 @@ def fake_icos(monkeypatch):
     FakeClient.fail_searches = ()
     FakeClient.fail_cases = ()
     written.clear()
+    attributed.clear()
     monkeypatch.setattr(tasks, 'IcosClient', FakeClient)
     monkeypatch.setattr(tasks.case_parser, 'parse_case_summary',
                         lambda html, case: case.update(county='DUBUQUE'))
@@ -130,12 +136,15 @@ def fake_icos(monkeypatch):
 
 
 written = []
+# The filed_as map each of those builds was handed.
+attributed = []
 
 
-def record_workbook(cases, name, dob, lite, failed=()):
+def record_workbook(cases, name, dob, lite, failed=(), filed_as=None):
     """What actually reached the workbook, which is the question the dedup
     test is asking. A case counted twice here is a client billed twice."""
     written.append([case['id'] for case in cases])
+    attributed.append(dict(filed_as or {}))
     path = os.path.join(tasks.tmp_dir, 'test_alias_stub.xlsx')
     with open(path, 'wb') as handle:
         handle.write(b'PK\x03\x04 stub workbook')
@@ -452,3 +461,97 @@ class TestAClinicListWithAnAka:
         entry = jobs.get(search_id).result['clients'][0]
         assert entry['keys'] == [JOINED_KEY]
         assert entry['error'] is None
+
+
+class TestWhichSpellingARowCameFrom:
+    """Iowa Legal Aid asked for this on 2026-08-18.
+
+    Two spellings merge into one workbook, and the finished rows do not say
+    which of them each case came from. CASE DATA has no name column at all: the
+    client is named once, on BASIC INFO, and def_name there is whichever key
+    sorted first. So a staffer checking a merged summary against the person in
+    front of them has no way to tell the two dockets apart.
+    """
+
+    def test_a_case_says_which_spelling_it_is_docketed_under(self, client):
+        build_from(client)
+        assert attributed[-1][ONLY_JOINED] == 'ALHAMEED, ALI'
+        assert attributed[-1][ONLY_SPACED] == 'AL HAMEED, ALI'
+
+    def test_a_case_on_both_dockets_is_attributed_once_to_one_of_them(self,
+                                                                     client):
+        """It is one row. Naming both spellings on it would be truthful and
+        would also be the row nobody can act on."""
+        build_from(client)
+        assert attributed[-1][SHARED] in ('ALHAMEED, ALI', 'AL HAMEED, ALI')
+        assert len(written[-1]) == len(attributed[-1])
+
+    def test_one_spelling_attributes_nothing(self, client):
+        """Every ordinary run. A note repeated on every row of a clinic sheet
+        is a column staff learn to skip, and the coding caveats are in it."""
+        build_from(client, spellings=[('Jane', '', 'Doe')])
+        assert attributed[-1] == {}
+
+    def test_picking_only_one_of_two_spellings_attributes_nothing(self,
+                                                                  client):
+        """Nothing merged, so there is nothing to tell apart."""
+        build_from(client, keys=[JOINED_KEY])
+        assert attributed[-1] == {}
+
+    def test_a_clinic_list_attributes_the_merged_client(self, client):
+        """Where it is least visible. The finish page shows one row per client
+        and names them by the first key, so the second spelling appears
+        nowhere else at all."""
+        TestAClinicListWithAnAka().run_list(
+            client, "Alhameed, Ali aka Al Hameed, Ali")
+        assert attributed[-1][ONLY_SPACED] == 'AL HAMEED, ALI'
+
+    def test_the_note_survives_a_rebuild(self, client):
+        """A retry rebuilds the workbook from the retry payload and never goes
+        back to the search job, which is the only thing that knew this."""
+        FakeClient.fail_cases = (ONLY_SPACED,)
+        search_id, job_id, _ = build_from(client)
+        FakeClient.fail_cases = ()
+        response = client.post('/retry/' + job_id,
+                               data={'username': 'ILATEST',
+                                     'password': 'secret'})
+        await_job(client, response.headers['Location'].rsplit('/', 1)[-1])
+        assert attributed[-1][ONLY_SPACED] == 'AL HAMEED, ALI'
+
+
+class TestTheNoteInTheWorkbook:
+    """The note itself, written into a real CRS rather than a stub."""
+
+    def _built(self, filed_as):
+        from openpyxl import load_workbook
+        path, _, _, _ = real_build_workbook(
+            synthetic_cases(2), 'ALHAMEED, ALI', DOB, False,
+            filed_as=filed_as)
+        return load_workbook(path)['CASE DATA']
+
+    def test_it_lands_in_the_notes_column(self):
+        sheet = self._built({'00000  FECR000000': 'ALHAMEED, ALI',
+                             '00000  FECR000001': 'AL HAMEED, ALI'})
+        assert 'ALHAMEED, ALI' in sheet['V4'].value
+        assert 'AL HAMEED, ALI' in sheet['V5'].value
+
+    def test_nothing_is_written_without_it(self):
+        # Column V is not empty on an ordinary row -- process_financials has
+        # its own say about the fee columns -- so this is about the one
+        # sentence, not about the cell.
+        sheet = self._built({})
+        assert 'Filed under' not in (sheet['V4'].value or '')
+
+    def test_it_does_not_displace_a_coding_caveat(self):
+        """Column V already carries what process_financials and the coding
+        guesses put there, and append_note joins rather than replaces."""
+        import crs
+        cases = synthetic_cases(1)
+        path, _, _, _ = real_build_workbook(
+            cases, 'ALHAMEED, ALI', DOB, False,
+            filed_as={'00000  FECR000000': 'ALHAMEED, ALI'})
+        from openpyxl import load_workbook
+        sheet = load_workbook(path)['CASE DATA']
+        crs.append_note(sheet, 4, 'A later caveat.')
+        assert 'ALHAMEED, ALI' in sheet['V4'].value
+        assert 'A later caveat.' in sheet['V4'].value

--- a/tests/test_basic_info.py
+++ b/tests/test_basic_info.py
@@ -21,7 +21,7 @@ import tasks
 
 def _build(is_lite=False):
     """A workbook with no cases in it. BASIC INFO does not depend on them."""
-    path, _, _ = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
+    path, _, _, _ = tasks.build_workbook([], 'TEST CLIENT', '01/01/1980', is_lite)
     return load_workbook(path)['BASIC INFO'], path
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -119,7 +119,7 @@ def fake_icos(monkeypatch):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(): (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
+                        lambda cases, name, dob, lite, failed=(): (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
     yield
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -119,7 +119,7 @@ def fake_icos(monkeypatch):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(): (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
+                        lambda cases, name, dob, lite, failed=(), filed_as=None: (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
     yield
 
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -80,7 +80,7 @@ def fake_icos(monkeypatch, tmp_path):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(): (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}))
+                        lambda cases, name, dob, lite, failed=(): (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
     yield
 
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -80,7 +80,7 @@ def fake_icos(monkeypatch, tmp_path):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(): (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
+                        lambda cases, name, dob, lite, failed=(), filed_as=None: (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
     yield
 
 

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -93,7 +93,7 @@ def run(monkeypatch, case_ids, unavailable=()):
     written = []
     TOLD_MISSING[:] = []
 
-    def fake_build(cases, name, dob, lite, failed=()):
+    def fake_build(cases, name, dob, lite, failed=(), filed_as=None):
         written.extend(case['id'] for case in cases)
         TOLD_MISSING.extend(failed)
         return (os.path.join(tasks.tmp_dir, 'stub.xlsx'), {},

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -96,7 +96,8 @@ def run(monkeypatch, case_ids, unavailable=()):
     def fake_build(cases, name, dob, lite, failed=()):
         written.extend(case['id'] for case in cases)
         TOLD_MISSING.extend(failed)
-        return os.path.join(tasks.tmp_dir, 'stub.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}
+        return (os.path.join(tasks.tmp_dir, 'stub.xlsx'), {},
+                {'balance': '$0.00', 'monthly': None, 'months': 12}, [])
 
     monkeypatch.setattr(tasks, 'build_workbook', fake_build)
 

--- a/tests/test_expungement_codes.py
+++ b/tests/test_expungement_codes.py
@@ -251,7 +251,7 @@ def test_a_case_that_fits_is_reported_as_nothing():
 
 def test_a_built_workbook_has_no_errors_waiting_in_the_split():
     """The whole point, through the path a clinic actually takes."""
-    path, _, _ = tasks.build_workbook(
+    path, _, _, _ = tasks.build_workbook(
         synthetic_cases(3, '715A.2'), 'TEST CLIENT', '01/01/1980', False)
     try:
         sheet = load_workbook(path)['CASE DATA']
@@ -274,7 +274,7 @@ def test_a_built_workbook_has_no_errors_waiting_in_the_split():
 def test_the_overflow_note_reaches_the_staffer():
     """Column V is the only place the workbook talks to whoever opens it."""
     charge = ';'.join('719.%d' % n for n in range(statutes.SLOTS + 2))
-    path, _, _ = tasks.build_workbook(
+    path, _, _, _ = tasks.build_workbook(
         synthetic_cases(1, charge), 'TEST CLIENT', '01/01/1980', False)
     try:
         sheet = load_workbook(path)['CASE DATA']

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -103,7 +103,8 @@ def fake_icos(monkeypatch):
                         lambda html, case: case.update(financials=[], total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
                         lambda cases, name, dob, lite, failed=(): (_write_stub_workbook(),
-                                                        {}, dict(ATP)))
+                                                        {}, dict(ATP),
+                                                        []))
     yield
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -102,7 +102,7 @@ def fake_icos(monkeypatch):
     monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
                         lambda html, case: case.update(financials=[], total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(): (_write_stub_workbook(),
+                        lambda cases, name, dob, lite, failed=(), filed_as=None: (_write_stub_workbook(),
                                                         {}, dict(ATP),
                                                         []))
     yield

--- a/tests/test_formula_grid.py
+++ b/tests/test_formula_grid.py
@@ -352,7 +352,7 @@ def test_a_short_case_list_leaves_the_array_formulas_alone():
 def test_a_built_workbook_covers_all_of_its_own_cases():
     """The whole point, through the path a clinic actually takes."""
     count = SOL_LAST_ROW + 10
-    path, _, _ = tasks.build_workbook(
+    path, _, _, _ = tasks.build_workbook(
         synthetic_cases(count), 'TEST CLIENT', '01/01/1980', False)
     try:
         workbook = load_workbook(path)

--- a/tests/test_guilty_other.py
+++ b/tests/test_guilty_other.py
@@ -145,7 +145,7 @@ def test_the_licence_sheet_can_now_answer_about_the_case():
     clears, so this builds the workbook, takes the code off CASE DATA, and
     looks for it.
     """
-    path, unknown, _ = tasks.build_workbook(
+    path, unknown, _, _ = tasks.build_workbook(
         [synthetic_case(WORDING, WORDING)], 'TEST CLIENT', '01/01/1980', False)
     try:
         cases = load_workbook(path)['CASE DATA']

--- a/tests/test_licence_row_alignment.py
+++ b/tests/test_licence_row_alignment.py
@@ -179,7 +179,7 @@ def test_a_short_run_puts_its_cases_on_the_first_rows():
     """What a staffer sees. Four cases, the money on the first two, and the
     licence sheet has to open with them rather than with blank rows."""
     owed = ['197.43', '89.50', '0.00', '0.00']
-    path, _, _ = tasks.build_workbook(
+    path, _, _, _ = tasks.build_workbook(
         synthetic_cases(owed), 'TEST CLIENT', '01/01/1980', False)
     try:
         workbook = load_workbook(path)

--- a/tests/test_no_conviction_dischargeable.py
+++ b/tests/test_no_conviction_dischargeable.py
@@ -248,7 +248,7 @@ def test_an_acquittal_is_sorted_like_a_dismissal():
     """
     dispositions = ['DISMISSED', 'ACQUITTED', 'WITHDRAWN', 'NOT FILED',
                     'GUILTY']
-    path, _, _ = tasks.build_workbook(
+    path, _, _, _ = tasks.build_workbook(
         synthetic_cases(dispositions), 'TEST CLIENT', '01/01/1980', False)
     try:
         workbook = load_workbook(path)

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -105,7 +105,7 @@ def _fake_build(cases, name, dob, lite, failed=()):
     path = os.path.join(tasks.tmp_dir, 'test_outage.xlsx')
     with open(path, 'wb') as handle:
         handle.write(b'PK\x03\x04 stub workbook')
-    return path, {}, {'balance': '$0.00', 'monthly': None, 'months': 12}
+    return path, {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -99,7 +99,7 @@ class StubClient:
 WRITTEN = []
 
 
-def _fake_build(cases, name, dob, lite, failed=()):
+def _fake_build(cases, name, dob, lite, failed=(), filed_as=None):
     WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases],
                    'failed': list(failed)})
     path = os.path.join(tasks.tmp_dir, 'test_outage.xlsx')

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -147,7 +147,8 @@ def _fake_build(cases, name, dob, lite, failed=()):
                         'test_retry_%s.xlsx' % name.split(',')[0].strip())
     with open(path, 'wb') as f:
         f.write(b'PK\x03\x04 stub workbook')
-    return path, dict(UNKNOWN), {'balance': '$0.00', 'monthly': None, 'months': 12}
+    return (path, dict(UNKNOWN),
+            {'balance': '$0.00', 'monthly': None, 'months': 12}, [])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -138,7 +138,7 @@ def fake_icos(monkeypatch):
 WRITTEN = []
 
 
-def _fake_build(cases, name, dob, lite, failed=()):
+def _fake_build(cases, name, dob, lite, failed=(), filed_as=None):
     # failed is recorded because a rebuilt workbook that still does not name
     # what is missing from it is the whole point of this going in.
     WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases],

--- a/tests/test_uncoded_case_status.py
+++ b/tests/test_uncoded_case_status.py
@@ -318,7 +318,7 @@ def test_the_build_hands_back_which_kind_each_wording_was(tmp_path, monkeypatch)
     it. Both cases in one workbook, because that is the run that was losing an
     email as well as mislabelling one."""
     monkeypatch.setattr(tasks, 'tmp_dir', str(tmp_path) + os.sep)
-    _, unknown, _ = tasks.build_workbook(
+    _, unknown, _, _ = tasks.build_workbook(
         [_case(UNADJUDICATED, CLOSED, case_id='00000  SRCR000000'),
          _case(UNREADABLE, '', case_id='00000  FECR000000')],
         'TEST CLIENT', '01/01/1980', False)

--- a/tests/test_unknown_disposition.py
+++ b/tests/test_unknown_disposition.py
@@ -243,6 +243,6 @@ def test_one_alert_per_wording_not_per_case(monkeypatch):
 def test_the_workbook_build_hands_the_wordings_back(tmp_path, monkeypatch):
     """process_case can report all it likes if build_workbook drops it."""
     monkeypatch.setattr(tasks, 'tmp_dir', str(tmp_path) + os.sep)
-    _, unknown, _ = tasks.build_workbook(
+    _, unknown, _, _ = tasks.build_workbook(
         [_case(NOVEL), _case('GUILTY')], 'TEST CLIENT', '01/01/1980', False)
     assert unknown == {(NOVEL, True): ['00000  FECR000000']}

--- a/tests/test_workbook_limits.py
+++ b/tests/test_workbook_limits.py
@@ -1,11 +1,24 @@
-"""The CRS template's own limits, read back out of the template.
+"""Whether the workbook Napier saves reaches its own last case.
 
-Napier writes CASE DATA rows until it runs out of cases. The workbook it writes
-them into stops counting at some point on every sheet, and stops having rows at
-all a little further down, and Excel reports neither. The numbers in crs.py are
-what the finish page warns on, so they are checked against the two .xlsx files
-here rather than trusted: a CRS 3.6 that moves them fails this instead of
-quietly making the warning wrong.
+This file used to check a prediction. crs.py carried the depths the templates
+shipped at -- 97 cases in the totals, 147 rows on SOL, 297 on CASE DATA -- and
+the finish page warned whenever a run was bigger than one of them, and here
+those numbers were read back out of the two .xlsx files so a CRS 3.6 that moved
+them would fail rather than go unnoticed.
+
+What went unnoticed instead was the extension. grid.extend_formula_grid has
+filled those sheets down to the case list on every build since, so the ceilings
+stopped being true of anything Napier saves, and the warning went on quoting
+them: Iowa Legal Aid ran 184 cases on 2026-08-18, got a complete workbook, and
+was told on the finish page that the analysis sheets stopped at 147 and that
+splitting the search in two was the way around it. Neither half was true, and
+Napier has never had a way to split a search.
+
+So the templates' depths are still checked here, because they are what the
+extension has to start from, but the thing staff are told now comes from
+grid.shortfalls measuring the saved workbook. The two tests that matter are
+that it finds the real ceilings on a template nobody extended, and finds
+nothing at all on one Napier built.
 """
 
 import os
@@ -18,6 +31,7 @@ from openpyxl import load_workbook
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import crs
+import grid
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
@@ -25,6 +39,14 @@ LITE = os.path.join(ROOT, 'CRS Lite 3.5.5.xlsx')
 
 # The three sheets whose row-1 totals are the ones staff read off.
 TOTALLED = ('SOL', 'BANKRUPTCY', 'EXEMPTIONS')
+
+# What the shipped templates reach, in cases. Not thresholds any more: the
+# starting point the extension has to cover, and the answer the measurement
+# below has to produce on a workbook that was never extended.
+CASE_DATA_TOTALS_REACH = 297
+ANALYSIS_TOTALS_REACH = 97
+ANALYSIS_ROWS_REACH = 147
+LITE_ANALYSIS_ROWS_REACH = 198
 
 
 def _total_range_end(sheet):
@@ -55,6 +77,16 @@ def _last_case_row_covered(sheet):
     return last
 
 
+def _built(count, template=FULL):
+    """A template with a case list written in and the grid extended to it."""
+    workbook = load_workbook(template)
+    sheet = workbook['CASE DATA']
+    for n in range(count):
+        sheet['A%d' % (crs.FIRST_CASE_ROW + n)] = '00000  FECR%06d' % n
+    grid.extend_formula_grid(workbook, count)
+    return workbook
+
+
 @pytest.fixture(scope='module')
 def full():
     return load_workbook(FULL)
@@ -65,28 +97,29 @@ def lite():
     return load_workbook(LITE)
 
 
+# -- what the templates ship with --------------------------------------------
+
 def test_case_data_totals_stop_where_we_say_they_do(full, lite):
     for workbook in (full, lite):
         end = _total_range_end(workbook['CASE DATA'])
         cases = end - crs.FIRST_CASE_ROW + 1
-        assert cases == crs.CASE_DATA_TOTAL_LIMIT
+        assert cases == CASE_DATA_TOTALS_REACH
 
 
 def test_analysis_totals_stop_where_we_say_they_do(full):
     ends = {name: _total_range_end(full[name]) for name in TOTALLED}
     assert None not in ends.values(), ends
     cases = min(ends.values()) - crs.FIRST_CASE_ROW + 1
-    assert cases == crs.ANALYSIS_TOTAL_LIMIT
+    assert cases == ANALYSIS_TOTALS_REACH
 
 
 def test_the_lite_template_has_no_totalled_analysis_sheets(lite):
-    # The Lite warning skips the totals line, which is only right while this is.
     assert not [name for name in TOTALLED if name in lite.sheetnames]
 
 
 def test_the_analysis_sheets_run_out_of_rows_where_we_say_they_do(full, lite):
-    for workbook, limit in ((full, crs.ANALYSIS_ROW_LIMIT),
-                            (lite, crs.LITE_ANALYSIS_ROW_LIMIT)):
+    for workbook, reach in ((full, ANALYSIS_ROWS_REACH),
+                            (lite, LITE_ANALYSIS_ROWS_REACH)):
         covered = {}
         for name in workbook.sheetnames:
             if name == 'CASE DATA':
@@ -95,22 +128,93 @@ def test_the_analysis_sheets_run_out_of_rows_where_we_say_they_do(full, lite):
             if last is not None:
                 covered[name] = last - crs.FIRST_CASE_ROW + 1
         assert covered, 'no sheet mirrors CASE DATA any more'
-        assert min(covered.values()) == limit, covered
+        assert min(covered.values()) == reach, covered
 
 
-def test_a_normal_run_says_nothing():
-    assert crs.workbook_limits(70, False) == []
-    assert crs.workbook_limits(70, True) == []
+# -- the measurement, on a workbook nobody extended --------------------------
+#
+# Non-vacuity. Every silent result below is only worth something while these
+# fail loudly, so they run against the raw templates at case counts chosen to
+# land either side of each ceiling above.
+
+def test_a_short_list_is_short_of_nothing(full):
+    assert grid.shortfalls(full, ANALYSIS_TOTALS_REACH) == {}
 
 
-def test_the_totals_warning_comes_first_and_only_for_the_full_template():
-    full = crs.workbook_limits(crs.ANALYSIS_TOTAL_LIMIT + 1, False)
-    assert len(full) == 1
-    assert 'SOL, BANKRUPTCY and EXEMPTIONS' in full[0]
-    assert crs.workbook_limits(crs.ANALYSIS_TOTAL_LIMIT + 1, True) == []
+def test_the_first_thing_to_give_way_is_the_analysis_totals(full):
+    short = grid.shortfalls(full, ANALYSIS_TOTALS_REACH + 1)
+    assert set(short) == set(TOTALLED), short
+    for name in TOTALLED:
+        assert short[name] == ['totals'], short
 
 
-def test_running_off_the_end_of_everything_says_so():
-    warnings = crs.workbook_limits(crs.CASE_DATA_TOTAL_LIMIT + 1, False)
-    assert len(warnings) == 3
-    assert 'CASE DATA' in warnings[0]
+def test_past_the_analysis_grid_the_rows_go_too(full):
+    short = grid.shortfalls(full, ANALYSIS_ROWS_REACH + 1)
+    assert 'rows' in short['SOL'], short
+    assert 'CASE DATA' not in short, short
+
+
+def test_past_the_case_data_totals_the_case_list_itself_is_short(full):
+    short = grid.shortfalls(full, CASE_DATA_TOTALS_REACH + 1)
+    assert 'CASE DATA' in short, short
+
+
+def test_the_lite_template_gives_way_on_rows_and_has_no_totals_to_lose(lite):
+    assert grid.shortfalls(lite, LITE_ANALYSIS_ROWS_REACH) == {}
+    short = grid.shortfalls(lite, LITE_ANALYSIS_ROWS_REACH + 1)
+    assert short, 'the Lite template has no ceiling at all now?'
+    assert not [name for name in short if name in TOTALLED], short
+
+
+# -- the measurement, on a workbook Napier built -----------------------------
+
+@pytest.mark.parametrize('count', [1, 40, 98, 148, 298, 400])
+def test_an_extended_workbook_is_short_of_nothing(count):
+    assert grid.shortfalls(_built(count), count) == {}
+
+
+@pytest.mark.parametrize('count', [1, 40, 199, 400])
+def test_an_extended_lite_workbook_is_short_of_nothing(count):
+    assert grid.shortfalls(_built(count, LITE), count) == {}
+
+
+def test_an_empty_run_measures_nothing(full):
+    # No cases is not a workbook that stops before its last case, and a run
+    # where Iowa Courts gave up nothing already says so in its own words.
+    assert grid.shortfalls(full, 0) == {}
+
+
+# -- what it puts in front of staff ------------------------------------------
+
+def test_nothing_short_says_nothing():
+    assert grid.describe_shortfalls({}) == []
+
+
+def test_a_sheet_short_of_rows_says_where_those_cases_are():
+    lines = grid.describe_shortfalls({'SOL': ['rows']})
+    assert len(lines) == 1
+    assert 'CASE DATA and nowhere else' in lines[0]
+    assert lines[0].startswith('SOL ')
+
+
+def test_a_sheet_short_of_totals_only_says_the_rows_are_right():
+    line = grid.describe_shortfalls({'BANKRUPTCY': ['totals']})[0]
+    assert 'rows are right' in line
+    assert 'totals are low' in line
+
+
+def test_the_case_list_gets_its_own_sentence():
+    # "the cases past that point are on CASE DATA and nowhere else" is nonsense
+    # when the sheet in question is CASE DATA.
+    line = grid.describe_shortfalls({'CASE DATA': ['rows', 'totals']})[0]
+    assert 'nowhere else' not in line
+    assert 'TOTAL column' in line
+
+
+def test_one_line_per_sheet_in_a_settled_order():
+    lines = grid.describe_shortfalls({'SOL': ['rows'], 'BANKRUPTCY': ['totals'],
+                                      'CASE DATA': ['totals']})
+    assert len(lines) == 3
+    assert lines[0].startswith('BANKRUPTCY')
+    assert lines[1].startswith('CASE DATA')
+    assert lines[2].startswith('SOL')

--- a/tests/test_workbook_receipt.py
+++ b/tests/test_workbook_receipt.py
@@ -163,7 +163,7 @@ class TestItSurvivesTheBuild:
         monkeypatched = tasks.tmp_dir
         tasks.tmp_dir = str(tmp_path) + os.sep
         try:
-            path, _, _ = tasks.build_workbook(
+            path, _, _, _ = tasks.build_workbook(
                 [], 'SYNTHETIC CLIENT', '01/01/1900', False, MISSING)
         finally:
             tasks.tmp_dir = monkeypatched
@@ -183,7 +183,7 @@ class TestItSurvivesTheBuild:
         monkeypatched = tasks.tmp_dir
         tasks.tmp_dir = str(tmp_path) + os.sep
         try:
-            path, _, _ = tasks.build_workbook(
+            path, _, _, _ = tasks.build_workbook(
                 [], 'SYNTHETIC CLIENT', '01/01/1900', True, MISSING)
         finally:
             tasks.tmp_dir = monkeypatched


### PR DESCRIPTION
Answers two things from Iowa Legal Aid's 2026-08-18 mail and one of the
alert emails from the same week.

## The overflow warning was wrong

A 184-case workbook came out with the "too many cases for this template"
notice on it, and the notice told staff to split the search into two
workbooks and merge them by hand. Neither half of that was true.

The ceilings it warned about (97 on the analysis sheets, 147 SOL rows,
198 Lite rows) stopped being real when the formula grid started
extending every derived sheet down to the case list. The advice pointed
at a splitting feature that has never existed, and merging two CRS
workbooks by hand breaks the formulas that make them worth building.

So the constants are gone and `grid.shortfalls()` measures the saved
workbook instead: which sheets do not reach the last case, in the file
that actually got written. One real ceiling turned up while doing it --
CASE DATA's T column and its row-1 totals stop at 297 -- and
`_extend_case_data` now carries those down too.

When a workbook genuinely comes up short the finish page says so
plainly, and `alerts.WORKBOOK_SHORT` emails Alex with the case count and
the sheet names. No client details in the mail.

The tests check the reach numbers against the real .xlsx both ways: raw
templates still stop exactly where they stop, extended workbooks are
silent at 1, 40, 98, 148, 298 and 400 cases.

## Which spelling a merged case came from

Ari's other question. Two spellings of one client are two rows on the
picking page, ticking both is one workbook, and the finished rows never
said which docket each case was on -- CASE DATA has no name column, and
BASIC INFO names the client once, by whichever key sorted first.

Rows now read "Filed under NAME." in column V, joined to the coding
caveats rather than replacing them, and only when the workbook actually
merges spellings.

## THIRD PARTY DEFENDANT

Two of the week's alert emails were this role coming back novel. It is a
party, so it goes in `KNOWN_PARTY_ROLES` and stops mailing.

CONSENT DECREE, OTHER JUDGMENT and TRANSFERRED are deliberately still
uncoded -- those are questions for Ari, not guesses to make here.

Draft: prod stays on v55 until Ari signs off on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jv4J3ABqZXhZPSnMRHh9Kv
