### PR TITLE
Re-search before pulling when the cases came from an earlier spelling

### DIFF
--- a/case_parser.py
+++ b/case_parser.py
@@ -154,6 +154,10 @@ NON_PARTY_ROLES = frozenset({
     'WITNESS - DEFENSE',
     'JUVENILE - MOTHER OF',
     'JUVENILE - FATHER OF',
+    # BROTHER OF alerted as unrecognised on 2026-08-25; SISTER OF is the same
+    # relationship the other way and is not worth a second email to learn.
+    'JUVENILE - BROTHER OF',
+    'JUVENILE - SISTER OF',
     'ATTORNEY',
     'INTERESTED PARTY'
 })

--- a/crs.py
+++ b/crs.py
@@ -1433,6 +1433,13 @@ def reconcile_financials(case):
     columns = {}
     unresolved = []
     unreconciled = []
+    # Unreconciled categories with nothing left owing. They still count as
+    # unreconciled for deciding whether the row fell back to the summary,
+    # but the note leaves them out: on 2026-08-25 Iowa Legal Aid read "OTHER
+    # did not add up" on a client who owed nothing under OTHER and asked
+    # where that money had gone. Nowhere; there was none. A warning about a
+    # balance that is zero sends somebody to look at an empty cell.
+    settled = []
     # Categories whose gap was recovered at all, and the subset of those that
     # put the unidentified part in UNKNOWN. FINE is in the first and not the
     # second, because its recovery lands in the fine column instead.
@@ -1456,6 +1463,8 @@ def reconcile_financials(case):
             due = category.get('due')
             if due is None:
                 due = category['original'] - (category.get('paid') or Decimal(0))
+            if not due:
+                settled.append(name)
             if due:
                 # A positive gap is money the summary says exists but the
                 # itemization never identifies. Keep every line ICOS *does*
@@ -1602,11 +1611,12 @@ def reconcile_financials(case):
         return None, None
 
     notes = []
-    if unreconciled:
+    named = [name for name in unreconciled if name not in settled]
+    if named:
         text = ("%s did not add up against the itemization, so %s "
                 "ICOS's category total rather than a per-fee breakdown"
-                % (_and_list(unreconciled),
-                   "those balances are" if len(unreconciled) > 1
+                % (_and_list(named),
+                   "those balances are" if len(named) > 1
                    else "that balance is"))
         # Only the categories whose balance really did end up in MISCELLANEOUS.
         # Deciding this from the category's label instead said MISCELLANEOUS
@@ -1616,7 +1626,7 @@ def reconcile_financials(case):
         # BOARD and then told the attorney it was a lump sum, which is the
         # reading that loses a room-and-board appeal. A category that placed no
         # money anywhere is not named at all: there is no cell to go look at.
-        stranded = [name for name in unreconciled
+        stranded = [name for name in named
                     if name not in apportioned and landed.get(name) == {'O'}]
         if len(stranded) > 1:
             text += (", and %s are in MISCELLANEOUS rather than in their own "

--- a/tasks.py
+++ b/tasks.py
@@ -795,6 +795,23 @@ def _reselect(job, client, pick):
     return True, False
 
 
+def _standing_on(searches, spellings):
+    """Whether ICOS is already looking at the result set these cases came from.
+
+    True only for one group of cases found by the last spelling searched. Any
+    other shape needs each spelling put back in front of ICOS before its share
+    is asked for, including a single group found by an earlier spelling: the
+    result set ICOS is holding is the one from whichever search ran last, not
+    the one that found anything.
+    """
+    if len(searches) != 1:
+        return False
+    spellings = list(spellings or [])
+    if len(spellings) < 2:
+        return True
+    return searches[0]['person'] is spellings[-1]
+
+
 def _pull_grouped(job, client, searches, reselect, offset=0, total=None,
                   outage=None, dead_searches=None):
     """Pull one client's cases a spelling at a time.
@@ -1073,11 +1090,18 @@ def crs_task(job, session_token, keys, case_dict, def_name, def_dob, is_lite,
         case_ids = [case_id for group in searches
                     for case_id in group['case_ids']]
 
-        # Only when there is more than one, because a single search is already
-        # the last thing ICOS answered and re-running it would cost every
-        # ordinary run a request to serve the rare one.
+        # Skipped only when the one search behind these cases is already the
+        # last thing ICOS answered, because re-running it would cost every
+        # ordinary run a request to serve the rare one. That used to be
+        # decided by counting groups, and on 2026-08-25 a client searched
+        # under two spellings, with every ticked case found under the first,
+        # came out as one group and no re-search: ICOS was standing on the
+        # second spelling, every case page came back empty, and three runs in
+        # a row failed until the staffer happened to type the spellings the
+        # other way round.
         cases, failed, refused_a_name = _pull_grouped(
-            job, client, searches, reselect=len(searches) > 1)
+            job, client, searches,
+            reselect=not _standing_on(searches, people or [person]))
 
         if not cases:
             if refused_a_name:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -340,6 +340,29 @@ class TestPullingWhatWasPicked:
         assert ('search', 'AL HAMEED') not in \
             FakeClient.instances[0].trace[2:]
 
+    def test_cases_found_by_an_earlier_spelling_get_it_put_back_first(self, client):
+        """Today's failure, 2026-08-25. Two spellings searched, every ticked
+        case found under the first. That is one group, and counting groups
+        said no re-search was needed -- but ICOS was standing on the second
+        spelling, so every case page came back empty and the run got nothing.
+        Three runs in a row, until the staffer typed the names the other way."""
+        _, job_id, _ = build_from(client, keys=[JOINED_KEY])
+        trace = FakeClient.instances[0].trace
+        first_pull = next(i for i, (kind, _) in enumerate(trace)
+                          if kind == 'case')
+        standing = [what for kind, what in trace[:first_pull]
+                    if kind == 'search'][-1]
+        assert standing == 'ALHAMEED', trace
+        assert jobs.get(job_id).result['written_cases'] == 2
+
+    def test_cases_found_by_the_last_spelling_pull_straight_away(self, client):
+        """The mirror image needs nothing: the last search is the one ICOS is
+        already holding, and the ordinary-run economy still applies."""
+        build_from(client, keys=[SPACED_KEY])
+        assert FakeClient.instances[0].trace == [
+            ('search', 'ALHAMEED'), ('search', 'AL HAMEED'),
+            ('case', SHARED), ('case', ONLY_SPACED)]
+
 
 class TestFinishingAShortRun:
     def test_the_retry_carries_the_spelling_behind_each_missing_case(self, client):

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -680,3 +680,21 @@ def test_an_unattributable_payment_is_apportioned_not_dumped():
     columns, note = crs.reconcile_financials(case)
     assert columns == {'P': Decimal('12.50'), 'K': Decimal('12.50')}
     assert note is not None and 'estimates' in note
+
+
+def test_a_settled_category_that_did_not_add_up_is_not_named(felony_case):
+    """Iowa Legal Aid, 2026-08-25: a row said "OTHER did not add up" on a client
+    who owed nothing under OTHER, and asked where that money had gone. The
+    itemization still disagrees with the summary, so the row is still handled
+    as a category total, but a warning about a zero balance points at an empty
+    cell. The row says nothing about a category with nothing owing."""
+    felony_case['financials'][0]['amount'] = '31.00'   # OTHER no longer adds up
+    other = next(c for c in felony_case['summary_categories']
+                 if c['label'] == 'OTHER')
+    other['paid'] = other['original']
+    other['due'] = Decimal('0')
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    note = sheet.value_of('V4') or ''
+    assert 'OTHER did not add up' not in note
+    assert 'did not add up' not in note

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -197,6 +197,18 @@ def test_a_property_role_case_is_left_out(role):
     assert role not in case_parser.KNOWN_PARTY_ROLES
 
 
+@pytest.mark.parametrize('role', ['JUVENILE - BROTHER OF', 'JUVENILE - SISTER OF'])
+def test_a_juvenile_sibling_role_case_is_left_out(role):
+    """A sibling named on a juvenile case is not the person the case is about,
+    any more than the mother or father is. BROTHER OF alerted as unrecognised
+    on 2026-08-25 and was kept by default; SISTER OF is added with it rather
+    than waiting to cost a second email."""
+    cases, _ = case_parser.parse_search(role_row(role))
+    assert cases == []
+    assert role in case_parser.NON_PARTY_ROLES
+    assert role not in case_parser.KNOWN_PARTY_ROLES
+
+
 def test_a_protective_order_respondent_is_the_person_the_search_is_about():
     """Alerted as unrecognised on runs through 2026-08-20. The role reads like
     a bystander and is not one: a no contact order and any contempt off it are


### PR DESCRIPTION
Fixes today's (2026-08-25) run of 'HTTP 200 with an empty body' failures on one client.

Root cause: `crs_task` skipped the pre-pull re-search whenever the picked cases formed a single spelling group (`reselect=len(searches) > 1`). With two spellings where every ticked case was found under the *first*, ICOS was still holding the second spelling's result set, so every `TViewCaseCivil` came back empty. Three runs failed (bb3ebb58, b88dde6a, 073f492c); the 18:50 run (91eb80bf) succeeded only because the spellings were typed in the other order.

Now the re-search is skipped only when the single group's spelling is the last one searched. Regression test fails on `main`, passes here.

Also adds `JUVENILE - BROTHER OF` / `SISTER OF` to `NON_PARTY_ROLES` (BROTHER OF alerted today).

Full suite: 1335 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpBkmNfs2prKbGTBaZAMo4