### PR TITLE
Two answers from Iowa Legal Aid on 21 August, and a guide to column V

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ ICOS itemized no payments for is reported as having no itemization rather than
 as having paid zero, because a hearing where someone is recorded as paying
 nothing on a debt they have been paying goes the wrong way.
 
+**The notes column** of CASE DATA, column V, is where a row says anything the other columns cannot. Most rows say nothing. Every message it can carry is written out in plain language, with what to do about each one, in [docs/CRS-Notes-Column.md](docs/CRS-Notes-Column.md). That file is written for the staff reading the workbook rather than for this repository, so it is the one to hand to a clinic.
+
 ## Why the retries and the logoff matter
 
 Two different failures were making a majority of searches fail in mid-2026:

--- a/case_parser.py
+++ b/case_parser.py
@@ -125,6 +125,14 @@ NON_PARTY_ROLES = frozenset({
     'OBLIGEE',
     'PAYOR',
     'PAYEE',
+    # A co-owner named on a case about the property, not about them. Read as
+    # the same question as PROPERTY OWNER when it first alerted on 2026-08-20
+    # and answered the same way. Iowa Legal Aid settled it the other way on
+    # 2026-08-21: they are content not to catch these, and asked for the
+    # co-owner wording to be excluded. PROPERTY OWNER itself is unchanged and
+    # stays a party role -- the sole owner is who the case is against, and a
+    # co-owner is on the page because of what they part-own.
+    'PROPERTY CO-OWNER',
     'TRUSTEE',
     'WARD',
     'WITNESS',
@@ -183,13 +191,6 @@ KNOWN_PARTY_ROLES = frozenset({
     # it was never in NON_PARTY_ROLES -- and stops a decided role mailing an
     # unrecognised-role alert on every run that touches one.
     'RESP/PROTECTED PERSON',
-    # ICOS's wording when the property has more than one owner on it. Nothing
-    # in the reasoning above turns on being the only owner: the case is still
-    # about their property and can still assess costs against them personally.
-    # So it was always going to need the same answer as PROPERTY OWNER, and was
-    # simply missed when that went in on 2026-08-12. Six separate searches
-    # alerted on it on 2026-08-20.
-    'PROPERTY CO-OWNER',
 })
 
 # The notice ICOS shows when a name matches more cases than it will list. The

--- a/crs.py
+++ b/crs.py
@@ -451,6 +451,28 @@ CIVIL_SECTIONS = ('820.2', '820.14', '908.1')
 # stripped, and only when the statute check could not already answer.
 CIVIL_DESCRIPTIONS = ('OUT OF COUNTY WARRANT',)
 
+# Docket types that are civil whatever the clerk typed on the counts.
+#
+# Iowa Legal Aid asked for both on 21 August 2026. AMCR is the appeal
+# misdemeanour docket the county files parole holds, contempts and fugitive
+# warrants under, and they report a recent decision reading the whole type as
+# civil. DRCV is the protective order docket, which is civil on its face.
+#
+# This is the one reading that does not go through the counts at all, and it is
+# deliberately a whitelist of exactly two four-character types rather than a
+# prefix rule. "AM" alone would also take AMCV and anything else Iowa adds, and
+# "DR" would take the DRCV cases' criminal neighbours on the domestic relations
+# docket. case_type gives the four characters, so the test is equality.
+#
+# What it costs, so it is written down somewhere other than an inbox: CIV is
+# one of the eight codes BANKRUPTCY and EXEMPTIONS read as no conviction, so a
+# guilty count on one of these types now sorts as dischargeable, and CIV is not
+# in the expungement sheet's DISM ACQ? cleared set, so a dismissal on one of
+# them stops answering YES there. Iowa Legal Aid has settled both trades before
+# -- see KEEPS_ITS_CLEARED_CODE -- on the ground that a civil case is not
+# eligible for dismissed-or-acquitted expungement in the first place.
+CIVIL_CASE_TYPES = ('AMCR', 'DRCV')
+
 # What a clerk files a pre-electronic-docket case under. Either spelling is
 # enough on its own, because the captured case carries both and there is no
 # reading of one without the other that means anything else.
@@ -820,6 +842,16 @@ def is_juvenile_case(case_id):
     prevent. Nothing but JV reaches it.
     """
     return case_type(case_id).startswith('JV')
+
+
+def is_civil_case_type(case_id):
+    """Whether the docket type alone decides this case is civil.
+
+    See CIVIL_CASE_TYPES. Read off the case number rather than the counts, so
+    it answers the same way on a case whose counts Napier could not read at
+    all, which is the shape Iowa Legal Aid raised it on.
+    """
+    return case_type(case_id) in CIVIL_CASE_TYPES
 
 
 def get_dominant_charge(charges, case_id=None):
@@ -2111,8 +2143,23 @@ def process_case(case, worksheet, row, as_of=None):
         # After the clerk's wording has had its say and before anything is
         # written, because what the charge is beats how the disposition was
         # typed. This is the only place the charge overrides the code.
-        if reads_civil(charge, disposition):
+        civil_by_case_type = is_civil_case_type(case['id'])
+        if civil_by_case_type or reads_civil(charge, disposition):
             disposition = "CIV"
+        if civil_by_case_type:
+            # The wording is no longer worth reporting on this row. The two
+            # unknown-disposition notes and the two lines they send Alex both
+            # describe a row coded on a guess -- one says the case reads OTH,
+            # the other that column G is empty -- and neither is true here:
+            # the docket type answered, and it answers the same way whatever
+            # the clerk typed. Left in place, an unread wording on a
+            # protective order case would put a note on the row saying it was
+            # coded OTH while column G reads CIV.
+            #
+            # The vocabulary is not lost. It alerts the first time the same
+            # wording lands on any other docket type, which is the run where
+            # Napier would actually have to code it.
+            charge['unknown_dispositions'] = []
 
         worksheet['C' + i] = charge['offenseDate']
         worksheet['D' + i] = disposition_date

--- a/docs/CRS-Notes-Column.md
+++ b/docs/CRS-Notes-Column.md
@@ -1,0 +1,256 @@
+# What the notes column is telling you
+
+Column V of the CASE DATA sheet is where Napier writes down anything about a
+row that the other columns cannot say on their own. Most rows have nothing in
+it. A row that does has something on it that a person needs to look at, or at
+least know about before quoting a number off the sheet.
+
+More than one note can land in the same cell. They are separated by spaces and
+read in order, so a long cell is a row with several things going on, not one
+long message.
+
+The notes fall into three groups, and the group tells you how much of a hurry
+you are in:
+
+1. **Money notes.** The ICOS total in column U is still right. The fee columns
+   next to it are less precise than they look. Nothing is wrong with the row.
+2. **Coding notes.** Column G or column D or column H came out on a guess, or
+   came out empty, and at least one analysis sheet is going to read that
+   literally. Check the case in ICOS before you rely on the sheet.
+3. **Client notes.** Something about how the record was matched to your client,
+   rather than about the case itself.
+
+Below is every message Napier can write, what it actually means, and what to do
+about it.
+
+---
+
+## Money notes: the fee columns
+
+These say the row's balances are grouped more coarsely than the columns
+suggest. **In every one of them the ICOS total in column U is correct.** If all
+you need is what the client owes on the case, take column U and stop reading.
+
+### "COSTS did not add up against the itemization, so that balance is ICOS's category total rather than a per-fee breakdown..."
+
+ICOS gives fees two ways: a five-line summary at the top, and an itemized list
+underneath. Napier adds up the itemization and checks it against the summary.
+When they don't match for a category, Napier trusts the summary and puts that
+category's whole balance in one column instead of splitting it.
+
+The sentence names the categories it happened to, and if a balance ended up in
+MISCELLANEOUS, it says so. It ends one of two ways:
+
+- "...**The rest of the row is fee by fee** and the ICOS total is still right."
+  Only the named categories are lumped. Everything else on the row split
+  normally.
+- "...**Each balance is in the fee column its itemized lines name**, and the
+  ICOS total is still right." Nothing on this row split. Every column on the
+  row is a category total.
+
+**What to do:** use column U for the amount owed. Don't quote an individual fee
+column off this row as if it were a single fee. If a specific fee matters, for
+example you're arguing about jail or room and board, get an accounting from the
+clerk.
+
+### "Fee columns are ICOS's five summary categories, not a per-fee breakdown. The itemization could not be reconciled against them, so sheriff, indigent defense, jail and probation fees are inside MISCELLANEOUS rather than in their own columns. The ICOS total is still right."
+
+The same thing, but for a case where nothing at all reconciled. The row is
+ICOS's five summary lines and nothing finer. Sheriff, indigent defense, jail and
+probation money is sitting in MISCELLANEOUS.
+
+**What to do:** same as above. Use column U. If you need to know how much of it
+is jail fees, that answer isn't on this row, it's in ICOS.
+
+### "ICOS gave no category summary for this case, so the fee columns come from the itemization. ICOS leaves the itemization's paid column blank on most fees, so anything already paid may still be counted here. Treat these as assessed rather than owed."
+
+The opposite problem. There was no summary to work from, so the row is built
+out of the itemized list. ICOS usually doesn't fill in what was paid on the
+itemization, so the figures here are what was *charged* over the life of the
+case, not what's still outstanding. The client may have paid some of it.
+
+**What to do:** this is the one money note where the numbers may be higher than
+what the client owes. Don't use it to tell a client what their balance is.
+Check ICOS or the clerk for the current balance.
+
+### "The part of COSTS that ICOS does not identify in the itemization is in UNKNOWN; the identified fees remain in their own columns."
+
+Most of the category split fine. There was a leftover piece that ICOS doesn't
+label, and that piece is in the UNKNOWN column.
+
+**What to do:** nothing, unless the UNKNOWN figure is large enough to matter to
+what you're doing. The rest of the row is good.
+
+### "ICOS records payments per category, not per fee. The payment in COSTS could not be tied to a specific line, so that balance is ICOS's category total."
+
+There was a payment on the case and ICOS records it against the category
+without saying which fee it came off. Napier can't split a category once it
+can't tell where the payment landed, so that one category stays whole.
+
+**What to do:** nothing. The category total is right. The split inside it just
+isn't available.
+
+### "The COSTS balance is divided across its fee columns in proportion to what those fees were assessed, so the column totals are estimates. Request an accounting before relying on the split."
+
+This one is different from the rest and worth reading carefully. Napier *did*
+split the category across the fee columns, but it split it proportionally
+because ICOS didn't say how the money actually applied. **The numbers in those
+columns are estimates.**
+
+**What to do:** the category total and column U are right. The individual
+columns are Napier's best guess at the split. If you're going to rely on one of
+them, ask the clerk for an accounting first.
+
+### "Category fees total $X but ICOS shows $Y due (summary figures) - trust the ICOS total; the difference is usually payments or third-party collection fees ICOS no longer counts"
+
+The fee columns and the ICOS total disagree. When this happens the row's ICOS
+total in column U is highlighted so you can spot it.
+
+**What to do:** exactly what it says. Use column U. The gap is almost always
+payments the client has made, or collection agency fees ICOS has stopped
+counting.
+
+---
+
+## Coding notes: column G, column D, column H
+
+These are the ones to take seriously. Every one of them means an analysis sheet
+is about to answer a question based on something Napier had to guess at, or
+based on a blank.
+
+### "Iowa Courts recorded a disposition Napier does not recognise (WORDING), so this case is coded OTH, and the sheets do not agree on what that means. The licence sheet reads OTH as no conviction and the expungement sheet answers n/a, but the bankruptcy and exemption sheets sort this case's debt as a conviction's. Check this case in ICOS before relying on any of them."
+
+A clerk entered a disposition wording Napier has never seen. The row is coded
+OTH, which is Napier's "I don't know". The problem is that the sheets disagree
+about OTH, so this row will read as no conviction on one sheet and as a
+conviction on another.
+
+**What to do:** open the case in ICOS and read the disposition yourself. Then
+tell Alex what the wording was. Napier learns these one at a time, and once it's
+added, every future client with that wording is coded correctly.
+
+### "No count on this case has been adjudicated in Iowa Courts. The only disposition it carries is the status of the case as a whole (STATUS), which Napier does not translate into a CRS code, so column G is empty. The BANKRUPTCY, EXEMPTIONS and SOL sheets all read an empty column G as "open charge", so this case appears on those three as a charge still pending against the client. A case Iowa Courts has closed or transferred is not that. Check this case in ICOS before relying on any of them."
+
+Different from the one above. Here no individual charge was ever ruled on. All
+ICOS has is a status for the case as a whole, and Napier deliberately refuses to
+turn most of those statuses into a code rather than guess.
+
+The consequence is the important part: **three sheets will show this as a
+pending charge against your client.** If the case was actually closed or moved
+to another county, that's wrong, and a pending charge is exactly the thing that
+blocks an expungement.
+
+**What to do:** check ICOS. If the case is genuinely resolved, this row's answer
+on BANKRUPTCY, EXEMPTIONS and SOL should be ignored. Send the status wording to
+Alex.
+
+### "Iowa Courts show no adjudication on this case, so column D is blank and column G has no code. Column D blank is what tells the EXPUNGEMENT sheet this charge is still pending, but the SOL sheet reads it as a date and a blank reads as 1900: it reports this row's indigent defense and collection costs as barred by the 20 year limit, counts jail and room & board as 20 years old, and leaves the rest of the balance out of all three of its columns. Nothing here has aged out, because there is no judgment yet. Treat this row's SOL figures as unanswered."
+
+This is a genuinely pending case, and Napier is right to leave it blank. The
+EXPUNGEMENT sheet handles that correctly. The SOL sheet does not, because it
+does arithmetic on the date and reads a blank as the year 1900.
+
+**What to do:** on this row only, ignore the SOL sheet. It will tell you the
+debt is time barred. It isn't. There's no judgment yet for the clock to run
+from. Everything else on the row is fine.
+
+### "The only disposition Iowa Courts show on this case is an adjudication, and this is not a juvenile case number, so column G reads JUV. Clerks enter "Adjudicated" on probation violation and contempt counts as well as on juvenile ones. If that is what this is, the case's real disposition is not on the page and JUV is wrong: BANKRUPTCY and EXEMPTIONS both read JUV as no conviction and will treat this debt as dischargeable. Check it."
+
+The case number isn't a juvenile number, but the only thing on the page is
+"Adjudicated", which is the juvenile word. Clerks also use it for probation
+violations and contempt.
+
+**What to do:** check it, and check it before advising on a bankruptcy. If this
+is really a probation violation on an adult conviction, the sheet is currently
+telling you the debt is dischargeable when it may not be.
+
+### "This case has 3 disposition dates (DATES). Column D counts the conviction date: DATE. For SOL analysis please review ICOS information for the timeline of debt assessed."
+
+The counts on this case were disposed on different days. The CRS has one row
+per case and one date column, so column D holds the conviction date, which is
+the one the expungement waiting periods run from.
+
+The SOL sheet runs its twenty year test off that same single date, and on a
+case with debt assessed at several points in time, one date can't describe all
+of it.
+
+**What to do:** the expungement answer is right. If you're doing SOL work on
+this case, go look at the actual timeline in ICOS.
+
+### "Column H is blank because Iowa Courts give the adjudicated charge as ORDINANCE, a city or county ordinance citation with no state chapter in it, so Napier cannot tell whether this is a chapter 321 offence. LICENSE-REGIS reads the blank as "Registration only". If the ordinance mirrors a chapter 321 offence the licence is at stake too, so check this one before advising on it."
+
+The charge is a city or county ordinance, so there's no state chapter number for
+Napier to check against chapter 321. Column H, the "Vehicular?" column, is left
+blank, and LICENSE-REGIS treats blank the same as no.
+
+**What to do:** if you're advising on the client's driving licence, look up what
+the ordinance covers. Plenty of city ordinances mirror chapter 321, and if this
+one does, the licence consequence is real and the sheet is currently saying
+"Registration only".
+
+### "This case is adjudicated under more than 12 statutes and the expungement sheet only screens the first 12. The rest (STATUTES) have to be checked by hand against 901C.2."
+
+The expungement sheet has twelve slots for statutes and this case has more than
+twelve. The extras are named in the note.
+
+**What to do:** check the named statutes by hand against 901C.2. Any one of them
+could be a disqualifier, and the sheet has not looked at them.
+
+### "CIV is not in this template, so no sheet in this Lite workbook counts this case. Build it on the full CRS to score it."
+
+**Lite workbooks only.** The Lite template doesn't carry formulas for every
+disposition code, and this row's code is one it doesn't have. The row is filled
+in, but no sheet in the Lite workbook is scoring it.
+
+**What to do:** rebuild the client on the full CRS if you need this case scored.
+
+---
+
+## Client notes: how the record was matched
+
+### "Filed under NAME."
+
+The workbook was built from more than one spelling of your client's name, and
+this case is filed under the spelling given here rather than the primary one.
+Usually a maiden name, a middle name, or a clerk's typo.
+
+**What to do:** nothing, as long as the name looks like your client. If it
+doesn't, this case may belong to someone else.
+
+### "DOB-Unknown: matched on the name alone."
+
+Iowa Courts listed this case with no date of birth, and it was picked on the
+name only. Every other row in the workbook was confirmed against a date of
+birth. This one was not.
+
+**What to do:** confirm the case is your client's before using it. Common names
+are the risk here.
+
+---
+
+## Quick reference
+
+| If the note is about | Column U (total) | The fee columns | The analysis sheets |
+|---|---|---|---|
+| Any of the money notes | Correct | Coarser or estimated | Fine |
+| "Treat these as assessed rather than owed" | Correct | May include paid amounts | Fine |
+| OTH / unrecognised disposition | Correct | Fine | Disagree with each other, check ICOS |
+| Empty column G / case status only | Correct | Fine | Show a pending charge that may not exist |
+| Pending case, column D blank | Correct | Fine | SOL is wrong, expungement is right |
+| JUV on an adult case number | Correct | Fine | Bankruptcy and exemptions may be wrong |
+| Several disposition dates | Correct | Fine | Expungement right, check SOL by hand |
+| Ordinance charge, column H blank | Correct | Fine | LICENSE-REGIS says "Registration only" without checking |
+| More than 12 statutes | Correct | Fine | Expungement screened only the first 12 |
+| Lite: code not in template | Correct | Fine | Nothing scored this row |
+| Filed under / DOB-Unknown | Correct | Fine | Fine, but confirm it's your client |
+
+## When to send something back to Alex
+
+Two of these notes are Napier telling you it hit something it hasn't been
+taught yet:
+
+- "a disposition Napier does not recognise (WORDING)"
+- "the status of the case as a whole (STATUS), which Napier does not translate"
+
+Both name the exact wording in the note. Sending that wording back means it gets
+added, and nobody sees that note on that wording again.

--- a/tests/test_ari_aug20_dispositions.py
+++ b/tests/test_ari_aug20_dispositions.py
@@ -14,10 +14,19 @@ juvenile reading is gated on a JV case number.
 
 That leaves two from the same run. TRANSFERRED on an adult criminal case is a
 change of venue, which has coded TNSF since 3 August, so that one is settled by
-the code that was already there. OTHER JUDGMENT on a civil case is not settled
-and stays uncoded on purpose: the code a civil judgment would want is CIV, CIV
+the code that was already there. OTHER JUDGMENT on a civil case was not settled
+and stayed uncoded on purpose: the code a civil judgment would want is CIV, CIV
 is in the expungement sheet's cleared set, and guessing it would clear every
 fee column on the row.
+
+Iowa Legal Aid settled that second one on 21 August, and not by answering the
+wording. They asked for the AMCR and DRCV dockets to read as civil whatever
+the counts say, so on those two types the case number now decides and column G
+reads CIV before any of this is consulted. That happens in process_case, above
+the reading tested here -- see CIVIL_CASE_TYPES and test_civil_case_types.py.
+The two case numbers below are on those dockets, so what these tests pin is
+the count-level vocabulary itself rather than what the workbook prints for
+these particular numbers, and they are named that way where it matters.
 
 Synthetic case numbers throughout. The repository is public.
 """
@@ -89,13 +98,18 @@ class TestOnTheJuvenileDocket:
 
 
 class TestOffTheJuvenileDocket:
-    def test_transferred_on_an_adult_case_is_a_change_of_venue(self):
-        """The wording Iowa Legal Aid's 20 August run alerted on, on an AMCR.
+    def test_transferred_off_the_juvenile_docket_is_a_change_of_venue(self):
+        """The wording Iowa Legal Aid's 20 August run alerted on.
 
         CHANGE OF VENUE has produced TNSF since 3 August and means the same
         thing: the charge left this court and was decided elsewhere.
+
+        The workbook no longer prints TNSF for the AMCR number this is built
+        on, because the docket type overrides it to CIV a layer up. The reading
+        is what is pinned here, and it is what any other adult docket gets.
         """
         assert _code(ADULT, TRANSFERRED) == ('TNSF', [])
+        assert _code('00000  FECR000000', TRANSFERRED) == ('TNSF', [])
 
     def test_it_agrees_with_change_of_venue(self):
         assert _code(ADULT, TRANSFERRED)[0] == _code(ADULT,
@@ -105,13 +119,19 @@ class TestOffTheJuvenileDocket:
         for case_id in (ADULT, CIVIL, '00000  FECR000000'):
             assert _code(case_id, TRANSFERRED)[0] != 'JWV'
 
-    def test_other_judgment_on_a_civil_case_stays_uncoded(self):
+    def test_other_judgment_is_still_an_unread_wording(self):
         """Uncoded and visibly so, rather than guessed at.
 
         CIV is what a civil judgment would want and CIV clears the fee
-        columns, so this one waits for Iowa Legal Aid rather than moving money
-        on a guess. The wording travels out through unknown_dispositions,
-        which is what puts it in column V and alerts the run.
+        columns, so this waited for Iowa Legal Aid rather than moving money on
+        a guess. The wording travels out through unknown_dispositions, which is
+        what puts it in column V and alerts the run.
+
+        Iowa Legal Aid's 21 August answer took the DRCV docket to CIV outright,
+        so the row this was raised on no longer reaches this reading and no
+        longer alerts. The wording itself is still unread, and still alerts the
+        first time it lands on a docket that has to code it, which is what this
+        pins.
         """
         code, unknown = _code(CIVIL, OTHER_JUDGMENT)
         assert code == 'OTH'
@@ -131,8 +151,9 @@ class TestTheCaseLevelStatusReadsTheSameDocket:
     def test_transferred_is_a_waiver_on_a_juvenile_case(self):
         assert crs.case_level_code(TRANSFERRED, JUVENILE) == 'JWV'
 
-    def test_transferred_is_a_change_of_venue_on_an_adult_case(self):
+    def test_transferred_is_a_change_of_venue_off_the_juvenile_docket(self):
         assert crs.case_level_code(TRANSFERRED, ADULT) == 'TNSF'
+        assert crs.case_level_code(TRANSFERRED, '00000  FECR000000') == 'TNSF'
 
     def test_no_case_number_cannot_invent_a_waiver(self):
         """Omitting the number reads as not juvenile, which is the way round

--- a/tests/test_civil_case_types.py
+++ b/tests/test_civil_case_types.py
@@ -1,0 +1,167 @@
+"""Two docket types Iowa Legal Aid read as civil on 21 August 2026.
+
+AMCR is the appeal misdemeanour docket, and it is where the county files the
+parole holds, contempts and fugitive warrants that have come back to Napier
+four separate times under four different codes. Iowa Legal Aid report a recent
+decision reading the whole type as civil. DRCV is the protective order docket,
+civil on its face, and the one their 20 August run left uncoded because OTHER
+JUDGMENT on a civil case had no settled answer.
+
+So the answer stopped being about the wording. On these two types the docket
+decides, and column G reads CIV whatever the clerk typed on the counts. That
+is a blunter rule than anything else in crs.py, which is why the guard rails
+below are the larger half of this file: exactly two four-character types, no
+prefix matching, and every other docket untouched.
+
+What it costs is written down in CIVIL_CASE_TYPES and tested here: a guilty
+count on one of these types sorts as no conviction on BANKRUPTCY and
+EXEMPTIONS, and a dismissal on one stops answering YES in the expungement
+sheet's DISM ACQ? column. Iowa Legal Aid has settled that trade before, on the
+ground that a civil case is not eligible for dismissed-or-acquitted
+expungement in the first place.
+
+Every case number here is synthetic. The repository is public.
+"""
+
+import os
+import sys
+from decimal import Decimal
+
+import pytest
+from openpyxl import load_workbook
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import case_parser
+import crs
+from test_multi_count import charges_page
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
+
+APPEAL_MISDEMEANOUR = '00000  AMCR000000'
+PROTECTIVE_ORDER = '00000  DRCV000000'
+FELONY = '00000  FECR000000'
+
+GUILTY = [('714.2(3)', 'SYNTHETIC THEFT', 'GUILTY', '02/02/1901')]
+DISMISSED = [('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED', '02/02/1901')]
+UNREADABLE = [('714.2(3)', 'SYNTHETIC THEFT',
+               'SYNTHETIC WORDING NOBODY HAS SEEN', '02/02/1901')]
+UNADJUDICATED = [('714.2(3)', 'SYNTHETIC THEFT', None, '')]
+
+
+def _case(case_id, counts, status='', costs='197.43'):
+    case = {'id': case_id, 'county': 'SYNTHETIC',
+            'financials': [], 'sentences': [],
+            'summary_created_date': '01/01/1900',
+            'summary_disposition_date': '02/02/1901',
+            'summary_dispo_status': status}
+    case_parser.parse_case_charges(charges_page(counts), case)
+    case['summary_categories'] = [
+        {'label': label,
+         'original': Decimal(costs) if label == 'COSTS' else Decimal('0'),
+         'paid': Decimal('0'),
+         'due': Decimal(costs) if label == 'COSTS' else Decimal('0')}
+        for label in ('COSTS', 'FINE', 'SURCHARGE', 'RESTITUTION', 'OTHER')]
+    case['total_due'] = '$' + costs
+    return case
+
+
+def _row(case_id, counts, status=''):
+    """Column G, column V and what the run was told, off one built row."""
+    sheet = load_workbook(FULL)['CASE DATA']
+    unknown = crs.process_case(_case(case_id, counts, status), sheet,
+                               crs.FIRST_CASE_ROW)
+    row = str(crs.FIRST_CASE_ROW)
+    return {'G': sheet['G' + row].value,
+            'V': sheet['V' + row].value or '',
+            'reported': unknown}
+
+
+# -- what Iowa Legal Aid asked for -------------------------------------------
+
+@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+@pytest.mark.parametrize('counts', [GUILTY, DISMISSED, UNREADABLE])
+def test_the_docket_type_decides_the_code(case_id, counts):
+    """Whatever the clerk typed on the counts, including nothing Napier reads."""
+    assert _row(case_id, counts)['G'] == 'CIV'
+
+
+@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+def test_it_also_decides_a_case_with_no_adjudication_at_all(case_id):
+    """The shape the 20 August run raised: nothing adjudicated on any count, so
+    column G used to read the case-level status or stay empty. An empty column
+    G is what BANKRUPTCY, EXEMPTIONS and SOL print as "open charge"."""
+    assert _row(case_id, UNADJUDICATED, 'OTHER JUDGMENT')['G'] == 'CIV'
+
+
+def test_transferred_on_an_appeal_misdemeanour_is_civil_now():
+    """The case from the 21 August email, which read TNSF the day before."""
+    assert _row(APPEAL_MISDEMEANOUR, UNADJUDICATED, 'TRANSFERRED')['G'] == 'CIV'
+
+
+# -- and what it must not reach ----------------------------------------------
+
+@pytest.mark.parametrize('case_id', [
+    FELONY,
+    '00000  AGCR000000',
+    '00000  SMCR000000',
+    '00000  JVJV000000',
+    # Neighbours on the same two letters. A prefix rule would take both.
+    '00000  AMCV000000',
+    '00000  DRCR000000',
+])
+def test_every_other_docket_reads_its_counts_as_before(case_id):
+    assert _row(case_id, GUILTY)['G'] == 'GTR'
+
+
+def test_an_unreadable_wording_still_alerts_off_these_types():
+    """The vocabulary discovery this rule switches off on two dockets is not
+    switched off anywhere else, so a wording Napier cannot read is still
+    reported the first time it lands on a docket that has to code it."""
+    assert _row(FELONY, UNREADABLE)['reported'] == [
+        ('SYNTHETIC WORDING NOBODY HAS SEEN', True)]
+
+
+# -- the row does not say things that are not so -----------------------------
+
+@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+def test_the_row_does_not_claim_to_be_coded_oth(case_id):
+    """The two unknown-disposition notes both describe a row coded on a guess.
+    Neither describes this row: the docket answered, and it answers the same
+    way whatever the clerk typed."""
+    note = _row(case_id, UNREADABLE)['V']
+    assert 'OTH' not in note, note
+    assert 'does not recognise' not in note, note
+
+
+@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+def test_the_run_is_not_told_to_go_and_code_it(case_id):
+    """Same sentence, in the half Alex reads. An alert saying these rows are
+    coded OTH would be pointing at a column G that reads CIV."""
+    assert _row(case_id, UNREADABLE)['reported'] == []
+
+
+@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+def test_the_row_does_not_claim_to_be_an_open_charge(case_id):
+    """The other half of the same defect, on the unadjudicated shape."""
+    assert 'open charge' not in _row(case_id, UNADJUDICATED, 'CLOSED')['V']
+
+
+# -- the reading itself ------------------------------------------------------
+
+def test_the_whitelist_is_exactly_two_types():
+    assert crs.CIVIL_CASE_TYPES == ('AMCR', 'DRCV')
+
+
+@pytest.mark.parametrize('case_id,expected', [
+    (APPEAL_MISDEMEANOUR, True),
+    (PROTECTIVE_ORDER, True),
+    (FELONY, False),
+    ('00000  AMCV000000', False),
+    ('00000  DRCR000000', False),
+    ('', False),
+    (None, False),
+])
+def test_is_civil_case_type_reads_the_four_characters(case_id, expected):
+    assert crs.is_civil_case_type(case_id) is expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -189,17 +189,20 @@ def test_a_property_owner_is_the_person_the_search_is_about():
     assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
 
 
-def test_a_property_co_owner_is_the_person_the_search_is_about():
-    """The same case as PROPERTY OWNER above, which is the point.
+def test_a_property_co_owner_case_is_left_out():
+    """The variant Iowa Legal Aid answered the other way on 2026-08-21.
 
-    ICOS writes this when the property has more than one owner on it. Nothing
-    in the reasoning for PROPERTY OWNER turns on being the only owner, so the
-    two were always going to need the same answer, and only one of them got it
-    on 2026-08-12. Six searches on 2026-08-20 alerted on the variant.
+    Read here as the same question as PROPERTY OWNER when it first alerted on
+    2026-08-20, on the reasoning that nothing about being the sole owner is
+    what makes the case theirs. Iowa Legal Aid asked for the co-owner wording
+    to be excluded instead: they are content not to catch these. PROPERTY
+    OWNER is untouched by that and still keeps its case, so the two now differ
+    on purpose and the test above is what holds them apart.
     """
     cases, _ = case_parser.parse_search(role_row('PROPERTY CO-OWNER'))
-    assert ids(cases) == ['00000  FECR000000']
-    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
+    assert cases == []
+    assert 'PROPERTY CO-OWNER' in case_parser.NON_PARTY_ROLES
+    assert 'PROPERTY CO-OWNER' not in case_parser.KNOWN_PARTY_ROLES
 
 
 def test_a_protective_order_respondent_is_the_person_the_search_is_about():


### PR DESCRIPTION
Ari Eddy replied to the 20 August run with two decisions and a request. Everything else in that thread she confirmed as working.

## AMCR and DRCV read CIV

> If all "AMCR" cases can read as [CIV] that would be preferred. We had a recent court decision that interprets these all as civil cases. DRCV cases are civil protective order cases so those can read as [CIV] as well.

The case number decides, not the counts, so it holds on a case whose disposition wording Napier cannot read at all. That is the shape it was raised on.

This is the only reading in `crs.py` that does not go through the counts, so it is a whitelist of exactly two four-character types rather than a prefix. `AM` alone would take AMCV, and `DR` would take DRCV's criminal neighbours on the domestic relations docket. Both are tested.

It also settles the one wording left open on 20 August. OTHER JUDGMENT on a civil case stayed uncoded on purpose, because CIV clears the fee columns and guessing it moves money. The docket answers it now without anyone guessing at the wording.

The unknown-disposition note and its alert are suppressed on those two types. Both describe a row coded on a guess, and neither is true of a row the docket decided: an unread wording on a protective order case would have put a note on the row saying it was coded OTH while column G read CIV. The vocabulary is not lost. It still alerts the first time the same wording lands on a docket that has to code it.

**What it costs**, documented in `CIVIL_CASE_TYPES` and tested:

- A guilty count on one of these types now sorts as no conviction on BANKRUPTCY and EXEMPTIONS, so the debt reads as dischargeable.
- CIV is not in the expungement sheet's DISM ACQ? cleared set, so a dismissal on one of these stops answering YES there.
- CRS Lite names CIV in no formula, so on a Lite workbook these rows score nothing. `note_unscored_codes` already says so on the row rather than letting it slide by silently, but Iowa Legal Aid's Lite template wants CIV adding. Flagged to them.

Iowa Legal Aid has settled the first two trades before, on the ground that a civil case is not eligible for dismissed-or-acquitted expungement in the first place. Raised with them explicitly so it is their call rather than an inference.

## PROPERTY CO-OWNER is not a party role

> If "Co-owner" can be added to the exclusionary role list that would be preferred. And we can keep RESP so Napier will add those to the CRS would be preferred.

It was moved the other way on 20 August, reasoning that nothing in the PROPERTY OWNER argument turns on being the only owner. Iowa Legal Aid settled it the other way: they are content not to catch these.

PROPERTY OWNER is untouched and still keeps its case, so the two now differ on purpose and a test holds them apart. RESP/PROTECTED PERSON stays a party role, which they confirmed.

## The guide

> Are you able to give me a list of the common responses that will show up in the "notes" column? I want to write a description so staff knows what they mean and what to do with them.

`docs/CRS-Notes-Column.md`, with a pointer from the README. All 17 messages column V can produce, read off the source rather than from memory, grouped by how much of a hurry the reader is in: the money notes where column U is still right and only the fee columns are coarser than they look, the coding notes where a sheet is about to answer off a guess or a blank, and the two about how the record was matched to the client.

It answers her other question in the two places it bites:

> When you say "CIV counts as *cleared* on the expungement sheet" what do you mean by "cleared"? Do you mean it won't trigger things in spreadsheet?

Written for the person with the client in front of them rather than for this repository, so it is the file to hand to a clinic. It closes by naming the two notes that mean Napier hit something it has not been taught, both of which quote the exact wording, so sending that wording back is what gets it added.

Intended to live on the repo wiki. That needs the wiki initialising by hand first, since GitHub's API cannot create a wiki's first page.

## Tests

Full suite green: 1312 passed, 47 minutes.

`tests/test_civil_case_types.py` is new and covers the override end to end through `process_case`: both types against guilty, dismissed, unreadable and unadjudicated counts; the TRANSFERRED case from the email; six other dockets including AMCV and DRCR proving it is not a prefix rule; the suppressed note and alert; and that an unreadable wording still alerts off these two types.

`tests/test_ari_aug20_dispositions.py` keeps its assertions and gets corrected docstrings. Those tests call `get_dominant_charge` rather than `process_case`, so they still pass, but two of them are built on AMCR and DRCV numbers and their prose described a workbook result that no longer happens for those numbers. Each now also asserts against a docket the override does not touch, so what they pin is the count-level vocabulary itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NBrdYZsKnpJ3f4Y6RF5dB