### PR TITLE
Read AMCV and DRCR as civil, exclude PROPERTY OWNER

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -125,14 +125,25 @@ NON_PARTY_ROLES = frozenset({
     'OBLIGEE',
     'PAYOR',
     'PAYEE',
-    # A co-owner named on a case about the property, not about them. Read as
-    # the same question as PROPERTY OWNER when it first alerted on 2026-08-20
-    # and answered the same way. Iowa Legal Aid settled it the other way on
-    # 2026-08-21: they are content not to catch these, and asked for the
-    # co-owner wording to be excluded. PROPERTY OWNER itself is unchanged and
-    # stays a party role -- the sole owner is who the case is against, and a
-    # co-owner is on the page because of what they part-own.
+    # Named on a case about the property, not about them.
+    #
+    # These two were read as the same question when PROPERTY CO-OWNER first
+    # alerted on 2026-08-20, then split apart: the co-owner was excluded and
+    # the sole owner kept, on the reading that a condemnation or tax sale is
+    # against whoever owns the thing. Iowa Legal Aid closed the split on
+    # 2026-08-21 and asked for PROPERTY OWNER to come out too, so both
+    # wordings are suppressed and the distinction is gone.
+    #
+    # What it costs, since suppression is the expensive direction: a case
+    # reaching the workbook under either role is now dropped rather than
+    # written, so a municipal infraction or in rem forfeiture that assessed
+    # costs against the client personally will not appear on the sheet. Iowa
+    # Legal Aid asked for that knowing it -- they had already said on
+    # 2026-08-20 they were content not to catch the co-owner ones. The
+    # opposite error, a stranger's property case in a client's record summary,
+    # is the one they were actually seeing.
     'PROPERTY CO-OWNER',
+    'PROPERTY OWNER',
     'TRUSTEE',
     'WARD',
     'WITNESS',
@@ -178,11 +189,6 @@ KNOWN_PARTY_ROLES = frozenset({
     # lists them under, so suppressing it would lose the case rather than
     # deduplicate it. Seen on two live searches 2026-08-18.
     'THIRD PARTY DEFENDANT',
-    # The owner named on a case about their property: condemnation, tax sale,
-    # a municipal infraction, an in rem forfeiture. The case can assess costs
-    # against them personally, so it is their record, unlike the LIEN FILER
-    # and INTERESTED PARTY bystander roles. Seen on a live search 2026-08-12.
-    'PROPERTY OWNER',
     # ICOS's role on a protective order case. It reads as a bystander role and
     # it is not: a no contact order and any contempt off it are the person's
     # own court record, and the client is who it was entered against. Iowa

--- a/crs.py
+++ b/crs.py
@@ -462,16 +462,24 @@ CIVIL_DESCRIPTIONS = ('OUT OF COUNTY WARRANT',)
 
 # Docket types that are civil whatever the clerk typed on the counts.
 #
-# Iowa Legal Aid asked for both on 21 August 2026. AMCR is the appeal
+# Iowa Legal Aid asked for AMCR and DRCV on 21 August 2026. AMCR is the appeal
 # misdemeanour docket the county files parole holds, contempts and fugitive
 # warrants under, and they report a recent decision reading the whole type as
 # civil. DRCV is the protective order docket, which is civil on its face.
 #
-# This is the one reading that does not go through the counts at all, and it is
-# deliberately a whitelist of exactly two four-character types rather than a
-# prefix rule. "AM" alone would also take AMCV and anything else Iowa adds, and
-# "DR" would take the DRCV cases' criminal neighbours on the domestic relations
-# docket. case_type gives the four characters, so the test is equality.
+# They asked for AMCV and DRCR in the same afternoon, on seeing the first two
+# land. That is every AM and DR docket type ICOS has shown us, so the reading
+# is now "the AM and DR dockets are civil" rather than "these two are". Their
+# ground is the docket, not the suffix: the recent decision reads the appeal
+# misdemeanour type as civil however the clerk styled it, and DR is the
+# domestic relations docket, whose criminal-styled cases are the contempts off
+# a protective order rather than convictions of their own.
+#
+# Still a whitelist of four-character types rather than a prefix rule, and
+# deliberately. "AM" and "DR" alone would take whatever Iowa adds next as
+# civil the day it appears, with no one deciding it. A fifth type wanted here
+# should cost an email, the way these four did. case_type gives the four
+# characters, so the test is equality.
 #
 # What it costs, so it is written down somewhere other than an inbox: CIV is
 # one of the eight codes BANKRUPTCY and EXEMPTIONS read as no conviction, so a
@@ -480,7 +488,7 @@ CIVIL_DESCRIPTIONS = ('OUT OF COUNTY WARRANT',)
 # them stops answering YES there. Iowa Legal Aid has settled both trades before
 # -- see KEEPS_ITS_CLEARED_CODE -- on the ground that a civil case is not
 # eligible for dismissed-or-acquitted expungement in the first place.
-CIVIL_CASE_TYPES = ('AMCR', 'DRCV')
+CIVIL_CASE_TYPES = ('AMCR', 'AMCV', 'DRCR', 'DRCV')
 
 # What a clerk files a pre-electronic-docket case under. Either spelling is
 # enough on its own, because the captured case carries both and there is no
@@ -1962,9 +1970,24 @@ def process_financials(case, worksheet, row):
 # What column V says on a row whose code the workbook it is going into cannot
 # see. Names the code and the remedy, because the person reading it is looking
 # at a row that otherwise looks finished.
-UNSCORED_CODE_NOTE = ("%s is not in this template, so no sheet in this Lite "
-                      "workbook counts this case. Build it on the full CRS to "
-                      "score it.")
+#
+# It says what is actually lost rather than "no sheet counts this case", which
+# is what it used to say and is more than Lite gets wrong. Measured on
+# 2026-08-21 against both files: on every sheet CRS Lite carries, its formulas
+# are character for character the full CRS's, so a CIV or JWV row gets the
+# same eligibility answers in either workbook. CIV and JWV are named only on
+# BANKRUPTCY and EXEMPTIONS, and what Lite is short of is those two sheets --
+# so the debt on the row is not sorted as dischargeable or exempt anywhere.
+# See TestWhatLiteIsActuallyShortOf, which holds that measurement.
+#
+# Telling staff to rebuild on the full CRS to fix answers that are already
+# right is the sort of thing a guide gets written around, so the note names
+# the one reading Lite cannot give.
+UNSCORED_CODE_NOTE = ("%s is in no formula in this Lite workbook. The "
+                      "eligibility answers on this row are the ones the full "
+                      "CRS gives; what Lite has no sheet for is sorting this "
+                      "case's debt as dischargeable or exempt. Build it on "
+                      "the full CRS if you need that.")
 
 # The one code that is meant to appear in no formula. OTH is what Napier writes
 # when it does not know the disposition, and it is deliberately in no cleared
@@ -1988,6 +2011,15 @@ def codes_the_template_scores(template):
     settled the juvenile transfer wording on 20 August, and CIV on every
     extradition hold and cleared parole violation since 19 August. On a Lite
     workbook those rows were scoring nothing and saying nothing about it.
+
+    What "scoring nothing" is worth knowing about precisely, because Lite is
+    what Drake Legal Clinic runs on. Both codes are named only on BANKRUPTCY
+    and EXEMPTIONS, the two sheets Lite does not carry, and every sheet it
+    does carry has the full CRS's formulas character for character. So the
+    row's eligibility answers are not wrong on Lite; its debt is simply not
+    sorted as dischargeable or exempt, because there is no sheet to sort it
+    on. UNSCORED_CODE_NOTE says that, and TestWhatLiteIsActuallyShortOf in
+    tests/test_lite_unscored_codes.py measures it off the two files.
     """
     blob = []
     with zipfile.ZipFile(template) as archive:

--- a/tests/test_civil_case_types.py
+++ b/tests/test_civil_case_types.py
@@ -1,4 +1,4 @@
-"""Two docket types Iowa Legal Aid read as civil on 21 August 2026.
+"""Four docket types Iowa Legal Aid read as civil on 21 August 2026.
 
 AMCR is the appeal misdemeanour docket, and it is where the county files the
 parole holds, contempts and fugitive warrants that have come back to Napier
@@ -7,11 +7,18 @@ decision reading the whole type as civil. DRCV is the protective order docket,
 civil on its face, and the one their 20 August run left uncoded because OTHER
 JUDGMENT on a civil case had no settled answer.
 
-So the answer stopped being about the wording. On these two types the docket
+Those two shipped first. On seeing them land, Iowa Legal Aid asked for AMCV
+and DRCR the same afternoon, which is every AM and DR type ICOS has shown us.
+Their ground is the docket rather than the CR/CV suffix: the decision reads
+the appeal misdemeanour type as civil however the clerk styled it, and the
+criminal-styled DR cases are contempts off a protective order rather than
+convictions of their own.
+
+So the answer stopped being about the wording. On these four types the docket
 decides, and column G reads CIV whatever the clerk typed on the counts. That
 is a blunter rule than anything else in crs.py, which is why the guard rails
-below are the larger half of this file: exactly two four-character types, no
-prefix matching, and every other docket untouched.
+below are the larger half of this file: four-character types, no prefix
+matching, and every other docket untouched.
 
 What it costs is written down in CIVIL_CASE_TYPES and tested here: a guilty
 count on one of these types sorts as no conviction on BANKRUPTCY and
@@ -40,8 +47,17 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 FULL = os.path.join(ROOT, 'CRS 3.5.5.xlsx')
 
 APPEAL_MISDEMEANOUR = '00000  AMCR000000'
+APPEAL_MISDEMEANOUR_CV = '00000  AMCV000000'
 PROTECTIVE_ORDER = '00000  DRCV000000'
+PROTECTIVE_ORDER_CR = '00000  DRCR000000'
 FELONY = '00000  FECR000000'
+
+# Every type the rule reads as civil, which is what the parametrised tests
+# below run over. Named once so a fifth type added to CIVIL_CASE_TYPES without
+# a decision behind it fails the whitelist test rather than quietly widening
+# every case here.
+CIVIL_DOCKETS = [APPEAL_MISDEMEANOUR, APPEAL_MISDEMEANOUR_CV,
+                 PROTECTIVE_ORDER, PROTECTIVE_ORDER_CR]
 
 GUILTY = [('714.2(3)', 'SYNTHETIC THEFT', 'GUILTY', '02/02/1901')]
 DISMISSED = [('714.2(3)', 'SYNTHETIC THEFT', 'DISMISSED', '02/02/1901')]
@@ -80,14 +96,14 @@ def _row(case_id, counts, status=''):
 
 # -- what Iowa Legal Aid asked for -------------------------------------------
 
-@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+@pytest.mark.parametrize('case_id', CIVIL_DOCKETS)
 @pytest.mark.parametrize('counts', [GUILTY, DISMISSED, UNREADABLE])
 def test_the_docket_type_decides_the_code(case_id, counts):
     """Whatever the clerk typed on the counts, including nothing Napier reads."""
     assert _row(case_id, counts)['G'] == 'CIV'
 
 
-@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+@pytest.mark.parametrize('case_id', CIVIL_DOCKETS)
 def test_it_also_decides_a_case_with_no_adjudication_at_all(case_id):
     """The shape the 20 August run raised: nothing adjudicated on any count, so
     column G used to read the case-level status or stay empty. An empty column
@@ -107,25 +123,28 @@ def test_transferred_on_an_appeal_misdemeanour_is_civil_now():
     '00000  AGCR000000',
     '00000  SMCR000000',
     '00000  JVJV000000',
-    # Neighbours on the same two letters. A prefix rule would take both.
-    '00000  AMCV000000',
-    '00000  DRCR000000',
+    # Synthetic neighbours on the same two letters. All four real AM and DR
+    # types are civil now, so these stand in for whatever Iowa adds next: a
+    # prefix rule would take them the day they appeared, and this rule does
+    # not. Adding a fifth type is meant to cost an email, the way these did.
+    '00000  AMXX000000',
+    '00000  DRXX000000',
 ])
 def test_every_other_docket_reads_its_counts_as_before(case_id):
     assert _row(case_id, GUILTY)['G'] == 'GTR'
 
 
 def test_an_unreadable_wording_still_alerts_off_these_types():
-    """The vocabulary discovery this rule switches off on two dockets is not
-    switched off anywhere else, so a wording Napier cannot read is still
-    reported the first time it lands on a docket that has to code it."""
+    """The vocabulary discovery this rule switches off on the civil dockets
+    is not switched off anywhere else, so a wording Napier cannot read is
+    still reported the first time it lands on a docket that has to code it."""
     assert _row(FELONY, UNREADABLE)['reported'] == [
         ('SYNTHETIC WORDING NOBODY HAS SEEN', True)]
 
 
 # -- the row does not say things that are not so -----------------------------
 
-@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+@pytest.mark.parametrize('case_id', CIVIL_DOCKETS)
 def test_the_row_does_not_claim_to_be_coded_oth(case_id):
     """The two unknown-disposition notes both describe a row coded on a guess.
     Neither describes this row: the docket answered, and it answers the same
@@ -135,14 +154,14 @@ def test_the_row_does_not_claim_to_be_coded_oth(case_id):
     assert 'does not recognise' not in note, note
 
 
-@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+@pytest.mark.parametrize('case_id', CIVIL_DOCKETS)
 def test_the_run_is_not_told_to_go_and_code_it(case_id):
     """Same sentence, in the half Alex reads. An alert saying these rows are
     coded OTH would be pointing at a column G that reads CIV."""
     assert _row(case_id, UNREADABLE)['reported'] == []
 
 
-@pytest.mark.parametrize('case_id', [APPEAL_MISDEMEANOUR, PROTECTIVE_ORDER])
+@pytest.mark.parametrize('case_id', CIVIL_DOCKETS)
 def test_the_row_does_not_claim_to_be_an_open_charge(case_id):
     """The other half of the same defect, on the unadjudicated shape."""
     assert 'open charge' not in _row(case_id, UNADJUDICATED, 'CLOSED')['V']
@@ -150,16 +169,20 @@ def test_the_row_does_not_claim_to_be_an_open_charge(case_id):
 
 # -- the reading itself ------------------------------------------------------
 
-def test_the_whitelist_is_exactly_two_types():
-    assert crs.CIVIL_CASE_TYPES == ('AMCR', 'DRCV')
+def test_the_whitelist_is_exactly_these_four_types():
+    """The list Iowa Legal Aid decided, spelled out rather than derived. A
+    fifth type belongs here only after somebody has answered for it."""
+    assert crs.CIVIL_CASE_TYPES == ('AMCR', 'AMCV', 'DRCR', 'DRCV')
 
 
 @pytest.mark.parametrize('case_id,expected', [
     (APPEAL_MISDEMEANOUR, True),
+    (APPEAL_MISDEMEANOUR_CV, True),
     (PROTECTIVE_ORDER, True),
+    (PROTECTIVE_ORDER_CR, True),
     (FELONY, False),
-    ('00000  AMCV000000', False),
-    ('00000  DRCR000000', False),
+    ('00000  AMXX000000', False),
+    ('00000  DRXX000000', False),
     ('', False),
     (None, False),
 ])

--- a/tests/test_lite_unscored_codes.py
+++ b/tests/test_lite_unscored_codes.py
@@ -26,6 +26,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import crs
+from openpyxl import load_workbook
 
 FULL = 'CRS 3.5.5.xlsx'
 LITE = 'CRS Lite 3.5.5.xlsx'
@@ -118,3 +119,87 @@ class TestTheFullCrsIsSilent:
     @pytest.mark.parametrize('code', ['JWV', 'CIV', 'GTR', 'TNSF', 'OTH'])
     def test_nothing_is_marked(self, code):
         assert _notes(FULL, [code]) == [None]
+
+
+# The columns on the shared sheet that name a disposition code, in each file.
+# They are the same columns in a different order: CRS Lite drops the four
+# columns that read BANKRUPTCY and SOL, and everything after them shifts left.
+SHARED_CODE_COLUMNS = [('E', 'E'), ('F', 'F'), ('I', 'I'), ('M', 'L'),
+                       ('T', 'Q')]
+
+# The three sheets the full CRS has and CRS Lite does not, which is the whole
+# of the difference between them.
+SHEETS_ONLY_THE_FULL_CRS_HAS = ['BANKRUPTCY', 'EXEMPTIONS', 'SOL']
+
+
+def _formula(cell):
+    """A cell's text whether the template stored it as an array formula."""
+    value = cell.value
+    return getattr(value, 'text', value)
+
+
+class TestWhatLiteIsActuallyShortOf:
+    """Iowa Legal Aid asked on 21 August whether the changes on the full CRS
+    could be matched on Lite, which is what Drake Legal Clinic runs.
+
+    Almost all of them already are, and not by anyone porting them: Napier
+    writes the same columns into whichever template was chosen, so the notes
+    column, the charge classes in column E, the disposition codes in column G,
+    the court debt and the contempt and juvenile readings land in a Lite
+    workbook exactly as they land in a full one.
+
+    What does not is anything that needs a sheet Lite has not got. These tests
+    measure that boundary off the two files rather than describing it, so the
+    answer stays true when a template is replaced by its author -- which is
+    how these files change, since this repo does not own them.
+    """
+
+    def test_the_shared_sheet_asks_the_same_questions_in_both(self):
+        """Every code-bearing formula on EXPUNGEMENT & 910.7, character for
+        character. This is the test behind UNSCORED_CODE_NOTE: a CIV or JWV
+        row gets the same eligibility answers on Lite as on the full CRS, so a
+        note telling staff to rebuild on the full CRS to fix those answers
+        would be sending them after nothing."""
+        full = load_workbook(FULL)['EXPUNGEMENT & 910.7']
+        lite = load_workbook(LITE)['EXPUNGEMENT & 910.7']
+        for full_column, lite_column in SHARED_CODE_COLUMNS:
+            row = str(crs.FIRST_CASE_ROW - 1)
+            assert (_formula(full[full_column + row])
+                    == _formula(lite[lite_column + row])), full_column
+
+    def test_the_codes_lite_cannot_see_are_named_only_on_its_missing_sheets(self):
+        """So the gap is those sheets, not a formula anybody forgot to update.
+        Adding CIV to a Lite formula is not a change that exists to make: the
+        formulas that name it are on BANKRUPTCY and EXEMPTIONS, and putting
+        those sheets in is what would stop the file being Lite."""
+        missing = crs.codes_the_template_scores(FULL) - \
+            crs.codes_the_template_scores(LITE)
+        assert missing == {'CIV', 'JWV'}
+        for code in missing:
+            named_on = _sheets_naming(FULL, code)
+            assert named_on, code
+            assert named_on <= set(SHEETS_ONLY_THE_FULL_CRS_HAS), (code,
+                                                                   named_on)
+
+    def test_that_is_the_only_difference_in_sheets(self):
+        """If a later template adds one of these back, the note above and the
+        answer given to Iowa Legal Aid both need revisiting."""
+        full = set(load_workbook(FULL).sheetnames)
+        lite = set(load_workbook(LITE).sheetnames)
+        assert full - lite == set(SHEETS_ONLY_THE_FULL_CRS_HAS)
+        assert lite - full == set()
+
+
+def _sheets_naming(template, code):
+    """Which sheets of a template mention a disposition code in a formula."""
+    workbook = load_workbook(template)
+    found = set()
+    for sheet in workbook.worksheets:
+        rows = sheet.iter_rows(min_row=1, max_row=crs.FIRST_CASE_ROW + 200)
+        for row in rows:
+            for cell in row:
+                text = _formula(cell)
+                if isinstance(text, str) and '"%s"' % code in text:
+                    found.add(sheet.title)
+                    break
+    return found

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -174,35 +174,27 @@ def test_a_juvenile_involved_is_the_person_the_search_is_about():
     assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
 
 
-def test_a_property_owner_is_the_person_the_search_is_about():
-    """Found by a live search on 2026-08-12: ICOS answered with PROPERTY OWNER,
-    which was in neither list, so the case was kept by default and the role
-    mailed out as unrecognised.
+@pytest.mark.parametrize('role', ['PROPERTY OWNER', 'PROPERTY CO-OWNER'])
+def test_a_property_role_case_is_left_out(role):
+    """Both wordings are suppressed, and it took two answers to get there.
 
-    The owner is named on a case about their own property — condemnation, tax
-    sale, a municipal infraction, an in rem forfeiture — and those cases can
-    assess costs against them personally, so the case belongs in their record
-    summary and the role is vouched for rather than suppressed.
+    PROPERTY OWNER turned up on a live search on 2026-08-12 in neither list,
+    so the case was kept by default and the role mailed out as unrecognised.
+    It was vouched for on the reading that a condemnation, tax sale, municipal
+    infraction or in rem forfeiture can assess costs against the owner
+    personally. PROPERTY CO-OWNER alerted the same way on 2026-08-20 and was
+    read as the same question; Iowa Legal Aid excluded the co-owner on
+    2026-08-21 and, later the same afternoon, the owner as well.
+
+    So the distinction this file used to hold apart is gone on purpose. What
+    it costs is a real property case dropped rather than written, which Iowa
+    Legal Aid asked for over the error they were actually seeing: somebody
+    else's property case in a client's record summary.
     """
-    cases, _ = case_parser.parse_search(role_row('PROPERTY OWNER'))
-    assert ids(cases) == ['00000  FECR000000']
-    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
-
-
-def test_a_property_co_owner_case_is_left_out():
-    """The variant Iowa Legal Aid answered the other way on 2026-08-21.
-
-    Read here as the same question as PROPERTY OWNER when it first alerted on
-    2026-08-20, on the reasoning that nothing about being the sole owner is
-    what makes the case theirs. Iowa Legal Aid asked for the co-owner wording
-    to be excluded instead: they are content not to catch these. PROPERTY
-    OWNER is untouched by that and still keeps its case, so the two now differ
-    on purpose and the test above is what holds them apart.
-    """
-    cases, _ = case_parser.parse_search(role_row('PROPERTY CO-OWNER'))
+    cases, _ = case_parser.parse_search(role_row(role))
     assert cases == []
-    assert 'PROPERTY CO-OWNER' in case_parser.NON_PARTY_ROLES
-    assert 'PROPERTY CO-OWNER' not in case_parser.KNOWN_PARTY_ROLES
+    assert role in case_parser.NON_PARTY_ROLES
+    assert role not in case_parser.KNOWN_PARTY_ROLES
 
 
 def test_a_protective_order_respondent_is_the_person_the_search_is_about():


### PR DESCRIPTION
Iowa Legal Aid's second round of feedback for the week, off the same "Napier Behavior Question" thread as the first. Three asks, all measured rather than assumed.

## AMCV and DRCR read CIV

`CIVIL_CASE_TYPES` goes from `('AMCR', 'DRCV')` to `('AMCR', 'AMCV', 'DRCR', 'DRCV')`, which is every AM and DR type ICOS has shown us. Ari's ground is the docket rather than the CR/CV suffix: the appeal misdemeanour type is civil however the clerk styled it, and the criminal-styled DR cases are contempts off a protective order rather than convictions of their own.

It stays a four-character whitelist rather than a prefix rule, so a fifth type still costs an email. `tests/test_civil_case_types.py` keeps that honest with synthetic `AMXX`/`DRXX` dockets in the must-not-reach list, which a prefix rule would swallow.

The cost is the one Iowa Legal Aid already settled on the first two types: a guilty count on one of these sorts as no conviction on BANKRUPTCY and EXEMPTIONS, and a dismissal stops answering YES in the expungement sheet's DISM ACQ? column.

## PROPERTY OWNER excluded

Moves from `KNOWN_PARTY_ROLES` to `NON_PARTY_ROLES`, beside the co-owner excluded the day before. The cost is written into the comment rather than left implicit: a real property case belonging to the client is now dropped rather than written. Iowa Legal Aid asked for that over the error they were seeing, which was a stranger's property case appearing in a client's record summary.

`RESP/PROTECTED PERSON` is untouched, since Ari confirmed those pull correctly.

No new alert noise: `tasks.py:307` computes novel roles from the already-suppression-filtered case list.

## The Lite question, and a note that was overstating itself

Ari asked whether the full CRS's changes could be matched onto CRS Lite for Drake Legal Clinic. Measured off the two files:

- `build_workbook` is template-agnostic. Napier writes the same columns into whichever template was chosen, so the notes column, charge classes in column E, column G codes, court debt rows, contempt/disposition-date fixes and JUV adjudication fixes already land in a Lite workbook exactly as they land in a full one.
- Every code-bearing formula on EXPUNGEMENT & 910.7, the sheet both files share, is character-for-character identical (full `E3/F3/I3/M3/T3` vs Lite `E3/F3/I3/L3/Q3`).
- The entire difference between the files is three sheets: BANKRUPTCY, EXEMPTIONS, SOL. CIV and JWV are named only there, which is the whole reason Lite cannot score them.

So there is no Napier change to make. It is a template decision for Ari.

That does mean `UNSCORED_CODE_NOTE` was overstating the defect. It said no sheet in the Lite workbook counts the case and told staff to rebuild on the full CRS to score it, which would send them chasing eligibility answers Lite already gives correctly. It now names what Lite genuinely cannot do: sort the case's debt as dischargeable or exempt. That note is going into a staff guide Ari is writing, so the wording had to be true.

`TestWhatLiteIsActuallyShortOf` holds the measurement off the two files rather than describing it, since this repo does not own the templates and they get replaced by their author.

## Verification

`1331 passed` (1328 before, plus the three new). `crs.py` is stored CRLF while the rest of the repo is LF, so it was edited byte-level; `git diff --stat` and `git diff --stat --ignore-all-space` agree at 42/10, confirming no line-ending flattening.

Production stays frozen at v55. This is for the test site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vp2LY4WjhfzeBEHRAYvUsh
