### PR TITLE
Stop a paid-off category crashing the workbook build

### DIFF
--- a/crs.py
+++ b/crs.py
@@ -1572,8 +1572,8 @@ def reconcile_financials(case):
             continue
 
         amounts = [entry[1] for entry in entries]
-        settled = _unique_paid_subset(amounts, paid)
-        if settled is None:
+        paid_indices = _unique_paid_subset(amounts, paid)
+        if paid_indices is None:
             # Cannot say which line was paid. The balance still belongs to this
             # bucket, though, so it goes to the column the bucket's lines share
             # and only falls back to MISC when they disagree. Sending a
@@ -1593,7 +1593,7 @@ def reconcile_financials(case):
                 columns[column] = columns.get(column, Decimal(0)) + share
             continue
         for index, (detail, amount, _line_paid) in enumerate(entries):
-            owed = Decimal(0) if index in settled else amount
+            owed = Decimal(0) if index in paid_indices else amount
             if owed == 0:
                 continue
             column = get_finance_column(detail)

--- a/tests/test_financials.py
+++ b/tests/test_financials.py
@@ -182,6 +182,29 @@ def test_a_paid_off_case_does_not_warn_about_a_breakdown_of_nothing(felony_case)
     assert sheet.value_of('V4') is None
 
 
+def test_a_reconciled_bucket_before_a_paid_off_one_does_not_crash(felony_case):
+    """Reported 2026-08-26: two clinic runs died with AttributeError.
+
+    COSTS reconciles, with its payment recorded on the category rather than
+    the line, so the bucket works out which line was paid. Then OTHER carries
+    a summary balance with no itemization and nothing owed. Working out the
+    paid line used to reuse the name of the list that collects paid-off
+    unreconciled buckets, so the second bucket appended to a frozenset and
+    the whole workbook build fell over on a case that owes nothing.
+    """
+    felony_case['total_due'] = '$0.00'
+    felony_case['summary_categories'] = _five_buckets(
+        COSTS=(Decimal('50.00'), Decimal('50.00')),
+        OTHER=(Decimal('100.00'), Decimal('100.00')))
+    felony_case['financials'] = [
+        {'detail': 'SHERIFFS FEES - LOCAL', 'amount': Decimal('50.00'),
+         'paid': None},
+    ]
+    sheet = FakeSheet()
+    crs.process_financials(felony_case, sheet, 4)
+    assert sheet.value_of('V4') is None
+
+
 def test_the_same_collapsed_row_still_warns_when_money_is_owed(felony_case):
     """What silences the caveat is the balance, not the fallback that wrote it.
 


### PR DESCRIPTION
reconcile_financials collects paid-off unreconciled categories in a list
named settled, and the reconciled-bucket branch reused that name for the
frozenset of paid line indexes. Once a bucket had worked out which line
its category-level payment covered, any later category that failed to
reconcile but owed nothing called append on a frozenset, and the whole
CRS build died with AttributeError. Five runs on one defendant failed
this way on 2026-08-26, and Iowa Legal Aid saw it as the "something went
wrong inside Napier" page.

Rename the per-bucket subset to paid_indices so the two never collide,
and add a test that walks exactly that pair of buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wn51FvaWtS49uRFhxXn6Yy