### PR TITLE
Map the five roles and the disposition that alerted 26-28 August

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -524,3 +524,26 @@ dead and this one is closed.
 An Iowa city ordinance conviction that mirrors a chapter 321 offence: does it
 put the licence at risk the way the state charge would? The LICENSE-REGIS
 sheet's answer depends on it.
+
+## Two from the 26 to 28 August 2026 runs
+
+DEFERRED MISTRIAL, on one juvenile count. The two words point opposite ways.
+DEFERRED on its own is DEF, which is a deferred judgment and which four sheets
+test for by name; a mistrial is a trial that reached no verdict at all, which
+belongs with the dismissals. Guessing DEF puts an adjudication on a client who
+may not have one. Guessing the other way drops a deferred judgment off the
+expungement and licence sheets, which exist to find exactly that. The wording
+is now mapped to OTH, which is the code the row was already getting as an
+unknown wording, so no workbook changes; the entry exists so it stops mailing
+an unrecognised-disposition alert on every run that touches the case. Column V
+still carries the ICOS wording. If Iowa Legal Aid says a mistrial that was
+deferred is a deferred judgment, the answer is DEF at rank 2 and one line in
+each of the two maps.
+
+GUILTY PLEA/DEFAULT as a case level status on a case with no adjudicated
+count. This is not new and is not a bug: it is the first wording in the list
+under "ICOS case statuses with no CRS code" above, and the alert firing is that
+section working as intended. It is repeated here because it now mails on every
+run that touches such a case, so it is the cheapest of these to close and the
+loudest left open. Column G is empty on that row, and BANKRUPTCY, EXEMPTIONS
+and SOL all read an empty G as an open charge.

--- a/case_parser.py
+++ b/case_parser.py
@@ -92,6 +92,14 @@ NON_PARTY_ROLES = frozenset({
     'CROSS DEFENDANT',
     'CROSS PLAINTIFF',
     'CUSTODIAN - LEGAL',
+    # The other half of the same pair. CUSTODIAN - LEGAL was already here, and
+    # ICOS splits custody into the legal and the physical kind on the same
+    # class of case; a person named as either is named because of the child in
+    # front of the court, not because the case is theirs. Alerted twice on one
+    # search on 2026-08-26. Listing it alongside its twin rather than waiting
+    # for a separate answer, on the same reading that took SISTER OF with
+    # BROTHER OF below.
+    'CUSTODIAN - PHYSICAL',
     'DECEASED INDIVIDUAL',
     'EXECUTOR',
     'FILING AGENT FOR PLAINTIFF',
@@ -109,6 +117,10 @@ NON_PARTY_ROLES = frozenset({
     # theirs.
     'LAW ENFORCEMENT',
     'LIEN FILER',
+    # Appointed to the case to run the settlement conference. The same class as
+    # ATTORNEY, JUDGE and INTERPRETER: a professional role on somebody else's
+    # dispute. Alerted 2026-08-26.
+    'MEDIATOR',
     'NAME OF TRUST',
     # Someone who filed a document into a case they are not party to,
     # which is why the charges and the money on that page belong to
@@ -158,6 +170,16 @@ NON_PARTY_ROLES = frozenset({
     # relationship the other way and is not worth a second email to learn.
     'JUVENILE - BROTHER OF',
     'JUVENILE - SISTER OF',
+    # Alerted 2026-08-28. Same shape again: a relative named on the child's
+    # case. JUVENILE - INVOLVED is the role the case actually belongs to, and
+    # it is in KNOWN_PARTY_ROLES below, so a grandparent's own record is not
+    # what a JV docket carrying this role is about.
+    'JUVENILE - GRANDPARENT OF',
+    # Alerted 2026-08-28. The court officer who supervises the restitution and
+    # community service a sentence orders, named on the case in the same way
+    # LAW ENFORCEMENT is. The trailing OFF is ICOS abbreviating OFFICER, which
+    # is what makes it read at a glance like part of a party's title.
+    'RESTITUTION/COMMUNITY SERV OFF',
     'ATTORNEY',
     'INTERESTED PARTY'
 })
@@ -172,6 +194,14 @@ KNOWN_PARTY_ROLES = frozenset({
     'DEFENDANT',
     'PRO SE DEFENDANT',
     'DEFENDANT - PRO SE',
+    # ICOS on its own, with no party word after it. Alerted 2026-08-28. Every
+    # other PRO SE wording here is a party representing themselves, and the
+    # bare one is the clerk not having recorded which kind, so it is the person
+    # the case is about. Naming it changes nothing about which cases are
+    # written -- it was never in NON_PARTY_ROLES, so these were already being
+    # kept -- and stops a decided role mailing an alert on every run that
+    # touches one.
+    'PRO SE',
     # ICOS code JVIN: the juvenile whose case this is, unlike the suppressed
     # JUVENILE - MOTHER OF and JUVENILE - FATHER OF relationship roles.
     'JUVENILE - INVOLVED',
@@ -290,7 +320,12 @@ charge_code_dict = {
     # court's record, and OTH is the code that moves no money and marks the
     # row as coded on less than a full answer. The entry exists so the
     # wording stops alerting as unknown on every run that touches the case.
-    "JCS OTHER ADJ OTHER COURT": "OTH"
+    "JCS OTHER ADJ OTHER COURT": "OTH",
+    # The twin of the crs.charge_code_map entry, which carries the reasoning:
+    # DEFERRED alone is DEF and a mistrial reached no verdict, the two answers
+    # are opposite, and OTH is the code the row already had as an unknown
+    # wording. The entry exists so it stops alerting on every run.
+    "DEFERRED MISTRIAL": "OTH"
 }
 
 # What three of those wordings mean when the docket is the juvenile court's,

--- a/crs.py
+++ b/crs.py
@@ -118,7 +118,22 @@ charge_code_map = {
     # juvenile docket this wording means something else entirely and
     # JUVENILE_DISPOSITIONS overrides it below.
     "TRANSFERRED": {"TNSF":0},
-    "JCS OTHER ADJ OTHER COURT": {"OTH": 0.5}
+    "JCS OTHER ADJ OTHER COURT": {"OTH": 0.5},
+    # Alerted 2026-08-27 on a JVJV count. Read as a wording the code
+    # cannot resolve rather than as either word alone, because the two
+    # halves point opposite ways: DEFERRED on its own is DEF, a deferred
+    # judgment the expungement and licence sheets both test for, and a
+    # mistrial is a trial that reached no verdict at all. Coding it DEF
+    # would put an adjudication on a client who may have none; coding it
+    # with the dismissals would drop a deferred judgment off the sheets
+    # that exist to find it. OTH is what the row already got as an
+    # unknown wording, so this entry changes no workbook: it is here so
+    # the wording stops mailing an unknown-disposition alert on every run
+    # that touches the case, the way JCS OTHER ADJ OTHER COURT above is.
+    # Ranked 0.5 with it, so a case that also carries a real conviction
+    # still reads as the conviction. Listed in OPEN_QUESTIONS.md for Iowa
+    # Legal Aid to overrule.
+    "DEFERRED MISTRIAL": {"OTH": 0.5}
 }
 
 # What three wordings mean when the docket is the juvenile court's, decided by

--- a/tests/test_charge_pages.py
+++ b/tests/test_charge_pages.py
@@ -198,6 +198,43 @@ def test_strip_dnu_only_reads_the_front_of_the_wording():
     assert case_parser.strip_dnu(None) == ''
 
 
+class TestTheDeferredMistrialWording:
+    """'DEFERRED MISTRIAL': one juvenile count, alerted 27 August 2026.
+
+    The two words disagree. DEFERRED alone is DEF, a deferred judgment four
+    sheets test for by name; a mistrial reached no verdict at all and belongs
+    with the dismissals. Neither guess is cheap, so the wording keeps the OTH
+    the row was already getting as an unknown, and the entry exists only so it
+    stops mailing an unrecognised-disposition alert on every run that touches
+    the case. Column V still carries the ICOS wording, and
+    OPEN_QUESTIONS.md carries it for Iowa Legal Aid to overrule.
+    """
+
+    def test_it_codes_oth_in_both_maps(self):
+        assert case_parser.disposition_code('DEFERRED MISTRIAL') == 'OTH'
+        import crs
+        assert crs.charge_code_map['DEFERRED MISTRIAL'] == \
+            {'OTH': crs.OTH_RANK}
+
+    def test_it_is_not_read_as_a_plain_deferred_judgment(self):
+        """The failure this entry is guarding against: prefix matching, or
+        anyone later 'tidying' it into the DEFERRED row, would put a deferred
+        judgment on a client whose trial produced no verdict."""
+        import crs
+        assert case_parser.disposition_code('DEFERRED MISTRIAL') != 'DEF'
+        assert crs.charge_code_map['DEFERRED'] == {'DEF': 2}
+
+    def test_a_conviction_alongside_it_still_wins_the_case_code(self):
+        charge = parse(GUILTY,
+                       ('321J.2', 'SYNTHETIC OWI', 'DEFERRED MISTRIAL'))
+        assert '[OTH]' in charge['description']
+        import crs
+        dominant = crs.get_dominant_charge([charge])
+        assert dominant['disposition'] == 'GTR'
+        # And no alert: the wording is known now, not an unknown coded OTH.
+        assert dominant['unknown_dispositions'] == []
+
+
 class TestTheStoryCountyWording:
     """'JCS OTHER ADJ OTHER COURT': another court adjudicated, JCS is relaying.
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -225,6 +225,41 @@ def test_a_protective_order_respondent_is_the_person_the_search_is_about():
     assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
 
 
+@pytest.mark.parametrize('role', [
+    'CUSTODIAN - PHYSICAL',
+    'MEDIATOR',
+    'JUVENILE - GRANDPARENT OF',
+    'RESTITUTION/COMMUNITY SERV OFF',
+])
+def test_the_roles_that_alerted_in_late_august_are_left_out(role):
+    """Four roles that mailed NOVEL_ROLE on the 26 and 28 August 2026 runs.
+
+    Each is somebody on a case that is not theirs, and each has a twin already
+    on the list that settles it: CUSTODIAN - LEGAL for the physical kind,
+    LAW ENFORCEMENT for the restitution and community service officer, JUDGE
+    and INTERPRETER for the mediator, and the JUVENILE relationship roles for
+    the grandparent. Suppression is the expensive direction, so what this
+    costs is a case dropped rather than written where one of these four is
+    also the person searched for -- the same trade Iowa Legal Aid took
+    knowingly on PROPERTY OWNER.
+    """
+    cases, _ = case_parser.parse_search(role_row(role))
+    assert cases == []
+    assert role in case_parser.NON_PARTY_ROLES
+    assert role not in case_parser.KNOWN_PARTY_ROLES
+
+
+def test_a_bare_pro_se_role_is_the_person_the_search_is_about():
+    """Alerted on the 28 August 2026 run. Every other PRO SE wording in the
+    list is a party representing themselves, and the bare one is the clerk not
+    having written down which kind. The case was always kept -- the role is in
+    neither list, and neither list is what decides that -- so naming it here
+    only stops the alert mailing on every run that meets one."""
+    cases, _ = case_parser.parse_search(role_row('PRO SE'))
+    assert ids(cases) == ['00000  FECR000000']
+    assert cases[0]['role'] in case_parser.KNOWN_PARTY_ROLES
+
+
 def test_the_two_role_lists_do_not_overlap():
     """A role in both would be suppressed and vouched for at the same time."""
     assert not (case_parser.NON_PARTY_ROLES & case_parser.KNOWN_PARTY_ROLES)


### PR DESCRIPTION
Everything Napier alerted on between 26 and 28 August, triaged from the alert mail.

## Fixed here

| Alert | Wording | Change |
|---|---|---|
| unrecognised party role | `CUSTODIAN - PHYSICAL` | → `NON_PARTY_ROLES` (twin of `CUSTODIAN - LEGAL`) |
| unrecognised party role | `MEDIATOR` | → `NON_PARTY_ROLES` (class of `JUDGE`, `INTERPRETER`) |
| unrecognised party role | `JUVENILE - GRANDPARENT OF` | → `NON_PARTY_ROLES` (class of the other `JUVENILE -` roles) |
| unrecognised party role | `RESTITUTION/COMMUNITY SERV OFF` | → `NON_PARTY_ROLES` (class of `LAW ENFORCEMENT`; `OFF` is ICOS for OFFICER) |
| unrecognised party role | `PRO SE` | → `KNOWN_PARTY_ROLES`; changes no filtering, silences the alert |
| unrecognised disposition | `DEFERRED MISTRIAL` | → `OTH` in both maps; same code the row already got, alert stops |

The four suppressions cost a case dropped rather than written where one of those
roles is also the person searched for. That is the trade Iowa Legal Aid took
knowingly on `PROPERTY OWNER`, against the error they were actually seeing.

`DEFERRED MISTRIAL` deliberately does **not** become `DEF`. The two words point
opposite ways — a deferred judgment four sheets test for by name, versus a trial
that reached no verdict — so it follows the `JCS OTHER ADJ OTHER COURT`
precedent: keep the conservative code, stop the repeat email, log the question.

## Not fixed, on purpose

- **`GUILTY PLEA/DEFAULT` case status** — `case_level_code` refusing to translate
  a case-level status is the design, not a bug. Already the first wording under
  "ICOS case statuses with no CRS code" in `OPEN_QUESTIONS.md`. **Needs an answer
  from Iowa Legal Aid**, not a patch. Column G stays empty, which BANKRUPTCY,
  EXEMPTIONS and SOL read as an open charge.
- **`ESA account stayed locked`** — somebody signed in to Iowa Courts outside
  Napier. The alert reports it correctly; no code change reaches it.

## Already shipped

The `AttributeError` that failed six `crs` jobs on 26 August (`crs.py:1467`,
`settled.append`) was the `settled` shadowing fixed in 7ac198d, merged as
395aae2 and deployed as **v63 at 13:49 EDT on 26 Aug** — eight minutes after the
last crash. No `job failed` alert has arrived since. Nothing here touches it.

## Tests

`1345 passed`, up from `1337` on `main`. Five new role tests, three new
disposition tests. The two-map agreement test covers the new `DEFERRED MISTRIAL`
entry in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RaHaKd3H4xiinjPC8ZT6b
