### PR TITLE
Code the two answers Iowa Legal Aid gave on 26 August

### DIFF
--- a/OPEN_QUESTIONS.md
+++ b/OPEN_QUESTIONS.md
@@ -347,13 +347,20 @@ Napier reads the case level status only where it overlaps the per count
 adjudication wordings. That overlap has grown twice since this section was
 written, at CHANGE OF VENUE on 3 August 2026 and at TRANSFERRED on 20 August,
 so it is now DISMISSED, CHANGE OF VENUE and TRANSFERRED, and on a juvenile
-docket OTHER JUDGMENT as well. The rest are still left uncoded, and the case goes onto the sheet with the
+docket OTHER JUDGMENT and, since 26 August, DISCHARGE as well. The rest are still left uncoded, and the case goes onto the sheet with the
 wording in column V so it is visibly uncoded rather than quietly miscoded:
 
 GUILTY PLEA/DEFAULT, VIOLATIONS HANDLED BY CLERK, BY TRIAL TO COURT, SMALL
 CLAIM-DISPOSED BY CLERK, CLOSED, DEFAULTED, DEFERRED JUDGEMENT, DISCHARGE,
-CONVERTED TO SIMPLE MISDEMEANR, and OTHER JUDGMENT anywhere but a juvenile
-docket.
+CONVERTED TO SIMPLE MISDEMEANR, and OTHER JUDGMENT and DISCHARGE anywhere but
+a juvenile docket.
+
+Iowa Legal Aid's 26 August answer on DISCHARGE was broader than the one
+wording: JUV for every JVJV case unless it was waived to adult court. Napier
+still codes a juvenile docket wording by wording, so a JVJV status it has not
+seen still goes out uncoded rather than as JUV. Whether a DISMISSED or
+WITHDRAWN count on a JVJV docket should also read JUV is the open half of
+that answer.
 
 Whether VIOLATIONS HANDLED BY CLERK is a guilty plea decides what five sheets
 compute, which is why the code will not guess.

--- a/case_parser.py
+++ b/case_parser.py
@@ -156,6 +156,12 @@ NON_PARTY_ROLES = frozenset({
     # is the one they were actually seeing.
     'PROPERTY CO-OWNER',
     'PROPERTY OWNER',
+    # Alerted 2026-08-26. A third-party plaintiff is a defendant who has
+    # brought somebody else into the suit, and Iowa Legal Aid answered the
+    # same day: leave the case off, as for victims and witnesses. Same cost
+    # as PROPERTY OWNER above -- a case reaching the workbook under this role
+    # is dropped rather than written -- and asked for knowing it.
+    'THIRD PARTY PLAINTIFF',
     'TRUSTEE',
     'WARD',
     'WITNESS',
@@ -337,6 +343,9 @@ JUVENILE_DISPOSITIONS = {
     "CONSENT DECREE": "JUV",
     "OTHER JUDGMENT": "JUV",
     "TRANSFERRED": "JWV",
+    # Answered by Iowa Legal Aid 2026-08-26. See the twin entry in
+    # crs.JUVENILE_DISPOSITIONS.
+    "DISCHARGE": "JUV",
 }
 
 

--- a/crs.py
+++ b/crs.py
@@ -159,6 +159,13 @@ JUVENILE_DISPOSITIONS = {
     "CONSENT DECREE": {"JUV":1},
     "OTHER JUDGMENT": {"JUV":1},
     "TRANSFERRED": {"JWV":0},
+    # A juvenile docket showed DISCHARGE on 2026-08-26 and Napier left it
+    # uncoded rather than guess. Iowa Legal Aid answered the same day: JUV,
+    # and JUV for a JVJV case generally unless it was waived to adult court,
+    # which is JWV. Only the juvenile reading is taken here; DISCHARGE on an
+    # adult docket stays uncoded, since a discharged adult case says nothing
+    # about how it was adjudicated. Same rank as the other adjudications.
+    "DISCHARGE": {"JUV":1},
 }
 
 

--- a/tests/test_charge_pages.py
+++ b/tests/test_charge_pages.py
@@ -172,6 +172,17 @@ def test_the_juvenile_table_is_the_same_table_in_both_modules():
         assert next(iter(crs.JUVENILE_DISPOSITIONS[wording])) == code, wording
 
 
+def test_a_discharged_juvenile_case_is_an_adjudication():
+    """A JVJV docket carried the case status DISCHARGE on 2026-08-26 and went
+    out uncoded. Iowa Legal Aid said JUV: a juvenile case is JUV unless it was
+    waived to adult court. The adult reading is unchanged, because a
+    discharged adult case does not say how it was adjudicated."""
+    import crs
+    assert crs.case_level_code('DISCHARGE', '07701  JVJV003889') == 'JUV'
+    assert crs.case_level_code('DISCHARGE', '07701  FECR003889') is None
+    assert case_parser.disposition_code('DISCHARGE', '07701  JVJV003889') == 'JUV'
+
+
 def test_a_deferred_judgment_is_adjudicated():
     """A deferred judgment is still an adjudication and still carries debt."""
     assert parse(('321J.2', 'SYNTHETIC OWI', 'DEFERRED'))['charge'] == '321J.2'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -197,6 +197,17 @@ def test_a_property_role_case_is_left_out(role):
     assert role not in case_parser.KNOWN_PARTY_ROLES
 
 
+def test_a_third_party_plaintiff_case_is_left_out():
+    """THIRD PARTY PLAINTIFF alerted on 2026-08-26 and was kept by default.
+    Iowa Legal Aid answered the same day that it should come out, the way a
+    victim or a witness does."""
+    role = 'THIRD PARTY PLAINTIFF'
+    cases, _ = case_parser.parse_search(role_row(role))
+    assert cases == []
+    assert role in case_parser.NON_PARTY_ROLES
+    assert role not in case_parser.KNOWN_PARTY_ROLES
+
+
 @pytest.mark.parametrize('role', ['JUVENILE - BROTHER OF', 'JUVENILE - SISTER OF'])
 def test_a_juvenile_sibling_role_case_is_left_out(role):
     """A sibling named on a juvenile case is not the person the case is about,


### PR DESCRIPTION
THIRD PARTY PLAINTIFF alerted as an unrecognised role and Iowa Legal Aid
said to leave the case off, the way a victim or witness is. It joins
NON_PARTY_ROLES with the same cost PROPERTY OWNER carries: a case that
reaches the workbook under that role is dropped rather than written.

A juvenile docket showed the case status DISCHARGE and Napier left it
uncoded. Iowa Legal Aid said JUV, and JUV for a JVJV case generally unless
it was waived to adult court. DISCHARGE joins JUVENILE_DISPOSITIONS in both
modules, so it codes JUV as a count disposition and as a case-level status
on a JV docket and stays uncoded on an adult one. The broader "every JVJV
is JUV" reading is recorded in OPEN_QUESTIONS.md rather than coded, since
it would also turn a dismissed juvenile count into an adjudication.

Wiki: the column V guide heading now reads "[ICOS CATEGORY] did not add up…" per Ari's wording (pushed to the wiki directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wn51FvaWtS49uRFhxXn6Yy