### PR TITLE
Stop three run messages from telling staff things that are not so

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -175,6 +175,13 @@ KNOWN_PARTY_ROLES = frozenset({
     # against them personally, so it is their record, unlike the LIEN FILER
     # and INTERESTED PARTY bystander roles. Seen on a live search 2026-08-12.
     'PROPERTY OWNER',
+    # ICOS's wording when the property has more than one owner on it. Nothing
+    # in the reasoning above turns on being the only owner: the case is still
+    # about their property and can still assess costs against them personally.
+    # So it was always going to need the same answer as PROPERTY OWNER, and was
+    # simply missed when that went in on 2026-08-12. Six separate searches
+    # alerted on it on 2026-08-20.
+    'PROPERTY CO-OWNER',
 })
 
 # The notice ICOS shows when a name matches more cases than it will list. The

--- a/icos.py
+++ b/icos.py
@@ -580,10 +580,15 @@ class IcosClient:
         slow = sorted(n for n in self.landed_on if n > 1)
         if not slow and not self.given_up:
             return None
+        # "requests", not a bare number. These count page requests, and a
+        # case costs three of them, so the bare version sat under a line about
+        # 22 cases that could not be pulled and read as though four of them
+        # had worked. None of them had.
         parts = ["%d first time" % self.landed_on.get(1, 0)]
         for n in slow:
             parts.append("%d on try %d" % (self.landed_on[n], n))
-        line = "Iowa Courts answered " + ", ".join(parts)
+        line = ("Of the page requests this run made, Iowa Courts answered "
+                + ", ".join(parts))
         if self.given_up:
             line += ", and never answered %d" % self.given_up
         return line + "."

--- a/tasks.py
+++ b/tasks.py
@@ -530,8 +530,15 @@ def _pull_cases(job, client, case_ids, offset=0, total=None, outage=None):
 
     if not_attempted:
         failed.extend(not_attempted)
-        job.log("%s, so the last %d case%s could not be pulled. The workbook "
-                "has the rest."
+        # Says what happened and stops there. It used to finish "The workbook
+        # has the rest", which it is in no position to know: this runs once per
+        # spelling group, so cases here is that group's share and not the
+        # client's, and the caller is the one that decides whether a workbook
+        # gets built at all. On 2026-08-20 Iowa Courts served its own outage
+        # page, every case of a 24 case run failed, the run raised "no cases
+        # could be read", and the last line the staffer saw promised them a
+        # workbook that was never written.
+        job.log("%s, so the last %d case%s could not be pulled."
                 % (stopped_responding(outage), len(not_attempted),
                    "" if len(not_attempted) == 1 else "s"))
     return cases, failed
@@ -1033,6 +1040,12 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
                 raise IcosError("Iowa Courts would not answer that name a "
                                 "second time, so none of the cases could be "
                                 "pulled. Please try the search again.")
+            # The staffer reads the progress log, not the traceback. Without
+            # this the run's last word is about the cases it skipped, and
+            # nothing anywhere says the outcome was nothing at all.
+            job.log("Iowa Courts did not give up a single one of these cases, "
+                    "so there is no workbook to build. Nothing is lost: run "
+                    "the search again once Iowa Courts is answering.")
             raise ValueError("no cases could be read")
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -75,6 +75,11 @@ class StubClient:
 # the copy that gets emailed and kept.
 TOLD_MISSING = []
 
+# The job the last run drove, kept so a test can read the progress log of a run
+# that raised on its way out. The runs that end in nothing are exactly the ones
+# whose last line matters most.
+LAST_JOB = []
+
 
 def run(monkeypatch, case_ids, unavailable=()):
     """Drive crs_task directly; parsing and workbook building are stubbed."""
@@ -102,6 +107,7 @@ def run(monkeypatch, case_ids, unavailable=()):
     monkeypatch.setattr(tasks, 'build_workbook', fake_build)
 
     job = FakeJob()
+    LAST_JOB[:] = [job]
     tasks.crs_task(job, 'tok', [KEY], {KEY: list(case_ids)},
                    'TESTER, PAT Q', '01/01/1900', False)
     return job, stub, written
@@ -174,6 +180,42 @@ def test_a_run_where_no_case_comes_back_still_fails(monkeypatch):
     case_ids = ids(4)
     with pytest.raises(ValueError):
         run(monkeypatch, case_ids, unavailable=case_ids)
+
+
+def test_the_skipped_cases_line_does_not_promise_a_workbook(monkeypatch):
+    """It used to end "The workbook has the rest", and it cannot know that.
+
+    The line is written where the cases are pulled, which happens once per
+    spelling group and knows neither the client's full total nor whether a
+    workbook gets built at all. On 2026-08-20 Iowa Courts served its own outage
+    page, every case of a 24 case run failed, the run ended in an error with no
+    file, and this was the last thing the staffer was told.
+    """
+    case_ids = ids(11)
+    job, _, _ = run(monkeypatch, case_ids, unavailable=case_ids[2:])
+
+    skipped = [line['message'] for line in job.progress
+               if 'could not be pulled' in line['message']]
+    assert skipped, [line['message'] for line in job.progress]
+    assert not any('workbook has the rest' in line for line in skipped)
+
+
+def test_a_run_that_gets_nothing_says_there_is_no_workbook(monkeypatch):
+    """The staffer reads the progress log, not the traceback.
+
+    Without this the run's last word is about the cases it skipped and nothing
+    anywhere says the outcome was nothing at all, which is how a failed run
+    reads like a finished one.
+    """
+    case_ids = ids(4)
+    with pytest.raises(ValueError):
+        run(monkeypatch, case_ids, unavailable=case_ids)
+
+    job = LAST_JOB[0]
+    assert any('no workbook to build' in line['message']
+               for line in job.progress), [l['message'] for l in job.progress]
+    assert any('run the search again' in line['message']
+               for line in job.progress)
 
 
 def test_a_session_that_is_already_gone_is_not_reported_as_a_bug(monkeypatch):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -189,6 +189,19 @@ def test_a_property_owner_is_the_person_the_search_is_about():
     assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
 
 
+def test_a_property_co_owner_is_the_person_the_search_is_about():
+    """The same case as PROPERTY OWNER above, which is the point.
+
+    ICOS writes this when the property has more than one owner on it. Nothing
+    in the reasoning for PROPERTY OWNER turns on being the only owner, so the
+    two were always going to need the same answer, and only one of them got it
+    on 2026-08-12. Six searches on 2026-08-20 alerted on the variant.
+    """
+    cases, _ = case_parser.parse_search(role_row('PROPERTY CO-OWNER'))
+    assert ids(cases) == ['00000  FECR000000']
+    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
+
+
 def test_the_two_role_lists_do_not_overlap():
     """A role in both would be suppressed and vouched for at the same time."""
     assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)

--- a/tests/test_retry_profile.py
+++ b/tests/test_retry_profile.py
@@ -71,7 +71,16 @@ class TestWhatItCounts:
         client.case_bundle(CASE_ID)
 
         assert client.landed_on == {1: 2, 2: 1}
-        assert client.retry_summary().startswith("Iowa Courts answered 2 first time")
+        assert "Iowa Courts answered 2 first time" in client.retry_summary()
+
+    def test_the_line_says_it_is_counting_requests_not_cases(self):
+        """A case costs three requests, so the bare number reads as cases."""
+        client, _, _ = build([FetchResult(OK, CASE_PAGE),
+                              FetchResult(TIMEOUT), FetchResult(OK, CASE_PAGE),
+                              FetchResult(OK, CASE_PAGE)])
+        client.case_bundle(CASE_ID)
+
+        assert client.retry_summary().startswith("Of the page requests")
 
     def test_a_whole_bundle_that_worked_is_still_quiet(self):
         client, _, _ = build([FetchResult(OK, CASE_PAGE)] * 3)


### PR DESCRIPTION
Fifteen alert mails on 2026-08-20 were two unrelated stories. Three defects fell out of reading them; none of them lost a case, all three of them lied to somebody.

## The outage (not our bug, but two of ours showed up inside it)

Iowa Courts served its own problem report page on `TViewCaseCivil` for most of the afternoon (HTTP 200, 3432 bytes, "There was a communication problem"). Napier told that apart from a dead request correctly, retried each case seven times over about four minutes, and tripped its circuit breaker after two cases of a twenty-four case run. Three CRS jobs died the same way. Searches were unaffected.

**1. `_pull_cases` promised a workbook it could not know about.** Its "the last N cases could not be pulled" line ended with "The workbook has the rest." That function runs once per spelling group, so its `cases` is that group's share and not the client's, and the caller is what decides whether a workbook gets built at all. On those three runs every case failed, `crs_task` raised `no cases could be read`, no file was written, and that sentence was the last thing the staffer read. Same family as the false overflow warning in #126.

The claim is gone from `_pull_cases` entirely — the fix is not to condition it, because that frame has no way to be right about it. `crs_task` now logs the truth at the one place that knows it, immediately before the raise: there is no workbook, and running the search again once ICOS answers loses nothing.

**2. `retry_summary` counted requests and read as cases.** It said "Iowa Courts answered 4 first time". A case costs three page requests, so under a line about 22 cases that could not be pulled, that reads as four cases having worked. None had. It now leads with "Of the page requests this run made".

## The roles (ours, and live)

Seven alerts were unrecognised party roles: `PROPERTY CO-OWNER` on six separate searches, and `RESP/PROTECTED PERSON` on one.

`PROPERTY CO-OWNER` is added here. Nothing in the reasoning that put `PROPERTY OWNER` on the list on 2026-08-12 turns on being the only owner, so it was always going to need the same answer and was simply missed.

`RESP/PROTECTED PERSON` is **not** decided in this PR — which side of a protective order that label names, and whether such a case belongs on a CRS, is a legal call. It is going to Iowa Legal Aid as a question.

Worth being clear about the blast radius: `NON_PARTY_ROLES` is a denylist, so an unrecognised role is *included* in the workbook rather than dropped. No client's CRS was missing a case over this. The cost is entirely the alert, and an alert that fires six times in an afternoon for a role that should have been on the list is the one that stops getting read.

## Verification

- Full suite: **1177 passed**.
- Three new tests, all mutation-checked: putting "The workbook has the rest" back fails `test_the_skipped_cases_line_does_not_promise_a_workbook`; removing the new log line fails `test_a_run_that_gets_nothing_says_there_is_no_workbook`; both pass again on restore.
- `tests/test_retry_profile.py` gained a test that the line names requests, and its existing assertion was loosened from `startswith` to `in` because the qualifier now leads.
- `tests/test_parser.py` gained the `PROPERTY CO-OWNER` case; the two-lists-do-not-overlap invariant still holds.

Prod `crs-napier` is untouched at v55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jv4J3ABqZXhZPSnMRHh9Kv
