### PR TITLE
Queue searches on one Iowa Courts login, and stop blaming strangers for our own collisions

### DIFF
--- a/accounts.py
+++ b/accounts.py
@@ -14,6 +14,15 @@ Procfile pins gunicorn to one worker, and a restart that loses this registry
 loses the sessions it describes at the same moment, so an entry cannot outlive
 the session behind it.
 
+Knowing who holds an account is only half of it. ICOS refuses a second
+session and offers no queue, so before this module grew a waiting line every
+job that collided simply slept and asked again. Whoever happened to ask in the
+instant the account came free won it, which is a race and not an order, and a
+job could lose that race for its whole retry budget while later arrivals walked
+straight past it. Tickets fix the order: a job joins the line before it asks
+ESA for anything, and only the job at the head of its account's line is allowed
+to try.
+
 The account id is staff-facing and the alerting is not. Somebody told their own
 sign in collided already typed the user id, so naming it back tells them
 nothing they did not bring with them, while alert mail keeps to the account
@@ -25,6 +34,21 @@ import time
 import uuid
 
 _held = {}
+
+# The waiting line for each account, oldest first. Kept apart from _held
+# because a ticket is intent and an entry in _held is possession: a job takes a
+# ticket before it asks ESA for anything and gives it back the moment it is
+# signed in or has given up, while an entry in _held lasts as long as the
+# session behind it does.
+_tickets = []
+
+# A ticket this old is ignored and swept. Nothing should ever hold one for
+# anywhere near this long -- the concurrent wait gives up after sixteen
+# minutes -- so a ticket that survives it belongs to a thread that died between
+# take_ticket and its finally. Counting it forever would wedge the line for
+# everybody behind it, and a wedged line is worse than the race it replaced.
+STALE_TICKET_SECONDS = 30 * 60
+
 _lock = threading.Lock()
 
 
@@ -104,7 +128,69 @@ def describe(username, now=None):
             % (entry["account"], describe_wait(entry["seconds"])))
 
 
+def take_ticket(username, now=None):
+    """Join the waiting line for an account.
+
+    Returns a ticket to give back to drop_ticket(), which the caller must do in
+    a finally: a ticket nobody drops is swept eventually, but everybody behind
+    it waits out STALE_TICKET_SECONDS first.
+
+    Taken before the first sign in attempt rather than after the first refusal.
+    The order the jobs arrived in is the only fair way to decide who gets the
+    account next, and by the time ESA has refused them they are all polling and
+    that order is gone.
+    """
+    ticket = uuid.uuid4().hex
+    with _lock:
+        _tickets.append({"id": ticket, "account": _key(username),
+                         "since": time.time() if now is None else now})
+    return ticket
+
+
+def drop_ticket(ticket):
+    """Leave the waiting line. Safe to call twice, and with an unknown ticket."""
+    if not ticket:
+        return
+    with _lock:
+        for index, entry in enumerate(_tickets):
+            if entry["id"] == ticket:
+                del _tickets[index]
+                return
+
+
+def ahead_of(username, ticket, now=None, stale_after=None):
+    """How many jobs joined this account's line before this one.
+
+    Zero means it is this job's turn. Counted by position in the line rather
+    than by timestamp, because several jobs submitted together can share a
+    clock reading and ties would leave two of them both believing they were
+    first, which is the race this exists to end.
+
+    An unknown ticket answers zero. A caller whose ticket has already been
+    dropped or swept has waited long enough, and hanging it on a line it is not
+    standing in would be the wedge described above.
+    """
+    account = _key(username)
+    stale_after = STALE_TICKET_SECONDS if stale_after is None else stale_after
+    now = time.time() if now is None else now
+    with _lock:
+        fresh = [entry for entry in _tickets
+                 if now - entry["since"] < stale_after]
+        if len(fresh) != len(_tickets):
+            _tickets[:] = fresh
+        position = None
+        for index, entry in enumerate(_tickets):
+            if entry["id"] == ticket:
+                position = index
+                break
+        if position is None:
+            return 0
+        return sum(1 for entry in _tickets[:position]
+                   if entry["account"] == account)
+
+
 def _reset():
     """For tests. Nothing in the app has any business emptying this."""
     with _lock:
         _held.clear()
+        del _tickets[:]

--- a/icos.py
+++ b/icos.py
@@ -35,6 +35,13 @@ BACKOFF = [2, 5, 10, 30, 60, 120, 120, 300]
 # that before giving up, and slowly -- hammering it does not release the lock.
 CONCURRENT_INTERVAL = 75
 
+# How often to look at the waiting line. Far shorter than CONCURRENT_INTERVAL
+# because it is not the same kind of wait: the concurrent poll is a request to
+# the court site and this is a list in this process. Making a job that is next
+# in line sit out another seventy-five seconds after the account came free
+# would give back most of what the line was added to win.
+QUEUE_INTERVAL = 5
+
 BAD_CREDS_MARKER = "The userID or password could not be validated"
 CONCURRENT_MARKER = "Concurrent Login Error"
 
@@ -404,11 +411,68 @@ class IcosClient:
     # -- operations --------------------------------------------------------
 
     def login(self, username, password):
-        """Log in, waiting out a concurrent-session lock if we hit one.
+        """Log in, waiting for our turn on the account and then out any lock.
 
         The password is used here and never stored on the client, on disk, or
         in a log line.
         """
+        # Joined before anything is asked of ESA, and given back in the finally
+        # whatever happens. A job that keeps its ticket after it has stopped
+        # trying holds up everybody standing behind it.
+        ticket = accounts.take_ticket(username)
+        try:
+            self._login(username, password, ticket)
+        finally:
+            accounts.drop_ticket(ticket)
+
+    def _await_turn(self, username, ticket, started):
+        """Hold this job behind the earlier ones on the same ICOS login.
+
+        ICOS allows one session per account and simply refuses the second, so
+        several jobs on one login run one at a time whatever happens here. What
+        this decides is the order. Without it every waiting job polls and the
+        account goes to whichever one happens to ask in the right half second,
+        which on 19 August let a job that arrived first lose to three that
+        arrived after it and then time out after fifteen minutes.
+
+        Checked often, because checking costs nothing: the answer is a list in
+        this process, not a request to the court site.
+        """
+        announced = None
+        while True:
+            ahead = accounts.ahead_of(username, ticket)
+            if not ahead:
+                return
+            if self._should_stop():
+                raise IcosStopped(STOPPED_MESSAGE)
+            elapsed = self._monotonic() - started
+            if elapsed + QUEUE_INTERVAL > self.concurrent_budget:
+                self._alert(
+                    alerts.CONCURRENT_EXHAUSTED,
+                    account=alerts.username_prefix(username),
+                    elapsed=_describe(elapsed),
+                    note="%d earlier %s on this login never finished, so this "
+                         "one never got a turn. More searches were started on "
+                         "one Iowa Courts account than it can run at once. Not "
+                         "an outside session."
+                         % (ahead, "search" if ahead == 1 else "searches"))
+                raise IcosAccountLocked(
+                    "This Iowa Courts account is still busy with %s started "
+                    "before this one. Iowa Courts allows one session per "
+                    "account, so they run one at a time. Nothing is lost; run "
+                    "this search again once they have finished."
+                    % ("a search" if ahead == 1 else "%d searches" % ahead))
+            if ahead != announced:
+                self._log(
+                    "%d earlier %s on this Iowa Courts account %s still "
+                    "running. Nothing is lost; this one starts as soon as they "
+                    "finish."
+                    % (ahead, "search" if ahead == 1 else "searches",
+                       "is" if ahead == 1 else "are"))
+                announced = ahead
+            self._sleep(QUEUE_INTERVAL)
+
+    def _login(self, username, password, ticket):
         self._log("Connecting to Iowa Courts Online...")
 
         # Said before ICOS is asked, not after it refuses. If Napier is holding
@@ -419,11 +483,27 @@ class IcosClient:
         if held_by_napier:
             self._log(held_by_napier)
 
-        self._retry("search", self.reader.init_request)
+        # Whether Napier was ever the one holding this account, rather than
+        # whether it happens to be holding it at the instant the budget runs
+        # out. The difference was a real misdiagnosis on 19 August: four
+        # searches on one login queued up, three of them took the account in
+        # turn and gave it back, and the fourth gave up twelve minutes after
+        # the last of them had finished. The end-of-wait sample found an empty
+        # registry and the alert blamed somebody signed in outside Napier, when
+        # Napier had held the account for nearly the whole wait. Once seen,
+        # this stays seen.
+        napier_ever_held = bool(held_by_napier)
 
         started = self._monotonic()
         waited_for_lock = False
         retried_trimmed = False
+
+        # Before init_request, so a job that is not going to run for ten
+        # minutes does not open a session on the court site and sit on it.
+        self._await_turn(username, ticket, started)
+
+        self._retry("search", self.reader.init_request)
+
         while True:
             # Without the validator a problem report lands on the size check
             # below, because it is well under MIN_SIGNED_IN_BYTES, and staff
@@ -446,23 +526,41 @@ class IcosClient:
                 # Asked again rather than reused, because a run can pick this
                 # account up or put it down while somebody is waiting on it.
                 napier_holds = accounts.describe(username)
+                napier_ever_held = napier_ever_held or bool(napier_holds)
                 if elapsed + CONCURRENT_INTERVAL > self.concurrent_budget:
+                    if napier_holds:
+                        note = ("Napier's own run held the account for the "
+                                "whole wait. Two staff on one login.")
+                    elif napier_ever_held:
+                        note = ("Napier's own runs held the account during the "
+                                "wait and gave it back before this one could "
+                                "get in. More searches were started on one "
+                                "Iowa Courts account than it can run at once. "
+                                "Not an outside session.")
+                    else:
+                        note = ("ESA never released the lock, and Napier was "
+                                "not holding the account at any point in the "
+                                "wait. Somebody is signed in to Iowa Courts "
+                                "outside Napier.")
                     self._alert(
                         alerts.CONCURRENT_EXHAUSTED,
                         account=alerts.username_prefix(username),
                         elapsed=_describe(elapsed),
-                        note="Napier's own run held the account for the whole "
-                             "wait. Two staff on one login."
-                             if napier_holds else
-                             "ESA never released the lock, and Napier was not "
-                             "holding the account. Somebody is signed in to "
-                             "Iowa Courts outside Napier.")
+                        note=note)
                     if napier_holds:
                         raise IcosAccountLocked(
                             "This Iowa Courts account has been busy with another "
                             "Napier run for the whole wait. Whoever started it can "
                             "stop it from their own progress page, or you can sign "
                             "in with a different Iowa Courts account.")
+                    if napier_ever_held:
+                        raise IcosAccountLocked(
+                            "Other searches on this Iowa Courts login kept it "
+                            "busy for the whole wait, and have finished now. "
+                            "Nothing is lost; run this search again. Starting "
+                            "several at once on one account does not make them "
+                            "go faster, because Iowa Courts allows one session "
+                            "per account.")
                     raise IcosAccountLocked(
                         "This Iowa Courts account is still logged in from another "
                         "session and Iowa Courts has not released it. Try again in a "
@@ -486,6 +584,10 @@ class IcosClient:
                             "as the account frees up.")
                     waited_for_lock = True
                 self._sleep(CONCURRENT_INTERVAL)
+                # Somebody may have joined the line ahead of us and taken the
+                # account while we slept. Asking again here is what keeps the
+                # order after the first attempt, not just before it.
+                self._await_turn(username, ticket, started)
                 continue
 
             if len(body) < MIN_SIGNED_IN_BYTES:

--- a/tests/test_icos_lock_fairness.py
+++ b/tests/test_icos_lock_fairness.py
@@ -1,0 +1,336 @@
+"""Who gets a shared Iowa Courts login next, and what we say when nobody did.
+
+Both halves of this file come from one incident on 19 August 2026. Four
+searches were started on one ILA login inside forty-five seconds. Three of them
+took the account in turn and finished. The fourth waited the full fifteen
+minutes and died, and the alert it sent said somebody was signed in to Iowa
+Courts outside Napier, which was not true: Napier had held that account for
+almost the whole wait with its own jobs.
+
+So there were two bugs wearing one coat. Nothing decided the order, so the job
+that asked first could lose to three that asked later; and the question "is
+Napier holding this account" was asked once, at the end, by which time the
+answer had changed.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import accounts
+import alerts
+import icos
+from icos import IcosAccountLocked, IcosClient, IcosStopped
+from reader import OK, FetchResult
+from test_accounts import CONCURRENT_PAGE, FakeReader, LOGIN_OK
+
+
+class Clock:
+    """A clock that can be given something to do while it sleeps.
+
+    The account registry changes underneath a waiting job in real life -- that
+    is the whole subject here -- and the only moment a single threaded test can
+    change it is during a sleep.
+    """
+
+    def __init__(self, on_sleep=None):
+        self.now = 0.0
+        self.slept = []
+        self._on_sleep = on_sleep
+
+    def sleep(self, seconds):
+        self.now += seconds
+        self.slept.append(seconds)
+        if self._on_sleep is not None:
+            self._on_sleep(len(self.slept))
+
+    def monotonic(self):
+        return self.now
+
+
+def build(script, on_sleep=None, budget=16 * 60, should_stop=None):
+    clock = Clock(on_sleep)
+    messages = []
+    alerted = []
+    client = IcosClient(log=messages.append,
+                        reader=FakeReader(script),
+                        sleep=clock.sleep, monotonic=clock.monotonic,
+                        alert=lambda failure, **fields: alerted.append(
+                            (failure, fields)),
+                        concurrent_budget_seconds=budget)
+    if should_stop is not None:
+        client.set_stop_check(should_stop)
+    return client, messages, alerted, clock
+
+
+def queue_waits(clock):
+    """Just the waits spent standing in line, not the ones spent asking ESA."""
+    return [s for s in clock.slept if s == icos.QUEUE_INTERVAL]
+
+
+# -- the waiting line itself ----------------------------------------------
+
+class TestTheWaitingLine:
+    def test_a_job_on_its_own_is_at_the_head(self):
+        ticket = accounts.take_ticket('ILA07')
+        assert accounts.ahead_of('ILA07', ticket) == 0
+
+    def test_a_second_job_stands_behind_the_first(self):
+        first = accounts.take_ticket('ILA07')
+        second = accounts.take_ticket('ILA07')
+        assert accounts.ahead_of('ILA07', first) == 0
+        assert accounts.ahead_of('ILA07', second) == 1
+
+    def test_a_different_account_is_a_different_line(self):
+        accounts.take_ticket('ILA07')
+        other = accounts.take_ticket('ILA09')
+        assert accounts.ahead_of('ILA09', other) == 0
+
+    def test_the_same_account_typed_differently_is_one_line(self):
+        """Staff type their user id by hand, so the line has to key the way the
+        rest of the registry does or two spellings become two lines and the
+        ordering is back to a race."""
+        first = accounts.take_ticket(' ila07 ')
+        second = accounts.take_ticket('ILA07')
+        assert accounts.ahead_of('ILA07', second) == 1
+        accounts.drop_ticket(first)
+        assert accounts.ahead_of('ILA07', second) == 0
+
+    def test_dropping_the_head_moves_everybody_up(self):
+        first = accounts.take_ticket('ILA07')
+        second = accounts.take_ticket('ILA07')
+        third = accounts.take_ticket('ILA07')
+        accounts.drop_ticket(first)
+        assert accounts.ahead_of('ILA07', second) == 0
+        assert accounts.ahead_of('ILA07', third) == 1
+
+    def test_tickets_taken_in_the_same_instant_still_have_an_order(self):
+        """Four searches submitted together can share a clock reading. Ordering
+        on the timestamp would leave two of them both believing they were
+        first, which is the race this exists to end."""
+        first = accounts.take_ticket('ILA07', now=1000.0)
+        second = accounts.take_ticket('ILA07', now=1000.0)
+        third = accounts.take_ticket('ILA07', now=1000.0)
+        assert [accounts.ahead_of('ILA07', t, now=1000.0)
+                for t in (first, second, third)] == [0, 1, 2]
+
+    def test_an_abandoned_ticket_does_not_wedge_the_line(self):
+        """A thread that dies between take_ticket and its finally would
+        otherwise hold up everybody behind it forever, which is worse than the
+        race it replaced."""
+        accounts.take_ticket('ILA07', now=0.0)
+        mine = accounts.take_ticket('ILA07', now=0.0)
+        stale = accounts.STALE_TICKET_SECONDS + 1
+        assert accounts.ahead_of('ILA07', mine, now=stale) == 0
+
+    def test_an_unknown_ticket_is_not_made_to_wait(self):
+        accounts.take_ticket('ILA07')
+        assert accounts.ahead_of('ILA07', 'never-issued') == 0
+
+    def test_dropping_twice_is_harmless(self):
+        ticket = accounts.take_ticket('ILA07')
+        accounts.drop_ticket(ticket)
+        accounts.drop_ticket(ticket)
+        accounts.drop_ticket(None)
+
+
+# -- the order is kept ----------------------------------------------------
+
+class TestSigningInWaitsItsTurn:
+    def test_a_job_on_its_own_does_not_wait_at_all(self):
+        client, _, _, clock = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login('ILA07', 'secret')
+        assert client.logged_in
+        assert queue_waits(clock) == []
+
+    def test_a_job_behind_another_waits_for_it(self):
+        """The regression. Before the line existed this signed in immediately,
+        raced the job that arrived first, and could win."""
+        earlier = accounts.take_ticket('ILA07')
+        client, messages, _, clock = build(
+            [FetchResult(OK, LOGIN_OK), FetchResult(OK, LOGIN_OK)],
+            on_sleep=lambda n: accounts.drop_ticket(earlier) if n == 2 else None)
+
+        client.login('ILA07', 'secret')
+
+        assert client.logged_in
+        assert queue_waits(clock) == [icos.QUEUE_INTERVAL] * 2
+
+    def test_it_says_how_many_are_ahead(self):
+        earlier = accounts.take_ticket('ILA07')
+        client, messages, _, _ = build(
+            [FetchResult(OK, LOGIN_OK), FetchResult(OK, LOGIN_OK)],
+            on_sleep=lambda n: accounts.drop_ticket(earlier))
+        client.login('ILA07', 'secret')
+
+        waiting = [m for m in messages if 'earlier' in m]
+        assert waiting
+        assert '1 earlier search' in waiting[0]
+        assert 'is still running' in waiting[0]
+
+    def test_it_counts_more_than_one_correctly(self):
+        first = accounts.take_ticket('ILA07')
+        second = accounts.take_ticket('ILA07')
+        dropped = []
+
+        def release(n):
+            for ticket in (first, second):
+                if ticket not in dropped:
+                    accounts.drop_ticket(ticket)
+                    dropped.append(ticket)
+                    return
+
+        client, messages, _, _ = build([FetchResult(OK, LOGIN_OK),
+                                        FetchResult(OK, LOGIN_OK)],
+                                       on_sleep=release)
+        client.login('ILA07', 'secret')
+
+        waiting = [m for m in messages if 'earlier' in m]
+        assert '2 earlier searches' in waiting[0]
+        assert 'are still running' in waiting[0]
+        # It counts down rather than repeating itself.
+        assert '1 earlier search' in waiting[1]
+
+    def test_a_line_on_another_account_is_not_ours(self):
+        accounts.take_ticket('ILA09')
+        client, _, _, clock = build([FetchResult(OK, LOGIN_OK),
+                                     FetchResult(OK, LOGIN_OK)])
+        client.login('ILA07', 'secret')
+        assert client.logged_in
+        assert queue_waits(clock) == []
+
+    def test_stopping_works_while_standing_in_line(self):
+        """Sixteen minutes is far too long to make somebody sit through once
+        they have decided to stop."""
+        accounts.take_ticket('ILA07')
+        client, _, _, _ = build([FetchResult(OK, LOGIN_OK)],
+                                should_stop=lambda: True)
+        with pytest.raises(IcosStopped):
+            client.login('ILA07', 'secret')
+
+    def test_the_ticket_is_given_back_even_when_the_login_fails(self):
+        """Otherwise one failed job holds up every job behind it until the
+        stale sweep, which is fifteen minutes of nothing for everybody."""
+        client, _, _, _ = build([FetchResult(OK, LOGIN_OK),
+                                 FetchResult(OK, CONCURRENT_PAGE),
+                                 FetchResult(OK, CONCURRENT_PAGE)],
+                                budget=100)
+        with pytest.raises(IcosAccountLocked):
+            client.login('ILA07', 'secret')
+
+        after = accounts.take_ticket('ILA07')
+        assert accounts.ahead_of('ILA07', after) == 0
+
+    def test_the_ticket_is_given_back_once_signed_in(self):
+        """A ticket is intent, not possession. Holding one for the length of
+        the session would stop the next job from even being told it is
+        waiting, which is what the registry is for."""
+        client, _, _, _ = build([FetchResult(OK, LOGIN_OK),
+                                 FetchResult(OK, LOGIN_OK)])
+        client.login('ILA07', 'secret')
+
+        after = accounts.take_ticket('ILA07')
+        assert accounts.ahead_of('ILA07', after) == 0
+        assert accounts.holder('ILA07') is not None
+
+
+class TestGivingUpInTheLine:
+    def test_it_gives_up_if_the_line_never_moves(self):
+        accounts.take_ticket('ILA07')
+        client, _, alerted, _ = build([FetchResult(OK, LOGIN_OK)], budget=100)
+
+        with pytest.raises(IcosAccountLocked) as caught:
+            client.login('ILA07', 'secret')
+
+        assert 'run this search again' in str(caught.value)
+        assert 'one session per account' in str(caught.value)
+
+    def test_it_does_not_blame_an_outsider_for_our_own_queue(self):
+        accounts.take_ticket('ILA07')
+        client, _, alerted, _ = build([FetchResult(OK, LOGIN_OK)], budget=100)
+
+        with pytest.raises(IcosAccountLocked):
+            client.login('ILA07', 'secret')
+
+        failure, fields = alerted[0]
+        assert failure == alerts.CONCURRENT_EXHAUSTED
+        assert 'outside Napier' not in fields['note']
+        assert 'Not an outside session' in fields['note']
+        assert 'never got a turn' in fields['note']
+
+    def test_the_alert_still_keeps_the_account_to_its_family(self):
+        accounts.take_ticket('ILA07')
+        client, _, alerted, _ = build([FetchResult(OK, LOGIN_OK)], budget=100)
+        with pytest.raises(IcosAccountLocked):
+            client.login('ILA07', 'secret')
+
+        assert alerted[0][1]['account'] == 'ILA##'
+
+
+# -- what the alert is allowed to conclude --------------------------------
+
+class TestTheHolderQuestionIsAskedAcrossTheWholeWait:
+    """19 August, exactly. Napier held the account for most of the wait and let
+    it go before the budget ran out, and the end-of-wait sample found an empty
+    registry and blamed a stranger."""
+
+    def _timed_out_with_a_hold_that_ends_midway(self):
+        handle = accounts.hold('ILA07', now=0.0)
+        client, _, alerted, _ = build(
+            [FetchResult(OK, LOGIN_OK),
+             FetchResult(OK, CONCURRENT_PAGE),
+             FetchResult(OK, CONCURRENT_PAGE)],
+            on_sleep=lambda n: accounts.release(handle),
+            budget=100)
+        with pytest.raises(IcosAccountLocked) as caught:
+            client.login('ILA07', 'secret')
+        return alerted[0][1]['note'], str(caught.value)
+
+    def test_the_alert_does_not_invent_an_outside_session(self):
+        note, _ = self._timed_out_with_a_hold_that_ends_midway()
+        assert 'signed in to Iowa Courts outside Napier' not in note
+
+    def test_the_alert_says_it_was_napier(self):
+        note, _ = self._timed_out_with_a_hold_that_ends_midway()
+        assert "Napier's own runs held the account" in note
+        assert 'Not an outside session' in note
+
+    def test_the_staffer_is_not_sent_after_a_phantom_colleague(self):
+        """The old message told her to use a different Iowa Courts account. She
+        has one account, and the collision was her own searches."""
+        _, told = self._timed_out_with_a_hold_that_ends_midway()
+        assert 'use your own Iowa Courts account' not in told
+        assert 'run this search again' in told
+
+    def test_an_account_napier_never_held_still_reads_as_an_outsider(self):
+        """The partition. Fixing the false accusation must not cost the true
+        one: a staffer signed in to ICOS in a browser tab is a real thing that
+        happens and the alert has to keep saying so."""
+        client, _, alerted, _ = build([FetchResult(OK, LOGIN_OK),
+                                       FetchResult(OK, CONCURRENT_PAGE),
+                                       FetchResult(OK, CONCURRENT_PAGE)],
+                                      budget=100)
+        with pytest.raises(IcosAccountLocked):
+            client.login('ILA07', 'secret')
+
+        note = alerted[0][1]['note']
+        assert 'Somebody is signed in to Iowa Courts outside Napier' in note
+        assert 'at any point in the wait' in note
+
+    def test_a_hold_that_lasts_the_whole_wait_still_names_two_staff(self):
+        """The third case, unchanged: the other run is still going, so there is
+        somebody who can stop it."""
+        accounts.hold('ILA07', now=0.0)
+        client, _, alerted, _ = build([FetchResult(OK, LOGIN_OK),
+                                       FetchResult(OK, CONCURRENT_PAGE),
+                                       FetchResult(OK, CONCURRENT_PAGE)],
+                                      budget=100)
+        with pytest.raises(IcosAccountLocked) as caught:
+            client.login('ILA07', 'secret')
+
+        assert 'Two staff on one login' in alerted[0][1]['note']
+        assert 'stop it from their own progress page' in str(caught.value)


### PR DESCRIPTION
Fixes the two defects behind the 19 August lock alerts. Separate from #127 (the CIV disposition work), which this does not touch.

## What happened

One ILA login, four searches started inside forty-five seconds from one browser. Three took the account in turn and finished. The fourth waited the full fifteen minutes, gave up, and emailed to say somebody was signed in to Iowa Courts outside Napier.

```
20:13:27  job A   refused, "already logged in somewhere else, and not by Napier"
20:13:53  job B   refused
20:14:01  job C   refused
20:14:12  job D   signed in   -> finished
20:14:43  job A   signed in   -> finished
20:16:24  job B   signed in   -> finished
20:29:04  job C   gave up after 15m02s, alerted
```

Job C asked before job D and lost. Then it was told the collision came from outside Napier, twelve minutes after the last Napier session on that account had released it.

## The order

ICOS allows one session per account and offers no queue, so several searches on one login run one at a time whatever we do. What was missing was the *order*: every waiting job slept seventy-five seconds and asked again, so the account went to whoever happened to ask in the right half second.

`accounts.py` now keeps a waiting line. A job takes a ticket before it asks ESA for anything, waits until nothing on its account is ahead of it, and gives the ticket back in a `finally`. Position is counted by place in the line rather than by timestamp, because four jobs submitted together can share a clock reading and ties would put us back where we started. Tickets older than thirty minutes are swept, so a thread that dies between `take_ticket` and its `finally` cannot wedge the line for everybody behind it.

The progress page says where a job is in line and counts down as the ones ahead finish.

## The diagnosis

`napier_holds` was sampled once, when the budget ran out. Now the observation is latched across the whole wait, and there are three answers rather than two:

| what happened | what the alert says | what the staffer is told |
|---|---|---|
| Napier still holds it | Two staff on one login | Whoever started it can stop it from their progress page |
| Napier held it earlier and let go | Too many searches on one account. Not an outside session | Nothing is lost, run it again |
| Napier never held it | Somebody is signed in outside Napier | Try again shortly, or use your own account |

The third row is unchanged on purpose. A staffer signed in to ICOS in a browser tab is a real thing that happens and the alert has to keep saying so.

## Tests

25 new in `tests/test_icos_lock_fairness.py`. Full suite 1173 passed.

Both fixes were mutation-checked rather than just run: reverting the ordering and unlatching the holder check fails 14 of the 25, including all three that pin the 19 August misdiagnosis. The 11 that still pass are the ones that should.

## Not in here

Copying the error alerts to Ari. Worth doing, but not until this ships -- the stream currently misdiagnoses, and the first thing he would have got is a false report of a colleague signed in to Iowa Courts. Better as class-based routing (locks and workbook problems to him, diagnostics to me) than a blanket CC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jv4J3ABqZXhZPSnMRHh9Kv