### PR TITLE
Say on the row when Iowa Courts gave no date of birth

### DIFF
--- a/app.py
+++ b/app.py
@@ -368,7 +368,11 @@ def batch_crs():
                       # workbook is least visible: the finish page shows one
                       # row per client and def_name is the first key's name, so
                       # the second spelling is named nowhere at all otherwise.
-                      'filed_as': tasks.docket_names(keys, entry['cases'])})
+                      'filed_as': tasks.docket_names(keys, entry['cases']),
+                      # Same window and the same reason as filed_as: the
+                      # results page is the only thing that ever knew.
+                      'no_dob': sorted(tasks.dob_unknown_cases(
+                          keys, entry['cases']))})
 
     if not picks:
         return jsonify({"error": "Pick a match for at least one client."}), 400

--- a/case_parser.py
+++ b/case_parser.py
@@ -175,6 +175,14 @@ KNOWN_PARTY_ROLES = frozenset({
     # against them personally, so it is their record, unlike the LIEN FILER
     # and INTERESTED PARTY bystander roles. Seen on a live search 2026-08-12.
     'PROPERTY OWNER',
+    # ICOS's role on a protective order case. It reads as a bystander role and
+    # it is not: a no contact order and any contempt off it are the person's
+    # own court record, and the client is who it was entered against. Iowa
+    # Legal Aid was asked on 2026-08-20 whether to drop these and said to keep
+    # them. Naming it here changes nothing about which cases are written --
+    # it was never in NON_PARTY_ROLES -- and stops a decided role mailing an
+    # unrecognised-role alert on every run that touches one.
+    'RESP/PROTECTED PERSON',
     # ICOS's wording when the property has more than one owner on it. Nothing
     # in the reasoning above turns on being the only owner: the case is still
     # about their property and can still assess costs against them personally.

--- a/tasks.py
+++ b/tasks.py
@@ -132,11 +132,18 @@ if platform.system() == 'Windows':
     tmp_dir = '.\\tmp\\'
 
 
+# What stands in for the date of birth in a defendant key when Iowa Courts'
+# results page left the column empty. It is the word the picking page shows and
+# the word BASIC INFO B6 ends up carrying, so anywhere else that has to say the
+# same thing says it with this rather than a second spelling of it.
+DOB_UNKNOWN = 'DOB-UNKNOWN'
+
+
 def _defendant_key(case):
     if case['dob'] and not case['dob'].isspace():
         month, day, year = [part.strip() for part in case['dob'].split('/')]
         return "{}-{}-{} {}".format(year, month, day, case['name'].strip())
-    return 'DOB-UNKNOWN ' + case['name']
+    return DOB_UNKNOWN + ' ' + case['name']
 
 
 def group_cases(cases):
@@ -211,6 +218,34 @@ def docket_names(keys, case_dict):
     if len(set(names.values())) < 2:
         return {}
     return names
+
+
+def dob_unknown_cases(keys, case_dict):
+    """Which picked cases Iowa Courts gave no date of birth for.
+
+    A results row with an empty date of birth column groups under DOB-UNKNOWN,
+    and ticking that group puts the case on the client's file on the strength
+    of the name and nothing else. That is the one thing on the finished row
+    that cannot be checked against the person sitting in the clinic, and until
+    now it was said only in BASIC INFO B6, which is one cell for the whole
+    workbook and is not the sheet anybody reads the cases off. Iowa Legal Aid
+    asked for it on the rows on 2026-08-20.
+
+    Marked even when every row carries it, unlike docket_names. Two spellings
+    of a name is a fact about the workbook, so saying it on every row of a
+    workbook that has only one spelling says nothing; no date of birth is a
+    fact about the case, and a sheet where it is true of every row is a sheet
+    where nothing at all was matched on a date of birth.
+
+    A case listed under both a dated key and an undated one is not marked. The
+    date of birth is known for it either way, and one result row missing the
+    column is not a reason to caveat a case the row above confirmed.
+    """
+    dated, undated = set(), set()
+    for key in keys:
+        into = undated if key.startswith(DOB_UNKNOWN + ' ') else dated
+        into.update(case_dict.get(key, []))
+    return undated - dated
 
 
 def searches_behind(entry):
@@ -545,7 +580,7 @@ def _pull_cases(job, client, case_ids, offset=0, total=None, outage=None):
 
 
 def _retry_entry(def_name, def_dob, person, case_ids, cases, failed,
-                 searches=None, filed_as=None):
+                 searches=None, filed_as=None, no_dob=None):
     """One client's share of what a retry needs.
 
     case_ids is everything that was asked for, in the order it was asked for,
@@ -561,6 +596,9 @@ def _retry_entry(def_name, def_dob, person, case_ids, cases, failed,
     filed_as is the note each case carries about which spelling of the client's
     name it is docketed under, empty unless there is more than one.
 
+    no_dob is the cases Iowa Courts listed without a date of birth. Both are
+    read off the search results, which a retry never sees again.
+
     These sit in the dyno's memory for the two hours the job lives, which is
     the same window the workbook itself sits in tmp for, so nothing is exposed
     here that the finished run was not already holding. They reach no log, no
@@ -571,7 +609,8 @@ def _retry_entry(def_name, def_dob, person, case_ids, cases, failed,
              # So a rebuilt workbook keeps the attribution. The keys and the
              # search results it was worked out from belong to the search job,
              # which a retry does not go back to.
-             'filed_as': dict(filed_as or {})}
+             'filed_as': dict(filed_as or {}),
+             'no_dob': list(no_dob or ())}
     if searches:
         entry['searches'] = [{'person': group['person'],
                               'case_ids': list(group['case_ids'])}
@@ -873,7 +912,8 @@ def batch_crs_task(job, session_token, picks, is_lite):
             entry = _retry_entry(pick['def_name'], pick['def_dob'],
                                  pick.get('person'), pick['case_ids'], [], [],
                                  pick.get('searches'),
-                                 pick.get('filed_as'))
+                                 pick.get('filed_as'),
+                                 pick.get('no_dob'))
             retry_entries.append(entry)
 
             # Before the re-search, not after it. A dead site would otherwise
@@ -920,7 +960,7 @@ def batch_crs_task(job, session_token, picks, is_lite):
             try:
                 path, unknown, atp, short = build_workbook(
                     cases, pick['def_name'], pick['def_dob'], is_lite, failed,
-                    pick.get('filed_as'))
+                    pick.get('filed_as'), pick.get('no_dob'))
             except Exception as e:
                 # The other clients' workbooks are already built or still to
                 # come, and neither should be lost to this one.
@@ -1024,6 +1064,10 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
         # Which spelling each case is docketed under, while the search results
         # are still here to say so. CASE DATA carries no name of its own.
         filed_as = docket_names(keys, case_dict)
+        # Same window, same reason: CASE DATA has no date of birth column of
+        # its own and the case page cannot be asked what the results page did
+        # not say.
+        no_dob = dob_unknown_cases(keys, case_dict)
         # The order the groups are pulled in, so the workbook's rows and the
         # retry's idea of where a recovered row goes back agree with each other.
         case_ids = [case_id for group in searches
@@ -1050,7 +1094,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
 
         job.log("Building the CRS workbook...", count=len(case_ids), total=len(case_ids))
         path, unknown_dispositions, atp, short = build_workbook(
-            cases, def_name, def_dob, is_lite, failed, filed_as)
+            cases, def_name, def_dob, is_lite, failed, filed_as, no_dob)
         report_unknown_dispositions(job, unknown_dispositions)
         report_short_workbook(job, short, len(cases))
         job.result = {
@@ -1065,7 +1109,7 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
             "done_url": "/done/%s" % job.id,
             "retry": _retry_payload('crs', is_lite, [
                 _retry_entry(def_name, def_dob, person, case_ids, cases,
-                             failed, searches, filed_as)]),
+                             failed, searches, filed_as, no_dob)]),
         }
 
         if failed:
@@ -1172,7 +1216,8 @@ def retry_task(job, username, password, payload):
                                         entry['person'], entry['case_ids'],
                                         cases, still_failed,
                                         entry.get('searches'),
-                                        entry.get('filed_as')))
+                                        entry.get('filed_as'),
+                                        entry.get('no_dob')))
             if not cases:
                 if skipped:
                     record['error'] = ("%s before Napier reached this client, "
@@ -1192,7 +1237,7 @@ def retry_task(job, username, password, payload):
             try:
                 path, unknown, atp, short = build_workbook(
                     cases, entry['def_name'], entry['def_dob'], is_lite,
-                    still_failed, entry.get('filed_as'))
+                    still_failed, entry.get('filed_as'), entry.get('no_dob'))
             except Exception as e:
                 print("Workbook failed on retry for client %d: %r" % (index, e),
                       flush=True)
@@ -1273,8 +1318,15 @@ def retry_task(job, username, password, payload):
 # column in one pass.
 FILED_AS_NOTE = "Filed under %s."
 
+# And what it says on a row Iowa Courts listed with no date of birth. Named the
+# way the picking page names it, because the staffer who ticked DOB-UNKNOWN
+# there is the one reading this, and the second clause is why it is worth a
+# note: every other row was confirmed against a date and this one was not.
+DOB_UNKNOWN_NOTE = "DOB-Unknown: matched on the name alone."
 
-def build_workbook(cases, def_name, def_dob, is_lite, failed=(), filed_as=None):
+
+def build_workbook(cases, def_name, def_dob, is_lite, failed=(), filed_as=None,
+                   no_dob=()):
     """Returns the path written, the dispositions Napier could not read, the
     two figures the ability-to-pay calculator asks for, and anything the saved
     workbook is still short of.
@@ -1287,6 +1339,10 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=(), filed_as=None):
     filed_as maps a case number to the spelling of the client's name it is
     docketed under, and is empty unless the workbook holds more than one. See
     docket_names for why the notes column is where that goes.
+
+    no_dob is the case numbers Iowa Courts listed without a date of birth, so
+    the row can say the client was matched on the name and nothing else. See
+    dob_unknown_cases.
 
     The second value maps the ICOS wording, paired with whether the row it
     landed on came out with a code in column G, to the case numbers it turned up
@@ -1310,6 +1366,7 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=(), filed_as=None):
     row = 4
     unknown = {}
     filed_as = filed_as or {}
+    no_dob = set(no_dob or ())
     for case in cases:
         for key in crs.process_case(case, sheet, row, clinic_date) or []:
             unknown.setdefault(key, []).append(case['id'])
@@ -1317,6 +1374,8 @@ def build_workbook(cases, def_name, def_dob, is_lite, failed=(), filed_as=None):
         # client this is and then what to watch on it.
         if filed_as.get(case['id']):
             crs.append_note(sheet, row, FILED_AS_NOTE % filed_as[case['id']])
+        if case['id'] in no_dob:
+            crs.append_note(sheet, row, DOB_UNKNOWN_NOTE)
         row += 1
 
     # A code the chosen template has no formula for counts for nothing, on

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -140,7 +140,7 @@ written = []
 attributed = []
 
 
-def record_workbook(cases, name, dob, lite, failed=(), filed_as=None):
+def record_workbook(cases, name, dob, lite, failed=(), filed_as=None, no_dob=()):
     """What actually reached the workbook, which is the question the dedup
     test is asking. A case counted twice here is a client billed twice."""
     written.append([case['id'] for case in cases])

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -119,7 +119,7 @@ def fake_icos(monkeypatch):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(), filed_as=None: (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
+                        lambda cases, name, dob, lite, failed=(), filed_as=None, no_dob=(): (_stub_workbook(name), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
     yield
 
 

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -80,7 +80,7 @@ def fake_icos(monkeypatch, tmp_path):
                         lambda html, case: case.update(financials=[],
                                                        total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(), filed_as=None: (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
+                        lambda cases, name, dob, lite, failed=(), filed_as=None, no_dob=(): (str(tmp_path / 'w.xlsx'), {}, {'balance': '$0.00', 'monthly': None, 'months': 12}, []))
     yield
 
 

--- a/tests/test_case_failures.py
+++ b/tests/test_case_failures.py
@@ -98,7 +98,7 @@ def run(monkeypatch, case_ids, unavailable=()):
     written = []
     TOLD_MISSING[:] = []
 
-    def fake_build(cases, name, dob, lite, failed=(), filed_as=None):
+    def fake_build(cases, name, dob, lite, failed=(), filed_as=None, no_dob=()):
         written.extend(case['id'] for case in cases)
         TOLD_MISSING.extend(failed)
         return (os.path.join(tasks.tmp_dir, 'stub.xlsx'), {},

--- a/tests/test_dob_unknown_note.py
+++ b/tests/test_dob_unknown_note.py
@@ -1,0 +1,151 @@
+"""A case Iowa Courts listed with no date of birth says so on its own row.
+
+The results page has a date of birth column and sometimes leaves it empty. A
+row like that groups under DOB-UNKNOWN on the picking page, and ticking it puts
+the case on the client's file on the strength of the name and nothing else --
+which, on a common name, is somebody else's convictions and somebody else's
+court debt.
+
+The workbook said it in one place: BASIC INFO B6, which is one cell for the
+whole file and reads as a blank field rather than as a warning. It is now on
+the CASE DATA row too, where the cases actually get read. Iowa Legal Aid asked
+for that on 2026-08-20.
+
+Every name here is invented and every case number is 00000-shaped. The
+repository is public.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import crs
+import tasks
+from test_formula_grid import synthetic_cases   # noqa: E402
+
+DATED = '1900-01-01 DOE, JANE'
+UNDATED = tasks.DOB_UNKNOWN + ' DOE, JANE'
+
+FIRST = '00000  FECR000000'
+SECOND = '00000  FECR000001'
+
+
+class TestWhichCasesAreUndated:
+    def test_a_result_with_no_date_of_birth_groups_under_the_word(self):
+        """The premise. dob_unknown_cases reads the key, so if _defendant_key
+        ever spells this differently the reading has to change with it."""
+        key = tasks._defendant_key({'dob': '', 'name': 'DOE, JANE'})
+        assert key == UNDATED
+        assert tasks._defendant_key(
+            {'dob': ' ', 'name': 'DOE, JANE'}) == UNDATED
+
+    def test_the_undated_group_is_marked(self):
+        assert tasks.dob_unknown_cases(
+            [UNDATED], {UNDATED: [FIRST, SECOND]}) == {FIRST, SECOND}
+
+    def test_a_dated_group_is_not(self):
+        assert tasks.dob_unknown_cases(
+            [DATED], {DATED: [FIRST]}) == set()
+
+    def test_only_the_undated_half_of_a_mixed_pick_is_marked(self):
+        """The pick that makes this worth doing per row rather than per file:
+        one client, one name, two groups, and only one of them checked against
+        a date."""
+        assert tasks.dob_unknown_cases(
+            [DATED, UNDATED],
+            {DATED: [FIRST], UNDATED: [SECOND]}) == {SECOND}
+
+    def test_a_case_listed_under_both_keeps_its_date(self):
+        """One result row missing the column is not a reason to caveat a case
+        another row confirmed."""
+        assert tasks.dob_unknown_cases(
+            [DATED, UNDATED],
+            {DATED: [FIRST], UNDATED: [FIRST, SECOND]}) == {SECOND}
+
+    def test_the_order_the_groups_were_picked_in_does_not_matter(self):
+        both = {DATED: [FIRST], UNDATED: [FIRST]}
+        assert tasks.dob_unknown_cases([UNDATED, DATED], both) == set()
+        assert tasks.dob_unknown_cases([DATED, UNDATED], both) == set()
+
+    def test_a_key_with_no_cases_behind_it_is_harmless(self):
+        assert tasks.dob_unknown_cases([UNDATED], {}) == set()
+
+    def test_a_name_that_merely_starts_with_the_word_is_not_a_key(self):
+        """The prefix is matched with its separating space on purpose. A
+        surname is a surname."""
+        assert tasks.dob_unknown_cases(
+            ['1900-01-01 DOB-UNKNOWNS, JANE'],
+            {'1900-01-01 DOB-UNKNOWNS, JANE': [FIRST]}) == set()
+
+
+def _built(no_dob, count=2, **kw):
+    from openpyxl import load_workbook
+    path, _, _, _ = tasks.build_workbook(
+        synthetic_cases(count), 'DOE, JANE', tasks.DOB_UNKNOWN, False,
+        no_dob=no_dob, **kw)
+    return load_workbook(path)['CASE DATA']
+
+
+class TestTheNoteInTheWorkbook:
+    def test_it_lands_in_the_notes_column(self):
+        sheet = _built({FIRST})
+        assert tasks.DOB_UNKNOWN_NOTE in sheet['V4'].value
+
+    def test_only_the_row_it_belongs_to(self):
+        sheet = _built({FIRST})
+        assert tasks.DOB_UNKNOWN_NOTE not in (sheet['V5'].value or '')
+
+    def test_nothing_is_written_without_it(self):
+        # Column V is not empty on an ordinary row -- process_financials has
+        # its own say about the fee columns -- so this is about the one
+        # sentence, not about the cell.
+        sheet = _built(set())
+        assert 'DOB-Unknown' not in (sheet['V4'].value or '')
+
+    def test_the_default_writes_nothing(self):
+        """Every caller that has nothing to say about this passes nothing."""
+        from openpyxl import load_workbook
+        path, _, _, _ = tasks.build_workbook(
+            synthetic_cases(1), 'DOE, JANE', '01/01/1900', False)
+        sheet = load_workbook(path)['CASE DATA']
+        assert 'DOB-Unknown' not in (sheet['V4'].value or '')
+
+    def test_every_row_is_marked_when_every_row_is_undated(self):
+        """Unlike the filed-under note, which goes quiet on a workbook where
+        it would say the same thing on every row. Two spellings of a name is a
+        fact about the workbook; no date of birth is a fact about the case,
+        and a sheet where it is true throughout is a sheet where nothing was
+        matched on a date at all."""
+        sheet = _built({FIRST, SECOND})
+        assert tasks.DOB_UNKNOWN_NOTE in sheet['V4'].value
+        assert tasks.DOB_UNKNOWN_NOTE in sheet['V5'].value
+
+    def test_it_sits_beside_the_filed_under_note(self):
+        """Both are about which client this row is, and a case can need both:
+        two spellings of the name and no date of birth under one of them."""
+        sheet = _built({FIRST}, filed_as={FIRST: 'DOE, JAYNE'})
+        assert 'Filed under DOE, JAYNE.' in sheet['V4'].value
+        assert tasks.DOB_UNKNOWN_NOTE in sheet['V4'].value
+
+    def test_it_does_not_displace_a_later_caveat(self):
+        sheet = _built({FIRST}, count=1)
+        crs.append_note(sheet, 4, 'A later caveat.')
+        assert tasks.DOB_UNKNOWN_NOTE in sheet['V4'].value
+        assert 'A later caveat.' in sheet['V4'].value
+
+
+def test_it_survives_a_rebuild():
+    """A retry rebuilds the workbook off the retry entry and never sees the
+    search results again, which are the only thing that ever knew this."""
+    entry = tasks._retry_entry('DOE, JANE', tasks.DOB_UNKNOWN, None,
+                               [FIRST], [], [], no_dob={FIRST})
+    assert list(entry['no_dob']) == [FIRST]
+
+
+def test_an_older_retry_entry_has_no_such_key():
+    """entry.get('no_dob') on the retry path, not entry['no_dob']: a job that
+    started before this shipped is still in the dyno's memory."""
+    entry = tasks._retry_entry('DOE, JANE', '01/01/1900', None, [FIRST],
+                               [], [])
+    assert entry['no_dob'] == []

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -102,7 +102,7 @@ def fake_icos(monkeypatch):
     monkeypatch.setattr(tasks.case_parser, 'parse_case_financials',
                         lambda html, case: case.update(financials=[], total_due='$0.00'))
     monkeypatch.setattr(tasks, 'build_workbook',
-                        lambda cases, name, dob, lite, failed=(), filed_as=None: (_write_stub_workbook(),
+                        lambda cases, name, dob, lite, failed=(), filed_as=None, no_dob=(): (_write_stub_workbook(),
                                                         {}, dict(ATP),
                                                         []))
     yield

--- a/tests/test_outage.py
+++ b/tests/test_outage.py
@@ -99,7 +99,7 @@ class StubClient:
 WRITTEN = []
 
 
-def _fake_build(cases, name, dob, lite, failed=(), filed_as=None):
+def _fake_build(cases, name, dob, lite, failed=(), filed_as=None, no_dob=()):
     WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases],
                    'failed': list(failed)})
     path = os.path.join(tasks.tmp_dir, 'test_outage.xlsx')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -202,6 +202,22 @@ def test_a_property_co_owner_is_the_person_the_search_is_about():
     assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
 
 
+def test_a_protective_order_respondent_is_the_person_the_search_is_about():
+    """Alerted as unrecognised on runs through 2026-08-20. The role reads like
+    a bystander and is not one: a no contact order and any contempt off it are
+    the person's own court record, and the client is who it was entered
+    against.
+
+    Iowa Legal Aid was asked on 2026-08-20 whether to drop these and said to
+    keep them. The case was always kept -- the role is in neither list, and
+    neither list is what decides that -- so this is about the alert: a role
+    somebody has ruled on should stop mailing out on every run that meets it.
+    """
+    cases, _ = case_parser.parse_search(role_row('RESP/PROTECTED PERSON'))
+    assert ids(cases) == ['00000  FECR000000']
+    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
+
+
 def test_the_two_role_lists_do_not_overlap():
     """A role in both would be suppressed and vouched for at the same time."""
     assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -138,7 +138,7 @@ def fake_icos(monkeypatch):
 WRITTEN = []
 
 
-def _fake_build(cases, name, dob, lite, failed=(), filed_as=None):
+def _fake_build(cases, name, dob, lite, failed=(), filed_as=None, no_dob=()):
     # failed is recorded because a rebuilt workbook that still does not name
     # what is missing from it is the whole point of this going in.
     WRITTEN.append({'name': name, 'ids': [case['id'] for case in cases],


### PR DESCRIPTION
Two things Ari raised on 20 August that were still open.

## DOB-Unknown in the notes

She asked whether the workbook could say when a case came in as DOB-Unknown. It could not, except in BASIC INFO B6, which is one cell for the whole file and looks like a blank field rather than a warning.

A results row with an empty date of birth column groups under `DOB-UNKNOWN`, and ticking that group attaches the case on the name alone. That now shows on the CASE DATA row, in column V beside the filed-under note:

> DOB-Unknown: matched on the name alone.

- `tasks.dob_unknown_cases(keys, case_dict)` works it out off the search results, in the same window and for the same reason as `docket_names` — the case page has no date of birth of its own and cannot be asked what the results page did not say.
- Carried through `_retry_entry`, so a rebuilt workbook keeps it. A retry never goes back to the search job.
- A case listed under both a dated key and an undated one is **not** marked: one result row missing the column is no reason to caveat a case another row confirmed.
- Marked on every row it is true of, unlike the filed-under note. Two spellings of a name is a fact about the workbook, so saying it on every row of a single-spelling workbook says nothing. No date of birth is a fact about the case, and a sheet where it holds throughout is a sheet where nothing at all was matched on a date.

## RESP/PROTECTED PERSON stops mailing an alert

Ari: *"I think we should keep the RESP/PROTECTED PERSON just in case."* Those cases were already kept — the role is in neither `NON_PARTY_ROLES` nor `KNOWN_PARTY_ROLES`, and only the first of those decides what gets written. But `KNOWN_PARTY_ROLES` is what suppresses the unrecognised-role alert, so every run touching one sent mail about a role that had already been ruled on. Named now; no case changes fate.

## Tests

New `tests/test_dob_unknown_note.py` (17 tests): the grouping logic including the mixed pick and the both-keys case, the note in a real CRS, the default writing nothing, coexistence with the filed-under note and with a later caveat, and the retry round trip including an entry written before this shipped. Plus one parser test for the role.

Full suite: **1282 passed**, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jv4J3ABqZXhZPSnMRHh9Kv